### PR TITLE
reafctor: move build time and build version into InfoAdaptor interface

### DIFF
--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/info/InfoAdapter.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/info/InfoAdapter.java
@@ -15,6 +15,8 @@
  */
 package com.oceanbase.odc.service.info;
 
+import java.time.OffsetDateTime;
+
 import javax.servlet.http.HttpServletRequest;
 
 public interface InfoAdapter {
@@ -24,6 +26,10 @@ public interface InfoAdapter {
     String getLogoutUrl(HttpServletRequest request);
 
     String getSupportGroupQRCodeUrl();
+
+    String getBuildVersion();
+
+    OffsetDateTime getBuildTime();
 
     boolean isPasswordLoginEnabled();
 

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/info/OdcInfoService.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/info/OdcInfoService.java
@@ -106,10 +106,8 @@ public class OdcInfoService {
     @PostConstruct
     public void init() {
         staticOdcInfo = new OdcInfo();
-        staticOdcInfo.setVersion(buildProperties.getVersion());
         staticOdcInfo.setStartTime(
                 instant2OffsetDateTime(Instant.ofEpochMilli(ManagementFactory.getRuntimeMXBean().getStartTime())));
-        staticOdcInfo.setBuildTime(instant2OffsetDateTime(buildProperties.getTime()));
         staticOdcInfo.setHomePageText(infoProperties.getHomePageText());
         staticOdcInfo.setSupportEmail(infoProperties.getSupportEmail());
         staticOdcInfo.setSupportUrl(infoProperties.getSupportUrl());
@@ -139,6 +137,8 @@ public class OdcInfoService {
     public OdcInfo info() {
         OdcInfo odcInfo = ObjectUtil.deepCopy(this.staticOdcInfo, OdcInfo.class);
         String[] profiles = SpringContextUtil.getProfiles();
+        odcInfo.setVersion(infoAdapter.getBuildVersion());
+        odcInfo.setBuildTime(infoAdapter.getBuildTime());
         odcInfo.setProfiles(profiles);
         odcInfo.setPasswordLoginEnabled(this.infoAdapter.isPasswordLoginEnabled());
         odcInfo.setSsoLoginEnabled(Objects.nonNull(getLoginUrl()));

--- a/server/starters/desktop-starter/src/main/java/com/oceanbase/odc/service/info/DesktopInfoAdapter.java
+++ b/server/starters/desktop-starter/src/main/java/com/oceanbase/odc/service/info/DesktopInfoAdapter.java
@@ -16,9 +16,14 @@
 
 package com.oceanbase.odc.service.info;
 
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+
 import javax.servlet.http.HttpServletRequest;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.info.BuildProperties;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Service;
 
@@ -31,6 +36,9 @@ public class DesktopInfoAdapter implements InfoAdapter {
 
     @Value("${odc.help.supportGroupQRCodeUrl:#{null}}")
     private String supportGroupQRCodeUrl;
+
+    @Autowired
+    private BuildProperties buildProperties;
 
     @Override
     public boolean isPasswordLoginEnabled() {
@@ -52,4 +60,13 @@ public class DesktopInfoAdapter implements InfoAdapter {
         return supportGroupQRCodeUrl;
     }
 
+    @Override
+    public String getBuildVersion() {
+        return buildProperties.getVersion();
+    }
+
+    @Override
+    public OffsetDateTime getBuildTime() {
+        return OffsetDateTime.ofInstant(buildProperties.getTime(), ZoneId.systemDefault());
+    }
 }

--- a/server/starters/web-starter/src/main/java/com/oceanbase/odc/service/info/WebInfoAdapter.java
+++ b/server/starters/web-starter/src/main/java/com/oceanbase/odc/service/info/WebInfoAdapter.java
@@ -15,12 +15,15 @@
  */
 package com.oceanbase.odc.service.info;
 
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
 import java.util.Set;
 
 import javax.servlet.http.HttpServletRequest;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.info.BuildProperties;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Service;
 
@@ -46,6 +49,8 @@ public class WebInfoAdapter implements InfoAdapter {
     private PlaysiteOpenApiProperties alipayOpenApiProperties;
     @Autowired
     protected IntegrationService integrationService;
+    @Autowired
+    private BuildProperties buildProperties;
 
     @Override
     public boolean isPasswordLoginEnabled() {
@@ -95,6 +100,16 @@ public class WebInfoAdapter implements InfoAdapter {
     @Override
     public String getSupportGroupQRCodeUrl() {
         return supportGroupQRCodeUrl;
+    }
+
+    @Override
+    public String getBuildVersion() {
+        return buildProperties.getVersion();
+    }
+
+    @Override
+    public OffsetDateTime getBuildTime() {
+        return OffsetDateTime.ofInstant(buildProperties.getTime(), ZoneId.systemDefault());
     }
 
 }


### PR DESCRIPTION
#### What type of PR is this?
type-refactor

#### What this PR does / why we need it:
This PR moves getBuildTime and getBuildVersion into InfoAdaptor interface. The reason for this change is making any other starters can define their own version and pass it to front-end