### PR TITLE
security: read-write "id" field may lead to overstep

### DIFF
--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/automation/model/AutomationRule.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/automation/model/AutomationRule.java
@@ -33,6 +33,7 @@ import lombok.Data;
 
 @Data
 public class AutomationRule implements OrganizationIsolated {
+    @JsonProperty(access = Access.READ_ONLY)
     private Long id;
     private String name;
     private Long eventId;

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/datasecurity/model/MaskingAlgorithm.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/datasecurity/model/MaskingAlgorithm.java
@@ -46,6 +46,7 @@ import lombok.Data;
 @Data
 public class MaskingAlgorithm implements SecurityResource, OrganizationIsolated {
 
+    @JsonProperty(access = Access.READ_ONLY)
     private Long id;
 
     @Size(min = 1, max = 64, message = "Masking algorithm name is out of range [1,64]")

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/datasecurity/model/SensitiveColumn.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/datasecurity/model/SensitiveColumn.java
@@ -36,6 +36,8 @@ import lombok.Data;
  */
 @Data
 public class SensitiveColumn implements SecurityResource, OrganizationIsolated {
+
+    @JsonProperty(access = Access.READ_ONLY)
     private Long id;
 
     @NotNull

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/datasecurity/model/SensitiveRule.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/datasecurity/model/SensitiveRule.java
@@ -39,6 +39,8 @@ import lombok.Data;
  */
 @Data
 public class SensitiveRule implements SecurityResource, OrganizationIsolated {
+
+    @JsonProperty(access = Access.READ_ONLY)
     private Long id;
 
     @Size(min = 1, max = 64, message = "Sensitive rule name is out of range [1,64]")

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/iam/model/Role.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/iam/model/Role.java
@@ -37,6 +37,7 @@ import lombok.Data;
 @Data
 public class Role implements SecurityResource, OrganizationIsolated, Serializable {
     private static final long serialVersionUID = 1094521546416165353L;
+    @JsonProperty(access = Access.READ_ONLY)
     private Long id;
     private String name;
     private RoleType type;

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/integration/model/IntegrationConfig.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/integration/model/IntegrationConfig.java
@@ -39,6 +39,8 @@ import lombok.NoArgsConstructor;
 @Data
 @NoArgsConstructor
 public class IntegrationConfig implements SecurityResource, OrganizationIsolated {
+
+    @JsonProperty(access = Access.READ_ONLY)
     private Long id;
 
     @NotNull

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/regulation/risklevel/model/RiskDetectRule.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/regulation/risklevel/model/RiskDetectRule.java
@@ -34,6 +34,8 @@ import lombok.Data;
 @Data
 @Valid
 public class RiskDetectRule {
+
+    @JsonProperty(access = Access.READ_ONLY)
     private Long id;
 
     private String name;

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/regulation/risklevel/model/RiskLevel.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/regulation/risklevel/model/RiskLevel.java
@@ -33,6 +33,8 @@ import lombok.Data;
  */
 @Data
 public class RiskLevel {
+
+    @JsonProperty(access = Access.READ_ONLY)
     private Long id;
 
     @JsonProperty(access = Access.READ_ONLY)

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/regulation/ruleset/model/Rule.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/regulation/ruleset/model/Rule.java
@@ -38,6 +38,8 @@ import lombok.Data;
 
 @Data
 public class Rule implements SecurityResource, OrganizationIsolated, Serializable {
+
+    @JsonProperty(access = Access.READ_ONLY)
     private Long id;
 
     @JsonProperty(access = Access.READ_ONLY)


### PR DESCRIPTION
### Task Description

Read-write "id" field may lead to overstep

### Solution Description

Make `id` field in DTO objects readonly

### Passed Regressions

manually

### Upgrade Compatibility

Compatible

### Other Information

<!-- Any information helping to review this pull request. -->

### Release Note
<!--
A concise release note can help users to understand how your pull request makes difference.
-->
