### PR TITLE
fix create oracle table failed with quote wrapped by special character

### DIFF
--- a/server/integration-test/src/test/java/com/oceanbase/odc/service/onlineschemachange/DdlUtilsTest.java
+++ b/server/integration-test/src/test/java/com/oceanbase/odc/service/onlineschemachange/DdlUtilsTest.java
@@ -34,7 +34,7 @@ public class DdlUtilsTest {
 
         String newName = DdlUtils.getNewNameWithSuffix(tableName, DdlConstants.RENAMED_TABLE_NAME_SUFFIX);
 
-        Assert.assertEquals("_t" + DdlConstants.RENAMED_TABLE_NAME_SUFFIX, newName);
+        Assert.assertEquals("\"_t" + DdlConstants.RENAMED_TABLE_NAME_SUFFIX + "\"", newName);
 
     }
 
@@ -44,7 +44,7 @@ public class DdlUtilsTest {
 
         String newName = DdlUtils.getNewNameWithSuffix(tableName, DdlConstants.RENAMED_TABLE_NAME_SUFFIX);
 
-        Assert.assertEquals("_t" + DdlConstants.RENAMED_TABLE_NAME_SUFFIX, newName);
+        Assert.assertEquals("`_t" + DdlConstants.RENAMED_TABLE_NAME_SUFFIX + "`", newName);
 
     }
 

--- a/server/integration-test/src/test/java/com/oceanbase/odc/service/onlineschemachange/ddl/TableNameReplacerTest.java
+++ b/server/integration-test/src/test/java/com/oceanbase/odc/service/onlineschemachange/ddl/TableNameReplacerTest.java
@@ -20,7 +20,10 @@ import org.junit.Test;
 
 public class TableNameReplacerTest {
     private static final String CREATE_STMT = "create table t1 (id int);";
+    private static final String CREATE_QUOTE_STMT = "create table \"t1\" (id int);";
+    private static final String CREATE_ACCENT_STMT = "create table `t1` (id int);";
     private static final String ALTER_STMT = "alter table t1 add constraint constraint_t1_id unique (id);";
+    private static final String ALTER_QUOTE_STMT = "alter table \"t1\" add constraint constraint_t1_id unique (id);";
 
     @Test
     public void test_RewriteCreateStmt_Mysql() {
@@ -29,9 +32,23 @@ public class TableNameReplacerTest {
     }
 
     @Test
+    public void test_RewriteCreateStmtWithAccent_Mysql() {
+        String newSql =
+                new OBMysqlTableNameReplacer().replaceCreateStmt(CREATE_ACCENT_STMT, DdlUtils.getNewTableName("`t1`"));
+        Assert.assertEquals("create table `_t1_osc_new_` (id int);", newSql);
+    }
+
+    @Test
     public void test_RewriteCreateStmt_Oracle() {
         String newSql = new OBOracleTableNameReplacer().replaceCreateStmt(CREATE_STMT, DdlUtils.getNewTableName("t1"));
         Assert.assertEquals("create table _t1_osc_new_ (id int);", newSql);
+    }
+
+    @Test
+    public void test_RewriteCreateStmtWithQuote_Oracle() {
+        String newSql = new OBOracleTableNameReplacer().replaceCreateStmt(CREATE_QUOTE_STMT,
+                DdlUtils.getNewTableName("\"t1\""));
+        Assert.assertEquals("create table \"_t1_osc_new_\" (id int);", newSql);
     }
 
     @Test
@@ -44,6 +61,14 @@ public class TableNameReplacerTest {
     public void test_RewriteAlterStmt_Oracle() {
         String newSql = new OBOracleTableNameReplacer().replaceAlterStmt(ALTER_STMT, DdlUtils.getNewTableName("t1"));
         Assert.assertEquals("alter table _t1_osc_new_ add constraint constraint_t1_id unique (id);", newSql);
+    }
+
+    @Test
+    public void test_RewriteAlterStmtQuote_Oracle() {
+        String newSql =
+                new OBOracleTableNameReplacer().replaceAlterStmt(ALTER_QUOTE_STMT, DdlUtils.getNewTableName("\"t1\""));
+        Assert.assertEquals("alter table \"_t1_osc_new_\" add constraint constraint_t1_id unique (id);", newSql);
+
     }
 
 }

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/onlineschemachange/DefaultOnlineSchemaChangeTaskHandler.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/onlineschemachange/DefaultOnlineSchemaChangeTaskHandler.java
@@ -177,7 +177,6 @@ public class DefaultOnlineSchemaChangeTaskHandler implements OnlineSchemaChangeT
 
         } catch (Exception e) {
             log.warn("Failed to start osc job with taskId={}.", scheduleTaskId, e);
-            dropNewTableIfExits(valveContext.getTaskParameter(), connectionSession);
             failedOscTask(valveContext);
         } finally {
             if (connectionSession != null) {
@@ -343,6 +342,8 @@ public class DefaultOnlineSchemaChangeTaskHandler implements OnlineSchemaChangeT
         completeHandler.onOscScheduleTaskFailed(valveContext.getTaskParameter().getOmsProjectId(),
                 valveContext.getTaskParameter().getUid(), valveContext.getSchedule().getId(),
                 valveContext.getScheduleTask().getId());
+
+        dropNewTableIfExits(valveContext.getTaskParameter(), valveContext.getConnectionSession());
     }
 
     private OscValveContext getOscValveContext(Long scheduleId, Long scheduleTaskId) {
@@ -399,7 +400,7 @@ public class DefaultOnlineSchemaChangeTaskHandler implements OnlineSchemaChangeT
         log.info("Successfully created new table, ddl: {}", taskParam.getNewTableCreateDdl());
     }
 
-    private  void dropNewTableIfExits(OnlineSchemaChangeScheduleTaskParameters taskParam, ConnectionSession session) {
+    private void dropNewTableIfExits(OnlineSchemaChangeScheduleTaskParameters taskParam, ConnectionSession session) {
         List<String> list = DBSchemaAccessors.create(session)
                 .showTablesLike(taskParam.getDatabaseName(), taskParam.getNewTableNameUnWrapped());
         // Drop new table suffix with _osc_new_ if exists

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/onlineschemachange/OnlineSchemaChangeFlowableTask.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/onlineschemachange/OnlineSchemaChangeFlowableTask.java
@@ -23,7 +23,6 @@ import java.util.stream.Collectors;
 import org.apache.commons.collections4.CollectionUtils;
 import org.flowable.engine.delegate.DelegateExecution;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
@@ -81,8 +80,7 @@ public class OnlineSchemaChangeFlowableTask extends BaseODCFlowTaskDelegate<Void
     @Autowired
     private OrganizationService organizationService;
 
-    @Value("${osc-check-task-cron-expression:0/10 * * * * ?}")
-    private String oscCheckTaskCronExpression;
+    private final static String checkTaskCronExpression = "0/10 * * * * ?";
 
     private volatile TaskStatus status;
     private long scheduleId;
@@ -244,7 +242,7 @@ public class OnlineSchemaChangeFlowableTask extends BaseODCFlowTaskDelegate<Void
         scheduleEntity.setModifierId(scheduleEntity.getCreatorId());
         TriggerConfig triggerConfig = new TriggerConfig();
         triggerConfig.setTriggerStrategy(TriggerStrategy.CRON);
-        triggerConfig.setCronExpression(oscCheckTaskCronExpression);
+        triggerConfig.setCronExpression(checkTaskCronExpression);
         scheduleEntity.setTriggerConfigJson(JsonUtils.toJson(triggerConfig));
         scheduleEntity.setMisfireStrategy(MisfireStrategy.MISFIRE_INSTRUCTION_DO_NOTHING);
         scheduleEntity.setJobParametersJson(JsonUtils.toJson(parameter));

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/onlineschemachange/OnlineSchemaChangeFlowableTask.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/onlineschemachange/OnlineSchemaChangeFlowableTask.java
@@ -107,9 +107,10 @@ public class OnlineSchemaChangeFlowableTask extends BaseODCFlowTaskDelegate<Void
         ConnectionConfig connectionConfig = FlowTaskUtil.getConnectionConfig(execution);
         String schema = FlowTaskUtil.getSchemaName(execution);
         continueOnError = parameter.isContinueOnError();
+        OnlineSchemaChangeContextHolder.trace(this.creatorId, this.flowTaskId, this.organizationId);
+        parameter.buildParameterDataMap();
         ScheduleEntity schedule = createScheduleEntity(connectionConfig, parameter, schema);
         scheduleId = schedule.getId();
-        OnlineSchemaChangeContextHolder.trace(this.creatorId, this.flowTaskId, this.organizationId);
         try {
             List<ScheduleTaskEntity> tasks = parameter.generateSubTaskParameters(connectionConfig, schema).stream()
                     .map(param -> {
@@ -246,7 +247,6 @@ public class OnlineSchemaChangeFlowableTask extends BaseODCFlowTaskDelegate<Void
         triggerConfig.setCronExpression(oscCheckTaskCronExpression);
         scheduleEntity.setTriggerConfigJson(JsonUtils.toJson(triggerConfig));
         scheduleEntity.setMisfireStrategy(MisfireStrategy.MISFIRE_INSTRUCTION_DO_NOTHING);
-        parameter.buildParameterDataMap();
         scheduleEntity.setJobParametersJson(JsonUtils.toJson(parameter));
         return scheduleService.create(scheduleEntity);
     }

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/onlineschemachange/ddl/DdlUtils.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/onlineschemachange/ddl/DdlUtils.java
@@ -17,12 +17,14 @@ package com.oceanbase.odc.service.onlineschemachange.ddl;
 
 import java.sql.SQLException;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.apache.commons.collections4.CollectionUtils;
 
+import com.google.common.collect.Lists;
 import com.oceanbase.odc.common.util.StringUtils;
 import com.oceanbase.odc.core.session.ConnectionSession;
 import com.oceanbase.odc.core.session.ConnectionSessionConstants;
@@ -37,24 +39,37 @@ import com.oceanbase.odc.service.onlineschemachange.model.OnlineSchemaChangeSqlT
  */
 public class DdlUtils {
 
+    // Pattern for oracle table with wrapped by ""
     private static final Pattern NAME_QUOTE_PATTERN = Pattern.compile("^\"(.+)\"$");
+    // Pattern for mysql table with wrapped by ``
     private static final Pattern NAME_ACCENT_PATTERN = Pattern.compile("^`(.+)`$");
 
-    public static String getNewTableName(String rawName) {
+    private static final List<Pattern> TABLE_PATTERNS = Lists.newArrayList(NAME_ACCENT_PATTERN, NAME_QUOTE_PATTERN);
 
+    public static String getNewTableName(String rawName) {
         return getNewNameWithSuffix(rawName, DdlConstants.NEW_TABLE_NAME_SUFFIX);
     }
 
     public static String getRenamedTableName(String rawName) {
-
         return getNewNameWithSuffix(rawName, DdlConstants.RENAMED_TABLE_NAME_SUFFIX);
     }
 
     public static String getNewNameWithSuffix(String rawName, String suffix) {
-        if (rawName == null) {
-            return null;
+        Optional<Matcher> matcherOptional = findMatcher(rawName);
+        String newTableName;
+        if (matcherOptional.isPresent()) {
+            Matcher matcher = matcherOptional.get();
+            newTableName = rawName.replaceFirst(matcher.group(1),
+                    DdlConstants.OSC_TABLE_NAME_PREFIX + matcher.group(1) + suffix);
+        } else {
+            newTableName = DdlConstants.OSC_TABLE_NAME_PREFIX + rawName + suffix;
         }
-        return DdlConstants.OSC_TABLE_NAME_PREFIX + getUnwrappedName(rawName) + suffix;
+        return newTableName;
+    }
+
+    public static String getUnwrappedName(String rawName) {
+        Optional<Matcher> matcherOptional = findMatcher(rawName);
+        return matcherOptional.isPresent() ? matcherOptional.get().group(1) : rawName;
     }
 
     public static String queryOriginTableCreateDdl(ConnectionSession session, String tableName)
@@ -68,16 +83,6 @@ public class DdlUtils {
         return ddl.get(0);
     }
 
-    public static String getUnwrappedName(String rawName) {
-        Matcher matcher = NAME_QUOTE_PATTERN.matcher(rawName);
-        if (matcher.matches()) {
-            return matcher.group(1);
-        }
-        matcher = NAME_ACCENT_PATTERN.matcher(rawName);
-
-        return matcher.matches() ? matcher.group(1) : rawName;
-    }
-
     public static String replaceTableName(String sql, String newTableName, DialectType dialectType,
             OnlineSchemaChangeSqlType sqlType) {
         TableNameReplacer rewriter =
@@ -88,6 +93,11 @@ public class DdlUtils {
 
     public static String getUUIDWithoutUnderline() {
         return UUID.randomUUID().toString().replace("-", "");
+    }
+
+
+    private static Optional<Matcher> findMatcher(String rawName) {
+        return TABLE_PATTERNS.stream().map(m -> m.matcher(rawName)).filter(Matcher::matches).findFirst();
     }
 
 }

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/onlineschemachange/pipeline/BaseCreateOmsProjectValve.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/onlineschemachange/pipeline/BaseCreateOmsProjectValve.java
@@ -26,7 +26,6 @@ import java.util.UUID;
 import org.quartz.JobKey;
 import org.quartz.SchedulerException;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 
 import com.oceanbase.odc.common.json.JsonUtils;
 import com.oceanbase.odc.core.session.ConnectionSession;
@@ -78,9 +77,6 @@ public abstract class BaseCreateOmsProjectValve extends BaseValve {
 
     @Autowired
     protected OnlineSchemaChangeProperties oscProperties;
-
-    @Value("${osc-check-task-cron-expression:0/10 * * * * ?}")
-    private String oscCheckTaskCronExpression;
 
     @Autowired
     private ScheduleService scheduleService;

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/onlineschemachange/pipeline/BaseCreateOmsProjectValve.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/onlineschemachange/pipeline/BaseCreateOmsProjectValve.java
@@ -98,6 +98,7 @@ public abstract class BaseCreateOmsProjectValve extends BaseValve {
         try {
             omsDsId = dataSourceOpenApiService.createOceanBaseDataSource(dataSourceRequest);
         } catch (OmsException ex) {
+            log.warn("Create database occur error {}", ex.getMessage());
             omsDsId = reCreateDataSourceRequestAfterThrowsException(context.getTaskParameter(), dataSourceRequest, ex);
         }
 

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/onlineschemachange/subtask/OscTaskCompleteHandler.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/onlineschemachange/subtask/OscTaskCompleteHandler.java
@@ -74,4 +74,5 @@ public class OscTaskCompleteHandler {
         }
         log.info("Successfully update schedule task id {} set status {}", scheduleTaskId, status);
     }
+
 }

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/onlineschemachange/subtask/SubTaskParameterFactory.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/onlineschemachange/subtask/SubTaskParameterFactory.java
@@ -52,8 +52,6 @@ public class SubTaskParameterFactory implements AutoCloseable {
         OnlineSchemaChangeScheduleTaskParameters taskParameter = createNewParameter(sql, sqlType);
         taskParameter.setDialectType(connectionConfig.getDialectType());
         taskParameter.setConnectionId(connectionId);
-        taskParameter.setNewTableName(DdlUtils.getNewTableName(taskParameter.getOriginTableName()));
-        taskParameter.setRenamedTableName(DdlUtils.getRenamedTableName(taskParameter.getOriginTableName()));
         taskParameter.setDatabaseName(schema);
         return taskParameter;
     }
@@ -68,7 +66,8 @@ public class SubTaskParameterFactory implements AutoCloseable {
     private OnlineSchemaChangeScheduleTaskParameters createNewParameter(String sql, OnlineSchemaChangeSqlType sqlType)
             throws SQLException {
         OnlineSchemaChangeScheduleTaskParameters taskParameter = new OnlineSchemaChangeScheduleTaskParameters();
-
+        taskParameter.setNewTableName(DdlUtils.getNewTableName(taskParameter.getOriginTableName()));
+        taskParameter.setRenamedTableName(DdlUtils.getRenamedTableName(taskParameter.getOriginTableName()));
         if (sqlType == OnlineSchemaChangeSqlType.ALTER) {
             AlterTable statement = (AlterTable) parse(sql);
             String tableName = statement.getTableName();
@@ -77,7 +76,7 @@ public class SubTaskParameterFactory implements AutoCloseable {
             String originTableCreateDdl = DdlUtils.queryOriginTableCreateDdl(session, tableName);
             taskParameter.setOriginTableCreateDdl(originTableCreateDdl);
             taskParameter.setNewTableCreateDdl(DdlUtils.replaceTableName(originTableCreateDdl,
-                    DdlUtils.getNewTableName(unquote(tableName)), session.getDialectType(), sqlType));
+                    DdlUtils.getNewTableName(tableName), session.getDialectType(), sqlType));
 
             taskParameter.setNewTableCreateDdlForDisplay("");
         } else {
@@ -87,7 +86,7 @@ public class SubTaskParameterFactory implements AutoCloseable {
 
             taskParameter.setOriginTableCreateDdl(DdlUtils.queryOriginTableCreateDdl(session, tableName));
             taskParameter.setNewTableCreateDdl(DdlUtils.replaceTableName(sql,
-                    DdlUtils.getNewTableName(unquote(tableName)), session.getDialectType(), sqlType));
+                    DdlUtils.getNewTableName(tableName), session.getDialectType(), sqlType));
 
             taskParameter.setNewTableCreateDdlForDisplay(sql);
         }

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/onlineschemachange/subtask/SubTaskParameterFactory.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/onlineschemachange/subtask/SubTaskParameterFactory.java
@@ -66,13 +66,13 @@ public class SubTaskParameterFactory implements AutoCloseable {
     private OnlineSchemaChangeScheduleTaskParameters createNewParameter(String sql, OnlineSchemaChangeSqlType sqlType)
             throws SQLException {
         OnlineSchemaChangeScheduleTaskParameters taskParameter = new OnlineSchemaChangeScheduleTaskParameters();
-        taskParameter.setNewTableName(DdlUtils.getNewTableName(taskParameter.getOriginTableName()));
-        taskParameter.setRenamedTableName(DdlUtils.getRenamedTableName(taskParameter.getOriginTableName()));
+
         if (sqlType == OnlineSchemaChangeSqlType.ALTER) {
             AlterTable statement = (AlterTable) parse(sql);
             String tableName = statement.getTableName();
             taskParameter.setOriginTableName(tableName);
-
+            taskParameter.setNewTableName(DdlUtils.getNewTableName(taskParameter.getOriginTableName()));
+            taskParameter.setRenamedTableName(DdlUtils.getRenamedTableName(taskParameter.getOriginTableName()));
             String originTableCreateDdl = DdlUtils.queryOriginTableCreateDdl(session, tableName);
             taskParameter.setOriginTableCreateDdl(originTableCreateDdl);
             taskParameter.setNewTableCreateDdl(DdlUtils.replaceTableName(originTableCreateDdl,
@@ -83,7 +83,8 @@ public class SubTaskParameterFactory implements AutoCloseable {
             CreateTable statement = (CreateTable) parse(sql);
             String tableName = statement.getTableName();
             taskParameter.setOriginTableName(tableName);
-
+            taskParameter.setNewTableName(DdlUtils.getNewTableName(taskParameter.getOriginTableName()));
+            taskParameter.setRenamedTableName(DdlUtils.getRenamedTableName(taskParameter.getOriginTableName()));
             taskParameter.setOriginTableCreateDdl(DdlUtils.queryOriginTableCreateDdl(session, tableName));
             taskParameter.setNewTableCreateDdl(DdlUtils.replaceTableName(sql,
                     DdlUtils.getNewTableName(tableName), session.getDialectType(), sqlType));


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines.
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request.
3. Ensure you have added or ran the appropriate tests for your PR.
5. If the PR is unfinished, you may add or remove a WIP or [WIP] prefix to your pull request title.
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
type-bug
type-feature
type-docs
etc.

Optionally add one or more of the following kinds if applicable:
module-resultset
module-sql execution
etc.
-->
module-oneline schema change

#### What this PR does / why we need it:
1.Create table failed when table contains chinese charcter wrapped by quote

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
1.Create new table with origin wrapped character
2.Drop new table created by task when task is failed
3.fix checkTaskCronExpression which is not initlized


#### Special notes for your reviewer:

#### Additional documentation e.g., usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```