### PR TITLE
fix(osc): fix old running task throw npe when enable full verify  

### DIFF
--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/onlineschemachange/DefaultOnlineSchemaChangeTaskHandler.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/onlineschemachange/DefaultOnlineSchemaChangeTaskHandler.java
@@ -140,7 +140,7 @@ public class DefaultOnlineSchemaChangeTaskHandler implements OnlineSchemaChangeT
 
         terminalErrorCodes = Lists.newArrayList(ErrorCodes.BadArgument, ErrorCodes.BadRequest,
                 ErrorCodes.OmsConnectivityTestFailed, ErrorCodes.Unexpected,
-                ErrorCodes.OmsPreCheckFailed, ErrorCodes.OscDataCheckInconsistent,
+                ErrorCodes.OmsPreCheckFailed, ErrorCodes.OmsDataCheckInconsistent,
                 ErrorCodes.OmsParamError);
 
         expectedTaskStatus = Lists.newArrayList(TaskStatus.DONE, TaskStatus.FAILED,

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/onlineschemachange/DefaultOnlineSchemaChangeTaskHandler.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/onlineschemachange/DefaultOnlineSchemaChangeTaskHandler.java
@@ -320,20 +320,18 @@ public class DefaultOnlineSchemaChangeTaskHandler implements OnlineSchemaChangeT
             }
         } catch (Exception e) {
             log.warn("Failed to complete osc job with scheduleTaskId " + scheduleTaskId, e);
-            handleExceptionResult(scheduleTaskId, valveContext, e);
+            handleExceptionResult(valveContext, e);
         }
     }
 
-    private void handleExceptionResult(Long scheduleTaskId, OscValveContext valveContext, Exception e) {
+    private void handleExceptionResult(OscValveContext valveContext, Exception e) {
         if (e instanceof OdcException) {
             OdcException actual = (OdcException) e;
             ErrorCode errorCode = actual.getErrorCode();
             if (terminalErrorCodes.contains(errorCode)) {
-                log.warn("Failed to complete osc job with scheduleTaskId " + scheduleTaskId, e);
                 failedOscTask(valveContext);
             }
         } else {
-            log.warn("Failed to complete osc job with scheduleTaskId " + scheduleTaskId, e);
             failedOscTask(valveContext);
         }
     }

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/onlineschemachange/oms/client/BaseOmsClient.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/onlineschemachange/oms/client/BaseOmsClient.java
@@ -36,6 +36,7 @@ import com.oceanbase.odc.core.shared.constant.ErrorCodes;
 import com.oceanbase.odc.core.shared.exception.UnexpectedException;
 import com.oceanbase.odc.service.onlineschemachange.exception.OmsException;
 import com.oceanbase.odc.service.onlineschemachange.oms.request.BaseOmsRequest;
+import com.oceanbase.odc.service.onlineschemachange.oms.request.CreateOceanBaseDataSourceRequest;
 import com.oceanbase.odc.service.onlineschemachange.oms.request.OmsApiReturnResult;
 
 import lombok.extern.slf4j.Slf4j;
@@ -114,6 +115,13 @@ public abstract class BaseOmsClient implements OmsClient {
             OmsApiReturnResult<T> result) {
         if (result.isSuccess()) {
             return;
+        }
+        if ("CreateOceanBaseDataSource".equals(requestParams.getAction())
+                && requestParams.getRequest() instanceof CreateOceanBaseDataSourceRequest) {
+            CreateOceanBaseDataSourceRequest request = (CreateOceanBaseDataSourceRequest) requestParams.getRequest();
+            // Clean password in log
+            request.setPassword(null);
+            request.setDrcPassword(null);
         }
         String msg = MessageFormat.format(
                 "Failed response oms result,Action={0}, Request Params={1}, Response={2}",

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/onlineschemachange/oms/client/BaseOmsClient.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/onlineschemachange/oms/client/BaseOmsClient.java
@@ -138,9 +138,9 @@ public abstract class BaseOmsClient implements OmsClient {
                 responseEntity.getStatusCode());
     }
 
-    private  void cleanUpSensitiveMsgInRequest(ClientRequestParams requestParams) {
+    private void cleanUpSensitiveMsgInRequest(ClientRequestParams requestParams) {
         if ("CreateOceanBaseDataSource".equals(requestParams.getAction())
-            && requestParams.getRequest() instanceof CreateOceanBaseDataSourceRequest) {
+                && requestParams.getRequest() instanceof CreateOceanBaseDataSourceRequest) {
             CreateOceanBaseDataSourceRequest request = (CreateOceanBaseDataSourceRequest) requestParams.getRequest();
             CreateOceanBaseDataSourceRequest copiedRequest = new CreateOceanBaseDataSourceRequest();
             BeanUtils.copyProperties(request, copiedRequest);

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/onlineschemachange/pipeline/ProjectStepResultChecker.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/onlineschemachange/pipeline/ProjectStepResultChecker.java
@@ -251,8 +251,10 @@ public class ProjectStepResultChecker {
         if (enableFullVerify) {
             // Set full verifier process percentage
             ProjectStepVO fullVerifyStep = currentProjectStepMap.get(OmsStepName.FULL_VERIFIER);
-            checkerResult.setFullVerificationProgressPercentage(
-                    BigDecimal.valueOf(fullVerifyStep.getProgress()).doubleValue());
+            if (fullVerifyStep != null && fullVerifyStep.getProgress() != null) {
+                checkerResult.setFullVerificationProgressPercentage(
+                        BigDecimal.valueOf(fullVerifyStep.getProgress()).doubleValue());
+            }
         }
 
     }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines.
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request.
3. Ensure you have added or ran the appropriate tests for your PR.
5. If the PR is unfinished, you may add or remove a WIP or [WIP] prefix to your pull request title.
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
type-bug
type-feature
type-docs
etc.

Optionally add one or more of the following kinds if applicable:
module-resultset
module-sql execution
etc.
-->
type-bug
module-online schema change

#### What this PR does / why we need it:
log password and check full verify result cause npe
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
1. fix check full verify result may cause npe when verify result is not arrived
2. fix clean up password in log when request oms create datasource failed
#### Special notes for your reviewer:

#### Additional documentation e.g., usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```