### PR TITLE
fix(osc): fix duplicate foreign key constraint name when execute new table create ddl

### DIFF
--- a/server/integration-test/src/test/java/com/oceanbase/odc/service/onlineschemachange/OnlineSchemaChangeValidatorTest.java
+++ b/server/integration-test/src/test/java/com/oceanbase/odc/service/onlineschemachange/OnlineSchemaChangeValidatorTest.java
@@ -16,12 +16,12 @@
 package com.oceanbase.odc.service.onlineschemachange;
 
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.util.Assert;
 
 import com.oceanbase.odc.ServiceTestEnv;
 import com.oceanbase.odc.TestConnectionUtil;
@@ -31,7 +31,6 @@ import com.oceanbase.odc.core.session.ConnectionSessionConstants;
 import com.oceanbase.odc.core.shared.constant.ConnectType;
 import com.oceanbase.odc.core.shared.constant.ErrorCodes;
 import com.oceanbase.odc.core.shared.exception.BadArgumentException;
-import com.oceanbase.odc.core.shared.exception.HttpException;
 import com.oceanbase.odc.service.connection.ConnectionService;
 import com.oceanbase.odc.service.connection.model.ConnectionConfig;
 import com.oceanbase.odc.service.flow.model.CreateFlowInstanceReq;
@@ -110,9 +109,8 @@ public class OnlineSchemaChangeValidatorTest extends ServiceTestEnv {
             validService.validate(getCreateRequest(
                     sql,
                     OnlineSchemaChangeSqlType.CREATE));
-        } catch (Exception ex) {
-            Assert.isTrue(ex instanceof BadArgumentException);
-            Assert.isTrue(((HttpException) ex).getErrorCode() == ErrorCodes.ObPreCheckDdlFailed);
+        } catch (BadArgumentException ex) {
+            Assert.assertSame(ex.getErrorCode(), ErrorCodes.ObPreCheckDdlFailed);
             throw ex;
         }
     }

--- a/server/integration-test/src/test/java/com/oceanbase/odc/service/onlineschemachange/ddl/TableNameReplacerTest.java
+++ b/server/integration-test/src/test/java/com/oceanbase/odc/service/onlineschemachange/ddl/TableNameReplacerTest.java
@@ -15,8 +15,19 @@
  */
 package com.oceanbase.odc.service.onlineschemachange.ddl;
 
+import java.io.StringReader;
+import java.util.List;
+import java.util.Optional;
+
 import org.junit.Assert;
 import org.junit.Test;
+
+import com.oceanbase.tools.sqlparser.OBMySQLParser;
+import com.oceanbase.tools.sqlparser.OBOracleSQLParser;
+import com.oceanbase.tools.sqlparser.statement.Statement;
+import com.oceanbase.tools.sqlparser.statement.createtable.CreateTable;
+import com.oceanbase.tools.sqlparser.statement.createtable.OutOfLineConstraint;
+import com.oceanbase.tools.sqlparser.statement.createtable.OutOfLineForeignConstraint;
 
 public class TableNameReplacerTest {
     private static final String CREATE_STMT = "create table t1 (id int);";
@@ -42,6 +53,68 @@ public class TableNameReplacerTest {
     public void test_RewriteCreateStmt_Oracle() {
         String newSql = new OBOracleTableNameReplacer().replaceCreateStmt(CREATE_STMT, getNewOracleTableName("t1"));
         Assert.assertEquals("create table t1_osc_new_ (id int);", newSql);
+    }
+
+    @Test
+    public void test_RewriteCreateStmtWittConstraint_Oracle() {
+        String createSql = "CREATE TABLE CHILD_TABLE1 (\n"
+                + "COL NUMBER NOT NULL,\n"
+                + "COL1 NUMBER NOT NULL,\n"
+                + "CONSTRAINT P1 PRIMARY KEY (COL),\n"
+                + "CONSTRAINT U1 UNIQUE (COL1),\n"
+                + "CONSTRAINT F1 FOREIGN KEY (COL) REFERENCES PARENT_TABLE1 (COL) ON DELETE CASCADE \n"
+                + ")";
+        String newSql = new OBOracleTableNameReplacer().replaceCreateStmt(createSql, "CHILD_TABLE_NEW");
+        Statement statement = new OBOracleSQLParser().parse(new StringReader(newSql));
+        Assert.assertTrue(statement instanceof CreateTable);
+        CreateTable createTable = (CreateTable) statement;
+        List<OutOfLineConstraint> constraints = createTable.getConstraints();
+        Optional<OutOfLineConstraint> pk = constraints.stream().filter(OutOfLineConstraint::isPrimaryKey).findFirst();
+        Assert.assertTrue(pk.isPresent());
+        Assert.assertNotEquals("P1", pk.get().getConstraintName());
+
+        Optional<OutOfLineConstraint> uk = constraints.stream().filter(OutOfLineConstraint::isUniqueKey).findFirst();
+        Assert.assertTrue(uk.isPresent());
+        Assert.assertNotEquals("U1", uk.get().getConstraintName());
+
+        Optional<OutOfLineForeignConstraint> fk =
+                constraints.stream().filter(c -> (c instanceof OutOfLineForeignConstraint))
+                        .map(c -> (OutOfLineForeignConstraint) c).findFirst();
+        Assert.assertTrue(fk.isPresent());
+        Assert.assertNotEquals("F1", pk.get().getConstraintName());
+    }
+
+
+
+    @Test
+    public void test_RewriteCreateStmtWittConstraint_MySql() {
+        String createSql = "CREATE TABLE `child_table1` (\n"
+                + "`col` int NOT NULL,\n"
+                + "`col1` int NOT NULL,\n"
+                + "CONSTRAINT `p1` PRIMARY KEY (`col`),\n"
+                + "CONSTRAINT `u1` UNIQUE (`col`),\n"
+                + "UNIQUE (`col`),\n"
+                + "CONSTRAINT `f1` FOREIGN KEY (`col`) REFERENCES `parent_table1` (`col`) ON DELETE CASCADE ON "
+                + "UPDATE NO ACTION\n"
+                + ")\n";
+        String newSql = new OBMysqlTableNameReplacer().replaceCreateStmt(createSql, "`child_table1_new`");
+        Statement statement = new OBMySQLParser().parse(new StringReader(newSql));
+        Assert.assertTrue(statement instanceof CreateTable);
+        CreateTable createTable = (CreateTable) statement;
+        List<OutOfLineConstraint> constraints = createTable.getConstraints();
+        Optional<OutOfLineConstraint> pk = constraints.stream().filter(OutOfLineConstraint::isPrimaryKey).findFirst();
+        Assert.assertTrue(pk.isPresent());
+        Assert.assertEquals("`p1`", pk.get().getConstraintName());
+
+        Optional<OutOfLineConstraint> uk = constraints.stream().filter(OutOfLineConstraint::isUniqueKey).findFirst();
+        Assert.assertTrue(uk.isPresent());
+        Assert.assertEquals("`u1`", uk.get().getConstraintName());
+
+        Optional<OutOfLineForeignConstraint> fk =
+                constraints.stream().filter(c -> (c instanceof OutOfLineForeignConstraint))
+                        .map(c -> (OutOfLineForeignConstraint) c).findFirst();
+        Assert.assertTrue(fk.isPresent());
+        Assert.assertNotEquals("`f1`", pk.get().getConstraintName());
     }
 
     @Test

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/onlineschemachange/ddl/OBMysqlTableNameReplacer.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/onlineschemachange/ddl/OBMysqlTableNameReplacer.java
@@ -16,6 +16,8 @@
 package com.oceanbase.odc.service.onlineschemachange.ddl;
 
 import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Function;
 
 import org.antlr.v4.runtime.CharStream;
 import org.antlr.v4.runtime.CharStreams;
@@ -24,20 +26,39 @@ import org.antlr.v4.runtime.TokenStreamRewriter;
 import org.antlr.v4.runtime.tree.ParseTree;
 import org.antlr.v4.runtime.tree.ParseTreeWalker;
 import org.antlr.v4.runtime.tree.TerminalNode;
+import org.antlr.v4.runtime.tree.TerminalNodeImpl;
 
+import com.oceanbase.odc.common.util.StringUtils;
 import com.oceanbase.odc.core.shared.PreConditions;
 import com.oceanbase.tools.sqlparser.FastFailErrorListener;
 import com.oceanbase.tools.sqlparser.obmysql.OBLexer;
 import com.oceanbase.tools.sqlparser.obmysql.OBParser;
 import com.oceanbase.tools.sqlparser.obmysql.OBParser.Alter_table_stmtContext;
+import com.oceanbase.tools.sqlparser.obmysql.OBParser.Constraint_nameContext;
 import com.oceanbase.tools.sqlparser.obmysql.OBParser.Create_table_stmtContext;
+import com.oceanbase.tools.sqlparser.obmysql.OBParser.Out_of_line_constraintContext;
 import com.oceanbase.tools.sqlparser.obmysql.OBParser.Relation_factorContext;
 import com.oceanbase.tools.sqlparser.obmysql.OBParser.Relation_nameContext;
 import com.oceanbase.tools.sqlparser.obmysql.OBParserBaseListener;
 
 public class OBMysqlTableNameReplacer implements TableNameReplacer {
 
+    private static final String CONSTRAINT_KEYWORD = "CONSTRAINT";
+    private static final String FOREIGN_KEYWORD = "FOREIGN";
+
     public String replaceCreateStmt(String originCreateStmt, String newTableName) {
+        return getRewriteSql(originCreateStmt,
+                rewriter -> new CreateWalkerOBParserReplaceStatementListener(rewriter, newTableName));
+    }
+
+    @Override
+    public String replaceAlterStmt(String originAlterStmt, String newTableName) {
+        return getRewriteSql(originAlterStmt,
+                rewriter -> new WalkerOBParserReplaceStatementListener(rewriter, newTableName));
+    }
+
+    private static String getRewriteSql(String originCreateStmt,
+            Function<TokenStreamRewriter, OBParserBaseListener> obParserBaseListenerFunc) {
         CharStream charStream = CharStreams.fromString(originCreateStmt);
         OBLexer lexer = new OBLexer(charStream);
 
@@ -49,21 +70,13 @@ public class OBMysqlTableNameReplacer implements TableNameReplacer {
         parser.setTrace(false);
 
         TokenStreamRewriter tokenStreamRewriter = new TokenStreamRewriter(tokens);
-        WalkerOBParserReplaceStatementListener eventParser = new WalkerOBParserReplaceStatementListener(
-                tokenStreamRewriter, newTableName);
-
-        new ParseTreeWalker().walk(eventParser, parser.sql_stmt());
+        new ParseTreeWalker().walk(obParserBaseListenerFunc.apply(tokenStreamRewriter), parser.sql_stmt());
         return tokenStreamRewriter.getText();
     }
 
-    @Override
-    public String replaceAlterStmt(String originAlterStmt, String newTableName) {
-        return replaceCreateStmt(originAlterStmt, newTableName);
-    }
-
     static class WalkerOBParserReplaceStatementListener extends OBParserBaseListener {
-        private final TokenStreamRewriter tokenStreamRewriter;
-        private final String newTableName;
+        protected final TokenStreamRewriter tokenStreamRewriter;
+        protected final String newTableName;
 
         public WalkerOBParserReplaceStatementListener(TokenStreamRewriter tokenStreamRewriter, String newTableName) {
             this.tokenStreamRewriter = tokenStreamRewriter;
@@ -75,12 +88,7 @@ public class OBMysqlTableNameReplacer implements TableNameReplacer {
             relationFactorReplace(ctx.relation_factor());
         }
 
-        @Override
-        public void enterCreate_table_stmt(Create_table_stmtContext ctx) {
-            relationFactorReplace(ctx.relation_factor());
-        }
-
-        private void relationFactorReplace(Relation_factorContext relation_factorContext) {
+        protected void relationFactorReplace(Relation_factorContext relation_factorContext) {
             List<Relation_nameContext> relation_nameContexts = relation_factorContext.normal_relation_factor()
                     .relation_name();
 
@@ -93,6 +101,60 @@ public class OBMysqlTableNameReplacer implements TableNameReplacer {
                 tokenStreamRewriter.replace(terminalNode.getSymbol(), newTableName);
             }
         }
+    }
 
+    static class CreateWalkerOBParserReplaceStatementListener extends WalkerOBParserReplaceStatementListener {
+        private final AtomicBoolean IS_CONSTRAINT_FOREIGN_KEY = new AtomicBoolean(false);
+
+        public CreateWalkerOBParserReplaceStatementListener(TokenStreamRewriter tokenStreamRewriter,
+                String newTableName) {
+            super(tokenStreamRewriter, newTableName);
+        }
+
+        @Override
+        public void enterCreate_table_stmt(Create_table_stmtContext ctx) {
+            relationFactorReplace(ctx.relation_factor());
+        }
+
+        @Override
+        public void enterOut_of_line_constraint(Out_of_line_constraintContext ctx) {
+            if (ctx.getChildCount() == 0) {
+                return;
+            }
+            ParseTree firstChild = ctx.getChild(0);
+            if (firstChild instanceof TerminalNodeImpl) {
+                String keyword = ((TerminalNodeImpl) firstChild).getSymbol().getText();
+                if (CONSTRAINT_KEYWORD.equalsIgnoreCase(keyword) && ctx.getChildCount() >= 3) {
+                    if (ctx.getChild(2) instanceof TerminalNodeImpl) {
+                        if (FOREIGN_KEYWORD.equalsIgnoreCase(
+                                ((TerminalNodeImpl) ctx.getChild(2)).getSymbol().getText())) {
+                            IS_CONSTRAINT_FOREIGN_KEY.getAndSet(true);
+                        }
+                    }
+                }
+            }
+        }
+
+        @Override
+        public void exitOut_of_line_constraint(Out_of_line_constraintContext ctx) {
+            IS_CONSTRAINT_FOREIGN_KEY.getAndSet(false);
+        }
+
+        @Override
+        public void enterConstraint_name(Constraint_nameContext ctx) {
+            if (ctx.getChildCount() == 0 || !IS_CONSTRAINT_FOREIGN_KEY.get()) {
+                return;
+            }
+            ParseTree parseTree = ctx.getChild(0);
+            if (parseTree instanceof Relation_nameContext) {
+
+                Relation_nameContext relation_nameContext = (Relation_nameContext) parseTree;
+                ParseTree childNode = relation_nameContext.getChild(0);
+                if (childNode instanceof TerminalNode) {
+                    TerminalNode terminalNode = (TerminalNode) childNode;
+                    tokenStreamRewriter.replace(terminalNode.getSymbol(), "A" + StringUtils.uuidNoHyphen());
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines.
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request.
3. Ensure you have added or ran the appropriate tests for your PR.
5. If the PR is unfinished, you may add or remove a WIP or [WIP] prefix to your pull request title.
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
type-bug
type-feature
type-docs
etc.

Optionally add one or more of the following kinds if applicable:
module-resultset
module-sql execution
etc.
-->
type-bug
type-Online schema change
#### What this PR does / why we need it:
occur duplicate key error when create a new table contain  foreign key with the same constraint name  exists in database
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
replace the old constraint name by TokenStreamRewriter when antlr invoke enterConstraint_name

#### Special notes for your reviewer:

#### Additional documentation e.g., usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```