### PR TITLE
feat(mysql): sql execution adaption for mysql5.7

### DIFF
--- a/server/odc-core/src/main/java/com/oceanbase/odc/core/sql/execute/SqlExecuteStages.java
+++ b/server/odc-core/src/main/java/com/oceanbase/odc/core/sql/execute/SqlExecuteStages.java
@@ -37,7 +37,6 @@ public class SqlExecuteStages {
     public static final String JDBC_PREPARE = "Jdbc prepare";
     public static final String NETWORK_CONSUMPTION = "Network consumption";
     public static final String OBSERVER_WAIT = "OBServer wait";
-    public static final String OBSERVER_EXECUTE_SQL = "OBServer Execute SQL";
     public static final String INIT_SQL_CHECK_MESSAGE = "Init sql check message";
     public static final String DB_SERVER_EXECUTE_SQL = "DB Server Execute SQL";
     public static final String SQL_INTERCEPT_PRE_CHECK = "Sql intercept pre-check";

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/session/OdcStatementCallBack.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/session/OdcStatementCallBack.java
@@ -403,8 +403,8 @@ public class OdcStatementCallBack implements StatementCallback<List<JdbcGeneralR
             try (EditableTraceStage dbServerExecute =
                     traceWatch.startEditableStage(SqlExecuteStages.DB_SERVER_EXECUTE_SQL)) {
                 dbServerExecute.setStartTime(traceWatch.getByTaskName(SqlExecuteStages.EXECUTE).get(0).getStartTime(),
-                        TimeUnit.MILLISECONDS);
-                dbServerExecute.setTime(executeDetails.getExecuteMicroseconds(), TimeUnit.MILLISECONDS);
+                        TimeUnit.MICROSECONDS);
+                dbServerExecute.setTime(executeDetails.getExecuteMicroseconds(), TimeUnit.MICROSECONDS);
             }
             try (EditableTraceStage calculateDuration =
                     traceWatch.startEditableStage(SqlExecuteStages.CALCULATE_DURATION)) {
@@ -436,7 +436,7 @@ public class OdcStatementCallBack implements StatementCallback<List<JdbcGeneralR
                     TimeUnit.MICROSECONDS);
         }
         try (EditableTraceStage obServerExecute =
-                traceWatch.startEditableStage(SqlExecuteStages.OBSERVER_EXECUTE_SQL)) {
+                traceWatch.startEditableStage(SqlExecuteStages.DB_SERVER_EXECUTE_SQL)) {
             obServerExecute.setStartTime(
                     lastPacketResponseTimestamp - networkConsumption / 2 - executeDetails.getExecuteMicroseconds(),
                     TimeUnit.MICROSECONDS);


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines.
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request.
3. Ensure you have added or ran the appropriate tests for your PR.
5. If the PR is unfinished, you may add or remove a WIP or [WIP] prefix to your pull request title.
-->

#### What type of PR is this?
type-feature
module-sql execution

#### What this PR does / why we need it:
1. Different data sources uniformly use `DB_SERVER_EXECUTE_SQL` as DB time-consuming, delete `OBSERVER_EXECUTE_SQL`
2.  fix native mysql show DB execution time unit conversion error

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #2

#### Special notes for your reviewer:

#### Additional documentation e.g., usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```