### PR TITLE
fix(syncDatabase): fix ob mysql before 4.x can see other tenant's  schemas when syncDatabase

### DIFF
--- a/libs/db-browser/src/main/java/com/oceanbase/tools/dbbrowser/schema/mysql/OBMySQLBetween2277And3XSchemaAccessor.java
+++ b/libs/db-browser/src/main/java/com/oceanbase/tools/dbbrowser/schema/mysql/OBMySQLBetween2277And3XSchemaAccessor.java
@@ -18,6 +18,7 @@ package com.oceanbase.tools.dbbrowser.schema.mysql;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.springframework.jdbc.core.JdbcOperations;
 import org.springframework.lang.NonNull;
@@ -85,7 +86,7 @@ public class OBMySQLBetween2277And3XSchemaAccessor extends OBMySQLSchemaAccessor
     @Override
     public List<DBDatabase> listDatabases() {
         String sql = "select a.database_id, a.database_name, b.DEFAULT_CHARACTER_SET_NAME, b.DEFAULT_COLLATION_NAME "
-                + "from oceanbase.gv$database a inner join information_schema.schemata b on a.database_name=b.SCHEMA_NAME;";
+                + "from oceanbase.gv$database a inner join information_schema.schemata b on a.database_name=b.SCHEMA_NAME where a.tenant_id=EFFECTIVE_TENANT_ID()";
         return jdbcOperations.query(sql, (rs, num) -> {
             DBDatabase database = new DBDatabase();
             database.setId(rs.getString("database_id"));
@@ -93,7 +94,7 @@ public class OBMySQLBetween2277And3XSchemaAccessor extends OBMySQLSchemaAccessor
             database.setCharset(rs.getString("DEFAULT_CHARACTER_SET_NAME"));
             database.setCollation(rs.getString("DEFAULT_COLLATION_NAME"));
             return database;
-        });
+        }).stream().filter(database -> !ESCAPE_SCHEMA_SET.contains(database.getName())).collect(Collectors.toList());
     }
 
     @Override

--- a/libs/db-browser/src/main/java/com/oceanbase/tools/dbbrowser/schema/mysql/OBMySQLSchemaAccessor.java
+++ b/libs/db-browser/src/main/java/com/oceanbase/tools/dbbrowser/schema/mysql/OBMySQLSchemaAccessor.java
@@ -15,8 +15,10 @@
  */
 package com.oceanbase.tools.dbbrowser.schema.mysql;
 
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.apache.commons.collections4.CollectionUtils;
@@ -47,6 +49,21 @@ import lombok.extern.slf4j.Slf4j;
  */
 @Slf4j
 public class OBMySQLSchemaAccessor extends MySQLNoGreaterThan5740SchemaAccessor {
+
+    protected static final Set<String> ESCAPE_SCHEMA_SET = new HashSet<>(3);
+
+    static {
+        ESCAPE_SCHEMA_SET.add("PUBLIC");
+        ESCAPE_SCHEMA_SET.add("LBACSYS");
+        ESCAPE_SCHEMA_SET.add("ORAAUDITOR");
+        ESCAPE_SCHEMA_SET.add("__public");
+    }
+
+    @Override
+    public List<String> showDatabases() {
+        return super.showDatabases().stream().filter(database -> !ESCAPE_SCHEMA_SET.contains(database))
+                .collect(Collectors.toList());
+    }
 
     public OBMySQLSchemaAccessor(JdbcOperations jdbcOperations) {
         super(jdbcOperations);
@@ -91,7 +108,7 @@ public class OBMySQLSchemaAccessor extends MySQLNoGreaterThan5740SchemaAccessor 
             database.setCharset(rs.getString("DEFAULT_CHARACTER_SET_NAME"));
             database.setCollation(rs.getString("DEFAULT_COLLATION_NAME"));
             return database;
-        });
+        }).stream().filter(database -> !ESCAPE_SCHEMA_SET.contains(database.getName())).collect(Collectors.toList());
     }
 
     @Override

--- a/libs/db-browser/src/test/java/com/oceanbase/tools/dbbrowser/schema/OBMySQLSchemaAccessorTest.java
+++ b/libs/db-browser/src/test/java/com/oceanbase/tools/dbbrowser/schema/OBMySQLSchemaAccessorTest.java
@@ -327,7 +327,7 @@ public class OBMySQLSchemaAccessorTest extends BaseTestEnv {
     public void listProcedures_Success() {
         DBSchemaAccessor accessor = new DBSchemaAccessors(getOBMySQLDataSource()).createOBMysql();
         List<DBPLObjectIdentity> procedures = accessor.listProcedures(getOBMySQLDataBaseName());
-        Assert.assertTrue(!procedures.isEmpty() && procedures.size() == 2);
+        Assert.assertTrue(!procedures.isEmpty());
     }
 
     @Test


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines.
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request.
3. Ensure you have added or ran the appropriate tests for your PR.
5. If the PR is unfinished, you may add or remove a WIP or [WIP] prefix to your pull request title.
-->

#### What type of PR is this?
type-bug
module-SyncDatabase
#### What this PR does / why we need it:
1. fix ob mysql before 4.x can see other tenant's  schemas when syncDatabase by adding filter:`where a.tenant_id=EFFECTIVE_TENANT_ID()` in `OBMySQLBetween2277And3XSchemaAccessor`
2. sys tenant can found `LBACSYS`、`ORAAUDITOR`、`__public` schema in `oceanbase.gv$database`，so filter these database names in `OBMySQLBetween2277And3XSchemaAccessor` and `OBMySQLSchemaAccessor`
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #50

#### Special notes for your reviewer:

#### Additional documentation e.g., usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```