### PR TITLE
fix(result-set): generate dml slowly when edit result-set

### DIFF
--- a/server/integration-test/src/test/java/com/oceanbase/odc/service/dml/DeleteGeneratorTest.java
+++ b/server/integration-test/src/test/java/com/oceanbase/odc/service/dml/DeleteGeneratorTest.java
@@ -96,7 +96,7 @@ public class DeleteGeneratorTest {
         String schema = ConnectionSessionUtil.getCurrentSchema(connectionSession);
         list.forEach(u -> u.setSchemaName(schema));
 
-        MySQLDMLBuilder builder = new MySQLDMLBuilder(list, Collections.emptyList(), connectionSession);
+        MySQLDMLBuilder builder = new MySQLDMLBuilder(list, Collections.emptyList(), connectionSession, null);
         DeleteGenerator generator = new DeleteGenerator(builder);
         String expect = "delete from `" + schema + "`.`t_test_delete_data_sql` where `c2`='abc';";
         Assert.assertEquals(expect, generator.generate());
@@ -129,7 +129,7 @@ public class DeleteGeneratorTest {
         String schema = ConnectionSessionUtil.getCurrentSchema(connectionSession);
         list.forEach(u -> u.setSchemaName(schema));
 
-        OracleDMLBuilder builder = new OracleDMLBuilder(list, Collections.emptyList(), connectionSession);
+        OracleDMLBuilder builder = new OracleDMLBuilder(list, Collections.emptyList(), connectionSession, null);
         DeleteGenerator generator = new DeleteGenerator(builder);
         String expect = "delete from \"" + schema + "\".\"t_test_delete_data_sql\" where \"c1\"=1 and \"c2\"='abc' and "
                 + "\"c3\"=to_timestamp('2023-07-11 20:04:31.008891234', 'YYYY-MM-DD HH24:MI:SS.FF');";

--- a/server/integration-test/src/test/java/com/oceanbase/odc/service/dml/InsertGeneratorTest.java
+++ b/server/integration-test/src/test/java/com/oceanbase/odc/service/dml/InsertGeneratorTest.java
@@ -110,7 +110,7 @@ public class InsertGeneratorTest {
         String schema = ConnectionSessionUtil.getCurrentSchema(connectionSession);
         list.forEach(u -> u.setSchemaName(schema));
 
-        MySQLDMLBuilder builder = new MySQLDMLBuilder(list, Collections.emptyList(), connectionSession);
+        MySQLDMLBuilder builder = new MySQLDMLBuilder(list, Collections.emptyList(), connectionSession, null);
         InsertGenerator generator = new InsertGenerator(builder);
         String expect = "insert into `" + schema + "`.`t_test_insert_data_sql`(`c1`,`c2`,`c3`) values(1,'abc',load_file"
                 + "('object@tmp_test.jpg'));";
@@ -146,7 +146,7 @@ public class InsertGeneratorTest {
         String schema = ConnectionSessionUtil.getCurrentSchema(connectionSession);
         list.forEach(u -> u.setSchemaName(schema));
 
-        MySQLDMLBuilder builder = new MySQLDMLBuilder(list, Collections.emptyList(), connectionSession);
+        MySQLDMLBuilder builder = new MySQLDMLBuilder(list, Collections.emptyList(), connectionSession, null);
         InsertGenerator generator = new InsertGenerator(builder);
         String expect = "insert into `" + schema + "`.`t_test_insert_data_sql`(`c1`,`c2`,`c3`) values(1,NULL,'');";
         Assert.assertEquals(expect, generator.generate());
@@ -194,7 +194,7 @@ public class InsertGeneratorTest {
         String schema = ConnectionSessionUtil.getCurrentSchema(connectionSession);
         list.forEach(u -> u.setSchemaName(schema));
 
-        OracleDMLBuilder builder = new OracleDMLBuilder(list, Collections.emptyList(), connectionSession);
+        OracleDMLBuilder builder = new OracleDMLBuilder(list, Collections.emptyList(), connectionSession, null);
         InsertGenerator generator = new InsertGenerator(builder);
         String expect = "insert into \"" + schema
                 + "\".\"t_test_insert_data_sql\"(\"c1\",\"c2\",\"c3\",\"c4\",\"c5\") values"
@@ -231,7 +231,7 @@ public class InsertGeneratorTest {
         String schema = ConnectionSessionUtil.getCurrentSchema(connectionSession);
         list.forEach(u -> u.setSchemaName(schema));
 
-        OracleDMLBuilder builder = new OracleDMLBuilder(list, Collections.emptyList(), connectionSession);
+        OracleDMLBuilder builder = new OracleDMLBuilder(list, Collections.emptyList(), connectionSession, null);
         InsertGenerator generator = new InsertGenerator(builder);
         String expect = "insert into \"" + schema + "\".\"t_test_insert_data_sql\"(\"c1\",\"c2\",\"c3\") values"
                 + "(to_timestamp_tz('2023-07-11 20:04:31.008891234 +08:00', 'YYYY-MM-DD HH24:MI:SS.FF TZH:TZM'),"

--- a/server/integration-test/src/test/java/com/oceanbase/odc/service/dml/UpdateGeneratorTest.java
+++ b/server/integration-test/src/test/java/com/oceanbase/odc/service/dml/UpdateGeneratorTest.java
@@ -119,7 +119,7 @@ public class UpdateGeneratorTest {
         String schema = ConnectionSessionUtil.getCurrentSchema(connectionSession);
         list.forEach(u -> u.setSchemaName(schema));
 
-        MySQLDMLBuilder builder = new MySQLDMLBuilder(list, Collections.emptyList(), connectionSession);
+        MySQLDMLBuilder builder = new MySQLDMLBuilder(list, Collections.emptyList(), connectionSession, null);
         UpdateGenerator generator = new UpdateGenerator(builder, connectionSession);
         String expect = "update `" + schema
                 + "`.`t_test_update_data_sql` set `c1` = 100, `c2` = 'test', `c4` = 'object@tmp_test.txt' where `c1`=1 and `c2`='abc';";
@@ -173,7 +173,7 @@ public class UpdateGeneratorTest {
         String schema = ConnectionSessionUtil.getCurrentSchema(connectionSession);
         list.forEach(u -> u.setSchemaName(schema));
 
-        OracleDMLBuilder builder = new OracleDMLBuilder(list, Collections.emptyList(), connectionSession);
+        OracleDMLBuilder builder = new OracleDMLBuilder(list, Collections.emptyList(), connectionSession, null);
         UpdateGenerator generator = new UpdateGenerator(builder, connectionSession);
         String expect = "update \"" + schema
                 + "\".\"t_test_update_data_sql\" set \"c1\" = 100, \"c2\" = 'test', \"c3\" = "

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/dml/BaseDMLBuilder.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/dml/BaseDMLBuilder.java
@@ -57,7 +57,7 @@ abstract class BaseDMLBuilder implements DMLBuilder {
     protected final ConnectionSession connectionSession;
 
     public BaseDMLBuilder(@NonNull List<DataModifyUnit> modifyUnits, List<String> whereColumns,
-            @NonNull ConnectionSession connectionSession) {
+            @NonNull ConnectionSession connectionSession, List<DBTableConstraint> constraints) {
         Set<String> schemas = modifyUnits.stream()
                 .map(DataModifyUnit::getSchemaName)
                 .filter(Objects::nonNull).collect(Collectors.toSet());
@@ -78,7 +78,7 @@ abstract class BaseDMLBuilder implements DMLBuilder {
             this.schema = null;
         }
         this.connectionSession = connectionSession;
-        this.constraints = getConstraints(this.schema, this.tableName);
+        this.constraints = constraints == null ? getConstraints(schema, tableName) : constraints;
         this.whereColumns = whereColumns;
     }
 

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/dml/BaseDMLBuilder.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/dml/BaseDMLBuilder.java
@@ -78,7 +78,7 @@ abstract class BaseDMLBuilder implements DMLBuilder {
             this.schema = null;
         }
         this.connectionSession = connectionSession;
-        this.constraints = constraints == null ? getConstraints(schema, tableName) : constraints;
+        this.constraints = constraints == null ? getConstraints(schema, tableName, connectionSession) : constraints;
         this.whereColumns = whereColumns;
     }
 
@@ -140,6 +140,16 @@ abstract class BaseDMLBuilder implements DMLBuilder {
                 .anyMatch(c -> columnNames.containsAll(c.getColumnNames()));
     }
 
+    public static List<DBTableConstraint> getConstraints(String schema,
+            @NonNull String tableName, ConnectionSession session) {
+        DBSchemaAccessor accessor = DBSchemaAccessors.create(session);
+        String schemaName = schema;
+        if (schema == null) {
+            schemaName = ConnectionSessionUtil.getCurrentSchema(session);
+        }
+        return accessor.listTableConstraints(schemaName, tableName);
+    }
+
     protected boolean isAppendable(DataModifyUnit unit) {
         if (CollectionUtils.isNotEmpty(this.whereColumns)) {
             return whereColumns.contains(unit.getColumnName());
@@ -184,16 +194,6 @@ abstract class BaseDMLBuilder implements DMLBuilder {
             return constraint;
         }
         return null;
-    }
-
-    private List<DBTableConstraint> getConstraints(String schema,
-            @NonNull String tableName) {
-        DBSchemaAccessor accessor = DBSchemaAccessors.create(connectionSession);
-        String schemaName = schema;
-        if (schema == null) {
-            schemaName = ConnectionSessionUtil.getCurrentSchema(connectionSession);
-        }
-        return accessor.listTableConstraints(schemaName, tableName);
     }
 
 }

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/dml/MySQLDMLBuilder.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/dml/MySQLDMLBuilder.java
@@ -22,6 +22,7 @@ import java.util.Set;
 
 import com.oceanbase.odc.core.session.ConnectionSession;
 import com.oceanbase.odc.service.dml.model.DataModifyUnit;
+import com.oceanbase.tools.dbbrowser.model.DBTableConstraint;
 import com.oceanbase.tools.dbbrowser.util.MySQLSqlBuilder;
 import com.oceanbase.tools.dbbrowser.util.SqlBuilder;
 
@@ -38,8 +39,8 @@ import lombok.NonNull;
 public class MySQLDMLBuilder extends BaseDMLBuilder {
 
     public MySQLDMLBuilder(@NonNull List<DataModifyUnit> modifyUnits, List<String> whereColumns,
-            ConnectionSession connectionSession) {
-        super(modifyUnits, whereColumns, connectionSession);
+            ConnectionSession connectionSession, List<DBTableConstraint> constraints) {
+        super(modifyUnits, whereColumns, connectionSession, constraints);
     }
 
     @Override

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/dml/OracleDMLBuilder.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/dml/OracleDMLBuilder.java
@@ -24,6 +24,7 @@ import java.util.Set;
 import com.oceanbase.odc.core.session.ConnectionSession;
 import com.oceanbase.odc.core.shared.constant.OdcConstants;
 import com.oceanbase.odc.service.dml.model.DataModifyUnit;
+import com.oceanbase.tools.dbbrowser.model.DBTableConstraint;
 import com.oceanbase.tools.dbbrowser.util.OracleSqlBuilder;
 import com.oceanbase.tools.dbbrowser.util.SqlBuilder;
 
@@ -40,8 +41,8 @@ import lombok.NonNull;
 public class OracleDMLBuilder extends BaseDMLBuilder {
 
     public OracleDMLBuilder(@NonNull List<DataModifyUnit> modifyUnits, List<String> whereColumns,
-            ConnectionSession connectionSession) {
-        super(modifyUnits, whereColumns, connectionSession);
+            ConnectionSession connectionSession, List<DBTableConstraint> constraints) {
+        super(modifyUnits, whereColumns, connectionSession, constraints);
     }
 
     @Override

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/dml/TableDataService.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/dml/TableDataService.java
@@ -34,7 +34,6 @@ import com.oceanbase.odc.core.shared.constant.DialectType;
 import com.oceanbase.odc.core.shared.exception.UnexpectedException;
 import com.oceanbase.odc.service.common.model.ResourceSql;
 import com.oceanbase.odc.service.connection.model.ConnectionConfig;
-import com.oceanbase.odc.service.db.browser.DBSchemaAccessors;
 import com.oceanbase.odc.service.dml.model.BatchDataModifyReq;
 import com.oceanbase.odc.service.dml.model.BatchDataModifyReq.Operate;
 import com.oceanbase.odc.service.dml.model.BatchDataModifyReq.Row;
@@ -43,9 +42,7 @@ import com.oceanbase.odc.service.dml.model.DataModifyUnit;
 import com.oceanbase.odc.service.feature.AllFeatures;
 import com.oceanbase.odc.service.feature.Features;
 import com.oceanbase.tools.dbbrowser.model.DBTableConstraint;
-import com.oceanbase.tools.dbbrowser.schema.DBSchemaAccessor;
 
-import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
@@ -70,7 +67,7 @@ public class TableDataService {
         BatchDataModifyResp resp = new BatchDataModifyResp();
         resp.setTableName(tableName);
         resp.setSchemaName(schemaName);
-        List<DBTableConstraint> constraints = getConstraints(schemaName, tableName, connectionSession);
+        List<DBTableConstraint> constraints = BaseDMLBuilder.getConstraints(schemaName, tableName, connectionSession);
         StringBuilder sqlBuilder = new StringBuilder();
         for (Row row : sortedRows) {
             Operate operate = row.getOperate();
@@ -148,16 +145,6 @@ public class TableDataService {
             default:
                 throw new UnexpectedException("Unexpected operate value:" + operate);
         }
-    }
-
-    private List<DBTableConstraint> getConstraints(String schema, @NonNull String tableName,
-            ConnectionSession connectionSession) {
-        DBSchemaAccessor accessor = DBSchemaAccessors.create(connectionSession);
-        String schemaName = schema;
-        if (schema == null) {
-            schemaName = ConnectionSessionUtil.getCurrentSchema(connectionSession);
-        }
-        return accessor.listTableConstraints(schemaName, tableName);
     }
 
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines.
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request.
3. Ensure you have added or ran the appropriate tests for your PR.
5. If the PR is unfinished, you may add or remove a WIP or [WIP] prefix to your pull request title.
-->

#### What type of PR is this?
type-bug
module-resultset
<!--
Add one of the following kinds:
type-bug
type-feature
type-docs
etc.

Optionally add one or more of the following kinds if applicable:
module-resultset
module-sql execution
etc.
-->

#### What this PR does / why we need it:
For any schema, when the number of rows in the edited result set exceeds 100, the time required to generate SQL is at the minute level.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

The root cause of above problem is abundant database queries. In this PR, it's been fixed. Only one query would be executed during generating DMLs.

#### Special notes for your reviewer:

#### Additional documentation e.g., usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```