### PR TITLE
feat(workflow): add checkbox in workflow to decide weather to install db-browser and ob-sql-parser

### DIFF
--- a/.github/workflows/build_artifact.yaml
+++ b/.github/workflows/build_artifact.yaml
@@ -14,6 +14,16 @@ run-name: Build Artifact triggered by ${{ github.actor }} 🛠️
 on:
   workflow_dispatch:
     inputs:
+      install_db_browser:
+        description: "Install db-browser"
+        required: true
+        type: boolean
+        default: false
+      install_ob_sql_parser:
+        description: "Install ob-sql-parser"
+        required: true
+        type: boolean
+        default: false
       build_jar:
         description: "Build jar package"
         required: true
@@ -126,6 +136,24 @@ jobs:
           echo "RPM's version is "${new_version}
           mvn versions:set -DnewVersion="${new_version}"
           mvn versions:commit
+      - name: Install db-browser
+        if: ${{ github.event.inputs.install_db_browser == 'true'}}
+        run: |
+          echo "Start install db-browser"
+          pushd libs/db-browser
+          echo "Current dir is "`pwd`
+          mvn clean install -Dmaven.test.skip=true
+          echo "Install db-browser success"
+          popd
+      - name: Install ob-sql-parser
+        if: ${{ github.event.inputs.install_ob_sql_parser == 'true'}}
+        run: |
+          echo "Start install ob-sql-parser"
+          pushd libs/ob-sql-parser
+          echo "Current dir is "`pwd`
+          mvn clean install -Dmaven.test.skip=true
+          echo "Install ob-sql-parser success"
+          popd
       - name: Build jar
         run: |
           echo "Start build jar packages"


### PR DESCRIPTION
#### What type of PR is this?
 
type-feature, type-refactor

#### What this PR does / why we need it:

We publish db-browser and ob-sql-parser by maven central repo, and we cannot publish to the central warehouse during the R&D process.

So, here is the solution. We install them into local machine which we run our workflow, so that we can build a jar that include what we modify on db-browser and ob-sql-parser

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Additional documentation e.g., usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```