### PR TITLE
fix(osc): fix sql of alter replace table name not correct

### DIFF
--- a/server/integration-test/src/test/java/com/oceanbase/odc/service/onlineschemachange/OscFactoryWrapperGeneratorTest.java
+++ b/server/integration-test/src/test/java/com/oceanbase/odc/service/onlineschemachange/OscFactoryWrapperGeneratorTest.java
@@ -37,14 +37,18 @@ public class OscFactoryWrapperGeneratorTest {
     private static String oraclePrefix;
     private static String mysqlPrefix;
     private static String newTableSuffix;
+    private static String newTableSuffixOBOracle;
     private static String renamedTableSuffix;
+    private static String renamedTableSuffixOBOracle;
 
     @BeforeClass
     public static void before() {
         oraclePrefix = DdlConstants.OSC_TABLE_NAME_PREFIX_OB_ORACLE;
         mysqlPrefix = DdlConstants.OSC_TABLE_NAME_PREFIX;
         newTableSuffix = DdlConstants.NEW_TABLE_NAME_SUFFIX;
+        newTableSuffixOBOracle = DdlConstants.NEW_TABLE_NAME_SUFFIX_OB_ORACLE;
         renamedTableSuffix = DdlConstants.RENAMED_TABLE_NAME_SUFFIX;
+        renamedTableSuffixOBOracle = DdlConstants.RENAMED_TABLE_NAME_SUFFIX_OB_ORACLE;
     }
 
     @Test
@@ -52,11 +56,11 @@ public class OscFactoryWrapperGeneratorTest {
         TableNameDescriptorFactory tableNameDescriptorFactory = getTableNameDescriptorFactory(DialectType.OB_ORACLE);
         TableNameDescriptor descriptor = tableNameDescriptorFactory.getTableNameDescriptor("t");
         Assert.equals("t", descriptor.getOriginTableNameUnwrapped());
-        Assert.equals(oraclePrefix + "t" + newTableSuffix,
+        Assert.equals(oraclePrefix + "t" + newTableSuffixOBOracle,
                 descriptor.getNewTableName());
-        Assert.equals(oraclePrefix + "t" + newTableSuffix,
+        Assert.equals(oraclePrefix + "t" + newTableSuffixOBOracle,
                 descriptor.getNewTableNameUnWrapped());
-        Assert.equals(oraclePrefix + "t" + renamedTableSuffix,
+        Assert.equals(oraclePrefix + "t" + renamedTableSuffixOBOracle,
                 descriptor.getRenamedTableName());
 
     }
@@ -66,12 +70,12 @@ public class OscFactoryWrapperGeneratorTest {
         TableNameDescriptorFactory tableNameDescriptorFactory = getTableNameDescriptorFactory(DialectType.OB_ORACLE);
         TableNameDescriptor descriptor = tableNameDescriptorFactory.getTableNameDescriptor("\"t\"");
         Assert.equals("t", descriptor.getOriginTableNameUnwrapped());
-        Assert.equals(quote(oraclePrefix + "t" + newTableSuffix),
+        Assert.equals(quote(oraclePrefix + "t" + newTableSuffixOBOracle),
                 descriptor.getNewTableName());
-        Assert.equals(oraclePrefix + "t" + newTableSuffix,
+        Assert.equals(oraclePrefix + "t" + newTableSuffixOBOracle,
                 descriptor.getNewTableNameUnWrapped());
         Assert.equals(
-                quote(oraclePrefix + "t" + renamedTableSuffix),
+                quote(oraclePrefix + "t" + renamedTableSuffixOBOracle),
                 descriptor.getRenamedTableName());
     }
 
@@ -92,15 +96,15 @@ public class OscFactoryWrapperGeneratorTest {
 
     @Test
     public void test_ob_mysql_table_name_accent() {
-        TableNameDescriptorFactory tableNameDescriptorFactory = getTableNameDescriptorFactory(DialectType.OB_ORACLE);
+        TableNameDescriptorFactory tableNameDescriptorFactory = getTableNameDescriptorFactory(DialectType.OB_MYSQL);
         TableNameDescriptor descriptor = tableNameDescriptorFactory.getTableNameDescriptor("`t`");
         Assert.equals("t", descriptor.getOriginTableNameUnwrapped());
-        Assert.equals(accent(oraclePrefix + "t" + newTableSuffix),
+        Assert.equals(accent(mysqlPrefix + "t" + newTableSuffix),
                 descriptor.getNewTableName());
-        Assert.equals(oraclePrefix + "t" + newTableSuffix,
+        Assert.equals(mysqlPrefix + "t" + newTableSuffix,
                 descriptor.getNewTableNameUnWrapped());
         Assert.equals(
-                accent(oraclePrefix + "t" + renamedTableSuffix),
+                accent(mysqlPrefix + "t" + renamedTableSuffix),
                 descriptor.getRenamedTableName());
     }
 

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/onlineschemachange/DefaultOnlineSchemaChangeTaskHandler.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/onlineschemachange/DefaultOnlineSchemaChangeTaskHandler.java
@@ -399,7 +399,7 @@ public class DefaultOnlineSchemaChangeTaskHandler implements OnlineSchemaChangeT
             // update new table ddl for display
             String finalTableDdl = DdlUtils.queryOriginTableCreateDdl(session, taskParam.getNewTableName());
             String ddlForDisplay = DdlUtils.replaceTableName(finalTableDdl, taskParam.getOriginTableName(),
-                    session.getDialectType(), param.getSqlType());
+                    session.getDialectType(), OnlineSchemaChangeSqlType.CREATE);
             taskParam.setNewTableCreateDdlForDisplay(ddlForDisplay);
             scheduleTaskRepository.updateTaskResult(scheduleTaskId,
                     JsonUtils.toJson(new OnlineSchemaChangeScheduleTaskResult(taskParam)));

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/onlineschemachange/ddl/BaseTableNameDescriptorFactory.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/onlineschemachange/ddl/BaseTableNameDescriptorFactory.java
@@ -29,19 +29,22 @@ public abstract class BaseTableNameDescriptorFactory implements TableNameDescrip
         nameDescriptor.setOriginTableName(tableName);
         nameDescriptor.setOriginTableNameUnwrapped(DdlUtils.getUnwrappedName(tableName));
 
-        String newTableName = DdlUtils.getNewNameWithSuffix(tableName, tablePrefix(),
-                DdlConstants.NEW_TABLE_NAME_SUFFIX);
+        String newTableName = DdlUtils.getNewNameWithSuffix(tableName, tablePrefix(), newTableSuffix());
         nameDescriptor.setNewTableName(newTableName);
         nameDescriptor.setNewTableNameUnWrapped(DdlUtils.getUnwrappedName(newTableName));
 
-        String renamedTableName = DdlUtils.getNewNameWithSuffix(tableName, tablePrefix(),
-                DdlConstants.RENAMED_TABLE_NAME_SUFFIX);
+        String renamedTableName = DdlUtils.getNewNameWithSuffix(tableName, tablePrefix(), renamedTableSuffix());
         nameDescriptor.setRenamedTableName(renamedTableName);
         nameDescriptor.setRenamedTableNameUnWrapped(DdlUtils.getUnwrappedName(renamedTableName));
         return nameDescriptor;
     }
 
     protected abstract String tablePrefix();
+
+    protected abstract String newTableSuffix();
+
+    protected abstract String renamedTableSuffix();
+
 
 
 }

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/onlineschemachange/ddl/DdlConstants.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/onlineschemachange/ddl/DdlConstants.java
@@ -29,6 +29,10 @@ public class DdlConstants {
 
     public static final String RENAMED_TABLE_NAME_SUFFIX = "_osc_old_";
 
+    public static final String NEW_TABLE_NAME_SUFFIX_OB_ORACLE = "_OSC_NEW_";
+
+    public static final String RENAMED_TABLE_NAME_SUFFIX_OB_ORACLE = "_OSC_OLD_";
+
     public static final String TABLE_NAME_WRAPPER = "`";
 
     public static final String TABLE_NAME_WRAPPED_QUOTE = "\"";

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/onlineschemachange/ddl/OBMySqlTableNameDescriptorFactory.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/onlineschemachange/ddl/OBMySqlTableNameDescriptorFactory.java
@@ -27,4 +27,14 @@ public class OBMySqlTableNameDescriptorFactory extends BaseTableNameDescriptorFa
     protected String tablePrefix() {
         return DdlConstants.OSC_TABLE_NAME_PREFIX;
     }
+
+    @Override
+    protected String newTableSuffix() {
+        return DdlConstants.NEW_TABLE_NAME_SUFFIX;
+    }
+
+    @Override
+    protected String renamedTableSuffix() {
+        return DdlConstants.RENAMED_TABLE_NAME_SUFFIX;
+    }
 }

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/onlineschemachange/ddl/OBOracleTableNameDescriptorFactory.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/onlineschemachange/ddl/OBOracleTableNameDescriptorFactory.java
@@ -27,4 +27,14 @@ public class OBOracleTableNameDescriptorFactory extends BaseTableNameDescriptorF
     protected String tablePrefix() {
         return DdlConstants.OSC_TABLE_NAME_PREFIX_OB_ORACLE;
     }
+
+    @Override
+    protected String newTableSuffix() {
+        return DdlConstants.NEW_TABLE_NAME_SUFFIX_OB_ORACLE;
+    }
+
+    @Override
+    protected String renamedTableSuffix() {
+        return DdlConstants.RENAMED_TABLE_NAME_SUFFIX_OB_ORACLE;
+    }
 }

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/onlineschemachange/ddl/OBOracleTableNameReplacer.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/onlineschemachange/ddl/OBOracleTableNameReplacer.java
@@ -134,7 +134,7 @@ public class OBOracleTableNameReplacer implements TableNameReplacer {
                 ParseTree childNode = relation_nameContext.getChild(0);
                 if (childNode instanceof TerminalNode) {
                     TerminalNode terminalNode = (TerminalNode) childNode;
-                    tokenStreamRewriter.replace(terminalNode.getSymbol(),  StringUtils.uuidNoHyphen());
+                    tokenStreamRewriter.replace(terminalNode.getSymbol(), "A" + StringUtils.uuidNoHyphen());
                 }
             }
         }
@@ -152,7 +152,7 @@ public class OBOracleTableNameReplacer implements TableNameReplacer {
                 if (childNode instanceof TerminalNode) {
                     TerminalNode terminalNode = (TerminalNode) childNode;
                     // replace constraints name
-                    tokenStreamRewriter.replace(terminalNode.getSymbol(), StringUtils.uuidNoHyphen());
+                    tokenStreamRewriter.replace(terminalNode.getSymbol(), "A" + StringUtils.uuidNoHyphen());
                 }
             }
         }

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/onlineschemachange/ddl/OBOracleTableNameReplacer.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/onlineschemachange/ddl/OBOracleTableNameReplacer.java
@@ -153,7 +153,7 @@ public class OBOracleTableNameReplacer implements TableNameReplacer {
                 ParseTree childNode = relation_nameContext.getChild(0);
                 if (childNode instanceof TerminalNode) {
                     TerminalNode terminalNode = (TerminalNode) childNode;
-                    // todo replace by OscFactoryWrapper
+                    // replace constraints name
                     tokenStreamRewriter.replace(terminalNode.getSymbol(), DdlUtils.getNewNameWithSuffix(
                             terminalNode.getSymbol().getText(), DdlConstants.OSC_TABLE_NAME_PREFIX,
                             DdlUtils.getUUIDWithoutUnderline()));

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/onlineschemachange/ddl/OBOracleTableNameReplacer.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/onlineschemachange/ddl/OBOracleTableNameReplacer.java
@@ -23,6 +23,7 @@ import org.antlr.v4.runtime.tree.ParseTree;
 import org.antlr.v4.runtime.tree.ParseTreeWalker;
 import org.antlr.v4.runtime.tree.TerminalNode;
 
+import com.oceanbase.odc.common.util.StringUtils;
 import com.oceanbase.odc.core.shared.PreConditions;
 import com.oceanbase.tools.sqlparser.FastFailErrorListener;
 import com.oceanbase.tools.sqlparser.oboracle.OBLexer;
@@ -133,10 +134,7 @@ public class OBOracleTableNameReplacer implements TableNameReplacer {
                 ParseTree childNode = relation_nameContext.getChild(0);
                 if (childNode instanceof TerminalNode) {
                     TerminalNode terminalNode = (TerminalNode) childNode;
-                    // todo replace by OscFactoryWrapper
-                    tokenStreamRewriter.replace(terminalNode.getSymbol(), DdlUtils.getNewNameWithSuffix(
-                            terminalNode.getSymbol().getText(), DdlConstants.OSC_TABLE_NAME_PREFIX_OB_ORACLE,
-                            DdlUtils.getUUIDWithoutUnderline()));
+                    tokenStreamRewriter.replace(terminalNode.getSymbol(),  StringUtils.uuidNoHyphen());
                 }
             }
         }
@@ -154,9 +152,7 @@ public class OBOracleTableNameReplacer implements TableNameReplacer {
                 if (childNode instanceof TerminalNode) {
                     TerminalNode terminalNode = (TerminalNode) childNode;
                     // replace constraints name
-                    tokenStreamRewriter.replace(terminalNode.getSymbol(), DdlUtils.getNewNameWithSuffix(
-                            terminalNode.getSymbol().getText(), DdlConstants.OSC_TABLE_NAME_PREFIX,
-                            DdlUtils.getUUIDWithoutUnderline()));
+                    tokenStreamRewriter.replace(terminalNode.getSymbol(), StringUtils.uuidNoHyphen());
                 }
             }
         }

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/onlineschemachange/model/OnlineSchemaChangeScheduleTaskParameters.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/onlineschemachange/model/OnlineSchemaChangeScheduleTaskParameters.java
@@ -21,7 +21,6 @@ import java.util.List;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.oceanbase.odc.common.util.StringUtils;
 import com.oceanbase.odc.core.shared.constant.DialectType;
 
@@ -91,7 +90,6 @@ public class OnlineSchemaChangeScheduleTaskParameters {
     /**
      * For ODC internal usage
      */
-    @JsonIgnore
     private List<String> sqlsToBeExecuted = new ArrayList<>();
 
     public String getOriginTableNameWithSchema() {

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/onlineschemachange/subtask/SubTaskParameterFactory.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/onlineschemachange/subtask/SubTaskParameterFactory.java
@@ -77,32 +77,39 @@ public class SubTaskParameterFactory implements AutoCloseable {
         if (sqlType == OnlineSchemaChangeSqlType.ALTER) {
             AlterTable statement = (AlterTable) parse(sql);
             String tableName = statement.getTableName();
-            populateTaskParameter(sqlType, taskParameter, tableName);
+            TableNameDescriptor tableNameDescriptor = tableNameDescriptorFactory.getTableNameDescriptor(tableName);
+            String originTableCreateDdl = DdlUtils.queryOriginTableCreateDdl(session, tableName);
+            taskParameter.setOriginTableCreateDdl(originTableCreateDdl);
+            taskParameter.setNewTableCreateDdl(DdlUtils.replaceTableName(originTableCreateDdl,
+                tableNameDescriptor.getNewTableName(), session.getDialectType(), OnlineSchemaChangeSqlType.CREATE));
+
+            populateTaskParameter(tableNameDescriptor, taskParameter, tableName);
         } else {
             CreateTable statement = (CreateTable) parse(sql);
             String tableName = statement.getTableName();
+            String originTableCreateDdl = DdlUtils.queryOriginTableCreateDdl(session, tableName);
+            taskParameter.setOriginTableCreateDdl(originTableCreateDdl);
+            TableNameDescriptor tableNameDescriptor = tableNameDescriptorFactory.getTableNameDescriptor(tableName);
+            taskParameter.setNewTableCreateDdl(DdlUtils.replaceTableName(sql,
+                tableNameDescriptor.getNewTableName(), session.getDialectType(), OnlineSchemaChangeSqlType.CREATE));
             taskParameter.setNewTableCreateDdlForDisplay(sql);
-            populateTaskParameter(sqlType, taskParameter, tableName);
+
+            populateTaskParameter(tableNameDescriptor, taskParameter, tableName);
         }
         return taskParameter;
     }
 
-    private void populateTaskParameter(OnlineSchemaChangeSqlType sqlType,
+    private void populateTaskParameter(TableNameDescriptor tableNameDescriptor,
             OnlineSchemaChangeScheduleTaskParameters taskParameter,
-            String tableName) throws SQLException {
+            String tableName){
         taskParameter.setOriginTableName(tableName);
-        TableNameDescriptor tableNameDescriptor = tableNameDescriptorFactory.getTableNameDescriptor(tableName);
-
         taskParameter.setNewTableName(tableNameDescriptor.getNewTableName());
         taskParameter.setRenamedTableName(tableNameDescriptor.getRenamedTableName());
         taskParameter.setNewTableNameUnwrapped(tableNameDescriptor.getNewTableNameUnWrapped());
         taskParameter.setOriginTableNameUnwrapped(tableNameDescriptor.getOriginTableNameUnwrapped());
         taskParameter.setRenamedTableNameUnwrapped(tableNameDescriptor.getRenamedTableNameUnWrapped());
 
-        String originTableCreateDdl = DdlUtils.queryOriginTableCreateDdl(session, tableName);
-        taskParameter.setOriginTableCreateDdl(originTableCreateDdl);
-        taskParameter.setNewTableCreateDdl(DdlUtils.replaceTableName(originTableCreateDdl,
-                tableNameDescriptor.getNewTableName(), session.getDialectType(), OnlineSchemaChangeSqlType.CREATE));
+
     }
 
     private Statement parse(String sql) {

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/onlineschemachange/subtask/SubTaskParameterFactory.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/onlineschemachange/subtask/SubTaskParameterFactory.java
@@ -77,7 +77,6 @@ public class SubTaskParameterFactory implements AutoCloseable {
         if (sqlType == OnlineSchemaChangeSqlType.ALTER) {
             AlterTable statement = (AlterTable) parse(sql);
             String tableName = statement.getTableName();
-            taskParameter.setNewTableCreateDdlForDisplay("");
             populateTaskParameter(sqlType, taskParameter, tableName);
         } else {
             CreateTable statement = (CreateTable) parse(sql);
@@ -103,7 +102,7 @@ public class SubTaskParameterFactory implements AutoCloseable {
         String originTableCreateDdl = DdlUtils.queryOriginTableCreateDdl(session, tableName);
         taskParameter.setOriginTableCreateDdl(originTableCreateDdl);
         taskParameter.setNewTableCreateDdl(DdlUtils.replaceTableName(originTableCreateDdl,
-                tableNameDescriptor.getNewTableName(), session.getDialectType(), sqlType));
+                tableNameDescriptor.getNewTableName(), session.getDialectType(), OnlineSchemaChangeSqlType.CREATE));
     }
 
     private Statement parse(String sql) {

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/onlineschemachange/subtask/SubTaskParameterFactory.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/onlineschemachange/subtask/SubTaskParameterFactory.java
@@ -81,7 +81,7 @@ public class SubTaskParameterFactory implements AutoCloseable {
             String originTableCreateDdl = DdlUtils.queryOriginTableCreateDdl(session, tableName);
             taskParameter.setOriginTableCreateDdl(originTableCreateDdl);
             taskParameter.setNewTableCreateDdl(DdlUtils.replaceTableName(originTableCreateDdl,
-                tableNameDescriptor.getNewTableName(), session.getDialectType(), OnlineSchemaChangeSqlType.CREATE));
+                    tableNameDescriptor.getNewTableName(), session.getDialectType(), OnlineSchemaChangeSqlType.CREATE));
 
             populateTaskParameter(tableNameDescriptor, taskParameter, tableName);
         } else {
@@ -91,7 +91,7 @@ public class SubTaskParameterFactory implements AutoCloseable {
             taskParameter.setOriginTableCreateDdl(originTableCreateDdl);
             TableNameDescriptor tableNameDescriptor = tableNameDescriptorFactory.getTableNameDescriptor(tableName);
             taskParameter.setNewTableCreateDdl(DdlUtils.replaceTableName(sql,
-                tableNameDescriptor.getNewTableName(), session.getDialectType(), OnlineSchemaChangeSqlType.CREATE));
+                    tableNameDescriptor.getNewTableName(), session.getDialectType(), OnlineSchemaChangeSqlType.CREATE));
             taskParameter.setNewTableCreateDdlForDisplay(sql);
 
             populateTaskParameter(tableNameDescriptor, taskParameter, tableName);
@@ -101,7 +101,7 @@ public class SubTaskParameterFactory implements AutoCloseable {
 
     private void populateTaskParameter(TableNameDescriptor tableNameDescriptor,
             OnlineSchemaChangeScheduleTaskParameters taskParameter,
-            String tableName){
+            String tableName) {
         taskParameter.setOriginTableName(tableName);
         taskParameter.setNewTableName(tableNameDescriptor.getNewTableName());
         taskParameter.setRenamedTableName(tableNameDescriptor.getRenamedTableName());


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines.
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request.
3. Ensure you have added or ran the appropriate tests for your PR.
5. If the PR is unfinished, you may add or remove a WIP or [WIP] prefix to your pull request title.
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
type-bug
type-feature
type-docs
etc.

Optionally add one or more of the following kinds if applicable:
module-resultset
module-sql execution
etc.
-->
type-debug
type-online schema change
#### What this PR does / why we need it:
fix alter type execute failed 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
1. oracle new table name with suffix with  "OSC_NEW_" and renamed table suffix with "OSC_OLD_"
2. fix alter type sql replaced by new table name
3. fix oracle constraints name with uuid, old renamed style may overrun 128 characters
#### Special notes for your reviewer:

#### Additional documentation e.g., usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```