### PR TITLE
[Fix]: Generated insert into statement error after executing alter table add column statement

### DIFF
--- a/server/integration-test/src/test/java/com/oceanbase/odc/service/session/ConnectConsoleServiceTest.java
+++ b/server/integration-test/src/test/java/com/oceanbase/odc/service/session/ConnectConsoleServiceTest.java
@@ -20,14 +20,12 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -35,8 +33,6 @@ import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
 
-import com.github.benmanes.caffeine.cache.Cache;
-import com.github.benmanes.caffeine.cache.Caffeine;
 import com.oceanbase.odc.ServiceTestEnv;
 import com.oceanbase.odc.TestConnectionUtil;
 import com.oceanbase.odc.core.datasource.DataSourceFactory;
@@ -46,7 +42,6 @@ import com.oceanbase.odc.core.session.ConnectionSessionUtil;
 import com.oceanbase.odc.core.session.ExpiredSessionException;
 import com.oceanbase.odc.core.shared.constant.ConnectType;
 import com.oceanbase.odc.core.shared.constant.DialectType;
-import com.oceanbase.odc.core.shared.model.TableIdentity;
 import com.oceanbase.odc.core.sql.execute.AsyncJdbcExecutor;
 import com.oceanbase.odc.core.sql.execute.FutureResult;
 import com.oceanbase.odc.core.sql.execute.GeneralAsyncJdbcExecutor;
@@ -70,7 +65,6 @@ import com.oceanbase.odc.service.session.model.BinaryContent;
 import com.oceanbase.odc.service.session.model.SqlAsyncExecuteReq;
 import com.oceanbase.odc.service.session.model.SqlAsyncExecuteResp;
 import com.oceanbase.odc.service.session.model.SqlExecuteResult;
-import com.oceanbase.tools.dbbrowser.model.DBTableColumn;
 
 import lombok.NonNull;
 
@@ -288,13 +282,6 @@ class TestConnectionSession implements ConnectionSession {
         this.map.putIfAbsent(ConnectionSessionConstants.NLS_TIMESTAMP_FORMAT_NAME, "DD-MON-RR");
         this.map.putIfAbsent(ConnectionSessionConstants.NLS_TIMESTAMP_TZ_FORMAT_NAME, "DD-MON-RR");
         this.connectType = connectType;
-
-        Cache<TableIdentity, List<DBTableColumn>> tableColumnsCache =
-                Caffeine.newBuilder().maximumSize(1000).expireAfterAccess(20, TimeUnit.MINUTES).build();
-        List<DBTableColumn> columns = new ArrayList<>();
-        columns.add(new DBTableColumn());
-        tableColumnsCache.put(TableIdentity.of("schema_test", "table_test"), columns);
-        ConnectionSessionUtil.setTableColumnCache(this, tableColumnsCache);
     }
 
     public TestConnectionSession(String id, InputStream inputStream) {

--- a/server/odc-core/src/main/java/com/oceanbase/odc/core/session/ConnectionSessionUtil.java
+++ b/server/odc-core/src/main/java/com/oceanbase/odc/core/session/ConnectionSessionUtil.java
@@ -32,7 +32,6 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
 
 import javax.sql.DataSource;
 
@@ -40,8 +39,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.springframework.jdbc.core.JdbcOperations;
 import org.springframework.jdbc.core.StatementCallback;
 
-import com.github.benmanes.caffeine.cache.Cache;
-import com.github.benmanes.caffeine.cache.Caffeine;
 import com.oceanbase.jdbc.OceanBaseConnection;
 import com.oceanbase.jdbc.internal.protocol.Protocol;
 import com.oceanbase.odc.common.event.EventPublisher;
@@ -56,7 +53,6 @@ import com.oceanbase.odc.core.shared.constant.ResourceType;
 import com.oceanbase.odc.core.shared.exception.NotFoundException;
 import com.oceanbase.odc.core.shared.exception.UnexpectedException;
 import com.oceanbase.odc.core.shared.model.OdcDBSession;
-import com.oceanbase.odc.core.shared.model.TableIdentity;
 import com.oceanbase.odc.core.sql.execute.GeneralSyncJdbcExecutor;
 import com.oceanbase.odc.core.sql.execute.SyncJdbcExecutor;
 import com.oceanbase.odc.core.sql.execute.cache.BinaryDataManager;
@@ -65,8 +61,6 @@ import com.oceanbase.odc.core.sql.execute.cache.table.VirtualTable;
 import com.oceanbase.odc.core.sql.execute.model.JdbcGeneralResult;
 import com.oceanbase.odc.core.sql.split.SqlCommentProcessor;
 import com.oceanbase.odc.core.sql.util.OdcDBSessionRowMapper;
-import com.oceanbase.tools.dbbrowser.model.DBTableColumn;
-import com.oceanbase.tools.dbbrowser.model.DBView;
 
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
@@ -377,27 +371,6 @@ public class ConnectionSessionUtil {
         return (BinaryDataManager) connectionSession.getAttribute(ConnectionSessionConstants.BINARY_FILE_MANAGER_KEY);
     }
 
-    public static void setTableColumnCache(@NonNull ConnectionSession connectionSession,
-            @NonNull Cache<TableIdentity, List<DBTableColumn>> cache) {
-        connectionSession.setAttribute(ConnectionSessionConstants.TABLE_COLUMN_CACHE, cache);
-    }
-
-    public static Cache<TableIdentity, List<DBTableColumn>> getTableColumnCache(
-            @NonNull ConnectionSession connectionSession) {
-        return (Cache<TableIdentity, List<DBTableColumn>>) connectionSession
-                .getAttribute(ConnectionSessionConstants.TABLE_COLUMN_CACHE);
-    }
-
-    public static void setViewColumnCache(@NonNull ConnectionSession connectionSession,
-            @NonNull Cache<TableIdentity, DBView> cache) {
-        connectionSession.setAttribute(ConnectionSessionConstants.VIEW_COLUMN_CACHE, cache);
-    }
-
-    public static Cache<TableIdentity, DBView> getViewColumnCache(@NonNull ConnectionSession connectionSession) {
-        return (Cache<TableIdentity, DBView>) connectionSession
-                .getAttribute(ConnectionSessionConstants.VIEW_COLUMN_CACHE);
-    }
-
     public static void setShowTableColumnInfo(@NonNull ConnectionSession connectionSession,
             Boolean getTableColumnsInfo) {
         connectionSession.setAttribute(ConnectionSessionConstants.SHOW_TABLE_COLUMN_INFO, getTableColumnsInfo);
@@ -635,15 +608,6 @@ public class ConnectionSessionUtil {
 
     private static SyncJdbcExecutor getSyncJdbcExecutor(ConnectionSession session) {
         return session.getSyncJdbcExecutor(ConnectionSessionConstants.CONSOLE_DS_KEY);
-    }
-
-    public static void initCache(@NonNull ConnectionSession connectionSession) {
-        Cache<TableIdentity, List<DBTableColumn>> tableColumnsCache =
-                Caffeine.newBuilder().maximumSize(1000).expireAfterWrite(20, TimeUnit.MINUTES).build();
-        Cache<TableIdentity, DBView> viewColumnsCache =
-                Caffeine.newBuilder().maximumSize(1000).expireAfterWrite(20, TimeUnit.MINUTES).build();
-        setTableColumnCache(connectionSession, tableColumnsCache);
-        setViewColumnCache(connectionSession, viewColumnsCache);
     }
 
 }

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/session/factory/DefaultConnectSessionFactory.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/session/factory/DefaultConnectSessionFactory.java
@@ -140,7 +140,6 @@ public class DefaultConnectSessionFactory implements ConnectionSessionFactory {
         ConnectionSessionUtil.setEventPublisher(session, eventPublisher);
         ConnectionSessionUtil.initArchitecture(session);
         ConnectionInfoUtil.initSessionVersion(session);
-        ConnectionSessionUtil.initCache(session);
         ConnectionSessionUtil.setConsoleSessionResetFlag(session, false);
         ConnectionInfoUtil.initConsoleConnectionId(session);
         ConnectionSessionUtil.setConnectionConfig(session, connectionConfig);


### PR DESCRIPTION
<!--
Thank you for contributing to OceanBase! 
Please feel free to ping the maintainers for the review!
-->

## Defect Description
After adding new columns to the table, when inserting table data,  the generated insert into statement still only has the original columns.
![image](https://github.com/oceanbase/odc/assets/140503120/d34ff43b-2d08-4e53-ae90-7754b91a9cb9)
Backend get `columnList` from cache, so when the user adds a field to a table, the `columnList `does not have the new field. The front end relies on the `columnList` field to obtain the field information of the table, and all subsequent components pass information through this field.


## Fix Solution
Delete `tableColumnsCache` and `viewColumnsCache`.
The cache was used before because the oracle statement querying constraint information was time-consuming, but the current `tryToGetTableColumnsFromCache` method has removed this logic, only querying the column information, and the query of the column information is not time-consuming, so there is no need to use this cache.

