### PR TITLE
enhancement(sql-check): check auto-increment column's datatype and check pk name's existence

### DIFF
--- a/server/odc-core/src/main/resources/i18n/BusinessMessages.properties
+++ b/server/odc-core/src/main/resources/i18n/BusinessMessages.properties
@@ -654,6 +654,10 @@ com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.restrict-drop-objec
 com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.restrict-drop-object-types.allowed-object-types=Database object type
 com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.restrict-drop-object-types.allowed-object-types.description=The types of database objects that are allowed to be deleted
 
+com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.no-primary-key-name-exists.message=Primary key constraint/index are not named
+com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.no-primary-key-name-exists.name=Primary key constraint/index need to set names
+com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.no-primary-key-name-exists.description=Primary key constraint/index need to be explicitly named, otherwise the database will automatically name them
+
 # below masking algorithm built-in
 com.oceanbase.odc.builtin-resource.masking-algorithm.mask-all.name=Mask all (system default)
 com.oceanbase.odc.builtin-resource.masking-algorithm.personal-name-chinese.name=Personal name (Chinese character)

--- a/server/odc-core/src/main/resources/i18n/BusinessMessages.properties
+++ b/server/odc-core/src/main/resources/i18n/BusinessMessages.properties
@@ -546,9 +546,9 @@ com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.restrict-index-nami
 com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.restrict-index-naming.name-pattern=Index name regular expression
 com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.restrict-index-naming.name-pattern.description=Index name regular expression
 
-com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.no-index-name-exists.message=Index definition is not named
-com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.no-index-name-exists.name=Index needs to set name
-com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.no-index-name-exists.description=Index needs to set name
+com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.no-index-name-exists.message=The definition of an index or constraint is not named
+com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.no-index-name-exists.name=Index or constraint needs to set name
+com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.no-index-name-exists.description=An index or constraint requires an explicitly defined name, otherwise the database names it automatically
 
 com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.zerofill-exists.message=Numeric types use the ZEROFILL attribute
 com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.zerofill-exists.name=Numeric types cannot use the ZEROFILL attribute

--- a/server/odc-core/src/main/resources/i18n/BusinessMessages.properties
+++ b/server/odc-core/src/main/resources/i18n/BusinessMessages.properties
@@ -658,6 +658,12 @@ com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.no-primary-key-name
 com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.no-primary-key-name-exists.name=Primary key constraint/index need to set names
 com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.no-primary-key-name-exists.description=Primary key constraint/index need to be explicitly named, otherwise the database will automatically name them
 
+com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.restrict-auto-increment-datatypes.message=Column {0} is marked as auto-increment. The column type is {1}, which is not within the allowed type range: {2}. This may lead to unexpected situations such as numeric overflow
+com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.restrict-auto-increment-datatypes.name=Limit optional data types for auto-increment columns
+com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.restrict-auto-increment-datatypes.description=The data type of columns marked as auto-increment should be carefully selected to avoid unexpected situations such as numerical overflow
+com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.restrict-auto-increment-datatypes.allowed-datatypes=Allowed data types
+com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.restrict-auto-increment-datatypes.allowed-datatypes.description=A collection of data types that allow columns to be marked as auto-increment
+
 # below masking algorithm built-in
 com.oceanbase.odc.builtin-resource.masking-algorithm.mask-all.name=Mask all (system default)
 com.oceanbase.odc.builtin-resource.masking-algorithm.personal-name-chinese.name=Personal name (Chinese character)

--- a/server/odc-core/src/main/resources/i18n/BusinessMessages_zh_CN.properties
+++ b/server/odc-core/src/main/resources/i18n/BusinessMessages_zh_CN.properties
@@ -501,9 +501,9 @@ com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.restrict-index-nami
 com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.restrict-index-naming.description=索引的规范命名有助于提高数据库开发效率，默认：idx_${table-name}_${column-name-1}_${column-name-2}_...
 com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.restrict-index-naming.name-pattern=索引名称正则表达式
 com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.restrict-index-naming.name-pattern.description=索引名称正则表达式
-com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.no-index-name-exists.message=索引定义没有命名
-com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.no-index-name-exists.name=索引需要设置名称
-com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.no-index-name-exists.description=索引需要设置名称
+com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.no-index-name-exists.message=索引或约束的定义没有命名
+com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.no-index-name-exists.name=索引或约束需要设置名称
+com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.no-index-name-exists.description=索引或约束需要显式定义名称，否则数据库会自动命名
 com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.zerofill-exists.message=数值类型使用 ZEROFILL 属性
 com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.zerofill-exists.name=数值类型不能使用 ZEROFILL 属性
 com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.zerofill-exists.description=数值类型不能使用 ZEROFILL 属性

--- a/server/odc-core/src/main/resources/i18n/BusinessMessages_zh_CN.properties
+++ b/server/odc-core/src/main/resources/i18n/BusinessMessages_zh_CN.properties
@@ -592,6 +592,13 @@ com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.restrict-drop-objec
 com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.no-primary-key-name-exists.message=主键约束/索引没有命名
 com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.no-primary-key-name-exists.name=主键约束/索引需要设置名称
 com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.no-primary-key-name-exists.description=主键约束/索引需要显式定义名称，否则数据库会自动命名
+
+com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.restrict-auto-increment-datatypes.message=列 {0} 被标记为 auto-increment，该列的类型为 {1}，不在允许的类型范围内：{2}，这可能会导致数值溢出等非预期情况的发生
+com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.restrict-auto-increment-datatypes.name=限制auto-increment列的可选数据类型
+com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.restrict-auto-increment-datatypes.description=被标记为auto-increment的列应该谨慎选择数据类型，避免数值溢出等预期外情况的发生
+com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.restrict-auto-increment-datatypes.allowed-datatypes=允许的数据类型
+com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.restrict-auto-increment-datatypes.allowed-datatypes.description=允许被标记为auto-increment的列的数据类型集合
+
 # below masking algorithm built-in
 com.oceanbase.odc.builtin-resource.masking-algorithm.mask-all.name=全部遮掩（系统默认）
 com.oceanbase.odc.builtin-resource.masking-algorithm.personal-name-chinese.name=个人姓名（汉字类型）

--- a/server/odc-core/src/main/resources/i18n/BusinessMessages_zh_CN.properties
+++ b/server/odc-core/src/main/resources/i18n/BusinessMessages_zh_CN.properties
@@ -589,6 +589,9 @@ com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.restrict-drop-objec
 com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.restrict-drop-object-types.description=不允许删除允许范围以外的数据库对象
 com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.restrict-drop-object-types.allowed-object-types=数据库对象类型
 com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.restrict-drop-object-types.allowed-object-types.description=允许删除的数据库对象类型
+com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.no-primary-key-name-exists.message=主键约束/索引没有命名
+com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.no-primary-key-name-exists.name=主键约束/索引需要设置名称
+com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.no-primary-key-name-exists.description=主键约束/索引需要显式定义名称，否则数据库会自动命名
 # below masking algorithm built-in
 com.oceanbase.odc.builtin-resource.masking-algorithm.mask-all.name=全部遮掩（系统默认）
 com.oceanbase.odc.builtin-resource.masking-algorithm.personal-name-chinese.name=个人姓名（汉字类型）

--- a/server/odc-core/src/main/resources/i18n/BusinessMessages_zh_TW.properties
+++ b/server/odc-core/src/main/resources/i18n/BusinessMessages_zh_TW.properties
@@ -656,6 +656,10 @@ com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.restrict-drop-objec
 com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.restrict-drop-object-types.allowed-object-types=數據庫對像類型
 com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.restrict-drop-object-types.allowed-object-types.description=允許刪除的數據庫對像類型
 
+com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.no-primary-key-name-exists.message=主鍵約束/索引沒有命名
+com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.no-primary-key-name-exists.name=主鍵約束/索引需要設置名稱
+com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.no-primary-key-name-exists.description=主鍵約束/索引需要顯式定義名稱，否則數據庫會自動命名
+
 # below masking algorithm built-in
 com.oceanbase.odc.builtin-resource.masking-algorithm.mask-all.name=全部遮掩（系統默認）
 com.oceanbase.odc.builtin-resource.masking-algorithm.personal-name-chinese.name=個人姓名（漢字類型）

--- a/server/odc-core/src/main/resources/i18n/BusinessMessages_zh_TW.properties
+++ b/server/odc-core/src/main/resources/i18n/BusinessMessages_zh_TW.properties
@@ -548,9 +548,9 @@ com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.restrict-index-nami
 com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.restrict-index-naming.name-pattern=索引名稱正則表達式
 com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.restrict-index-naming.name-pattern.description=索引名稱正則表達式
 
-com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.no-index-name-exists.message=索引定義沒有命名
-com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.no-index-name-exists.name=索引需要設置名稱
-com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.no-index-name-exists.description=索引需要設置名稱
+com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.no-index-name-exists.message=索引或約束的定義沒有命名
+com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.no-index-name-exists.name=索引或約束需要設置名稱
+com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.no-index-name-exists.description=索引或約束需要顯式定義名稱，否則數據庫會自動命名
 
 com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.zerofill-exists.message=數值類型使用 ZEROFILL 屬性
 com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.zerofill-exists.name=數值類型不能使用 ZEROFILL 屬性

--- a/server/odc-core/src/main/resources/i18n/BusinessMessages_zh_TW.properties
+++ b/server/odc-core/src/main/resources/i18n/BusinessMessages_zh_TW.properties
@@ -660,6 +660,12 @@ com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.no-primary-key-name
 com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.no-primary-key-name-exists.name=主鍵約束/索引需要設置名稱
 com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.no-primary-key-name-exists.description=主鍵約束/索引需要顯式定義名稱，否則數據庫會自動命名
 
+com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.restrict-auto-increment-datatypes.message=列 {0} 被標記為 auto-increment，該列的類型為 {1}，不在允許的類型範圍內：{2}，這可能會導致數值溢出等非預期情況的發生
+com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.restrict-auto-increment-datatypes.name=限制auto-increment列的可選數據類型
+com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.restrict-auto-increment-datatypes.description=被標記為auto-increment的列應該謹慎選擇數據類型，避免數值溢出等預期外情況的發生
+com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.restrict-auto-increment-datatypes.allowed-datatypes=允許的數據類型
+com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.restrict-auto-increment-datatypes.allowed-datatypes.description=允許被標記為auto-increment的列的數據類型集合
+
 # below masking algorithm built-in
 com.oceanbase.odc.builtin-resource.masking-algorithm.mask-all.name=全部遮掩（系統默認）
 com.oceanbase.odc.builtin-resource.masking-algorithm.personal-name-chinese.name=個人姓名（漢字類型）

--- a/server/odc-migrate/src/main/resources/init-config/init/regulation-rule-applying.yaml
+++ b/server/odc-migrate/src/main/resources/init-config/init/regulation-rule-applying.yaml
@@ -475,6 +475,14 @@
 - enabled: 1
   level: 0
   environmentName: ${com.oceanbase.odc.builtin-resource.collaboration.environment.sit.name}
+  ruleName: ${com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.no-primary-key-name-exists.name}
+  appliedDialectTypes:
+      - 'OB_MYSQL'
+      - 'OB_ORACLE'
+  propertiesJson: '{}'
+- enabled: 1
+  level: 0
+  environmentName: ${com.oceanbase.odc.builtin-resource.collaboration.environment.sit.name}
   ruleName: ${com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.zerofill-exists.name}
   appliedDialectTypes:
       - 'OB_MYSQL'
@@ -827,6 +835,14 @@
 - enabled: 1
   level: 0
   environmentName: ${com.oceanbase.odc.builtin-resource.collaboration.environment.dev.name}
+  ruleName: ${com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.no-primary-key-name-exists.name}
+  appliedDialectTypes:
+      - 'OB_MYSQL'
+      - 'OB_ORACLE'
+  propertiesJson: '{}'
+- enabled: 1
+  level: 0
+  environmentName: ${com.oceanbase.odc.builtin-resource.collaboration.environment.dev.name}
   ruleName: ${com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.zerofill-exists.name}
   appliedDialectTypes:
       - 'OB_MYSQL'
@@ -1179,6 +1195,14 @@
 - enabled: 1
   level: 0
   environmentName: ${com.oceanbase.odc.builtin-resource.collaboration.environment.prod.name}
+  ruleName: ${com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.no-primary-key-name-exists.name}
+  appliedDialectTypes:
+      - 'OB_MYSQL'
+      - 'OB_ORACLE'
+  propertiesJson: '{}'
+- enabled: 1
+  level: 0
+  environmentName: ${com.oceanbase.odc.builtin-resource.collaboration.environment.prod.name}
   ruleName: ${com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.zerofill-exists.name}
   appliedDialectTypes:
       - 'OB_MYSQL'
@@ -1516,6 +1540,14 @@
   level: 0
   environmentName: ${com.oceanbase.odc.builtin-resource.collaboration.environment.default.name}
   ruleName: ${com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.no-index-name-exists.name}
+  appliedDialectTypes:
+      - 'OB_MYSQL'
+      - 'OB_ORACLE'
+  propertiesJson: '{}'
+- enabled: 1
+  level: 0
+  environmentName: ${com.oceanbase.odc.builtin-resource.collaboration.environment.default.name}
+  ruleName: ${com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.no-primary-key-name-exists.name}
   appliedDialectTypes:
       - 'OB_MYSQL'
       - 'OB_ORACLE'

--- a/server/odc-migrate/src/main/resources/init-config/init/regulation-rule-applying.yaml
+++ b/server/odc-migrate/src/main/resources/init-config/init/regulation-rule-applying.yaml
@@ -432,7 +432,7 @@
   appliedDialectTypes:
       - 'OB_MYSQL'
       - 'OB_ORACLE'
-  propertiesJson: '{"${com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.restrict-pk-datatypes.allowed-datatypes}":["int", "varchar2", "number", "float", "bigint"]}'
+  propertiesJson: '{"${com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.restrict-pk-datatypes.allowed-datatypes}":["varchar", "varchar2", "number", "float", "bigint"]}'
 - enabled: 1
   level: 0
   environmentName: ${com.oceanbase.odc.builtin-resource.collaboration.environment.sit.name}
@@ -792,7 +792,7 @@
   appliedDialectTypes:
       - 'OB_MYSQL'
       - 'OB_ORACLE'
-  propertiesJson: '{"${com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.restrict-pk-datatypes.allowed-datatypes}":["int", "varchar2", "number", "float", "bigint"]}'
+  propertiesJson: '{"${com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.restrict-pk-datatypes.allowed-datatypes}":["varchar", "varchar2", "number", "float", "bigint"]}'
 - enabled: 1
   level: 0
   environmentName: ${com.oceanbase.odc.builtin-resource.collaboration.environment.dev.name}
@@ -1152,7 +1152,7 @@
   appliedDialectTypes:
       - 'OB_MYSQL'
       - 'OB_ORACLE'
-  propertiesJson: '{"${com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.restrict-pk-datatypes.allowed-datatypes}":["int", "varchar2", "number", "float", "bigint"]}'
+  propertiesJson: '{"${com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.restrict-pk-datatypes.allowed-datatypes}":["varchar", "varchar2", "number", "float", "bigint"]}'
 - enabled: 1
   level: 0
   environmentName: ${com.oceanbase.odc.builtin-resource.collaboration.environment.prod.name}
@@ -1504,7 +1504,7 @@
   appliedDialectTypes:
       - 'OB_MYSQL'
       - 'OB_ORACLE'
-  propertiesJson: '{"${com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.restrict-pk-datatypes.allowed-datatypes}":["int", "varchar2", "number", "float", "bigint"]}'
+  propertiesJson: '{"${com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.restrict-pk-datatypes.allowed-datatypes}":["varchar", "varchar2", "number", "float", "bigint"]}'
 - enabled: 1
   level: 0
   environmentName: ${com.oceanbase.odc.builtin-resource.collaboration.environment.default.name}

--- a/server/odc-migrate/src/main/resources/init-config/init/regulation-rule-applying.yaml
+++ b/server/odc-migrate/src/main/resources/init-config/init/regulation-rule-applying.yaml
@@ -620,7 +620,7 @@
       - 'OB_ORACLE'
   propertiesJson: '{"${com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.restrict-index-datatypes.allowed-datatypes}":["int", "varchar2", "number", "float", "bigint"]}'
 - enabled: 1
-  level: 0
+  level: 1
   environmentName: ${com.oceanbase.odc.builtin-resource.collaboration.environment.sit.name}
   ruleName: ${com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.restrict-auto-increment-datatypes.name}
   appliedDialectTypes:
@@ -987,7 +987,7 @@
       - 'OB_ORACLE'
   propertiesJson: '{"${com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.restrict-index-datatypes.allowed-datatypes}":["int", "varchar2", "number", "float", "bigint"]}'
 - enabled: 1
-  level: 0
+  level: 2
   environmentName: ${com.oceanbase.odc.builtin-resource.collaboration.environment.dev.name}
   ruleName: ${com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.restrict-auto-increment-datatypes.name}
   appliedDialectTypes:
@@ -1354,7 +1354,7 @@
       - 'OB_ORACLE'
   propertiesJson: '{"${com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.restrict-index-datatypes.allowed-datatypes}":["int", "varchar2", "number", "float", "bigint"]}'
 - enabled: 1
-  level: 0
+  level: 2
   environmentName: ${com.oceanbase.odc.builtin-resource.collaboration.environment.prod.name}
   ruleName: ${com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.restrict-auto-increment-datatypes.name}
   appliedDialectTypes:
@@ -1713,7 +1713,7 @@
       - 'OB_ORACLE'
   propertiesJson: '{"${com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.restrict-index-datatypes.allowed-datatypes}":["int", "varchar2", "number", "float", "bigint"]}'
 - enabled: 1
-  level: 0
+  level: 1
   environmentName: ${com.oceanbase.odc.builtin-resource.collaboration.environment.default.name}
   ruleName: ${com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.restrict-auto-increment-datatypes.name}
   appliedDialectTypes:

--- a/server/odc-migrate/src/main/resources/init-config/init/regulation-rule-applying.yaml
+++ b/server/odc-migrate/src/main/resources/init-config/init/regulation-rule-applying.yaml
@@ -622,6 +622,13 @@
 - enabled: 1
   level: 0
   environmentName: ${com.oceanbase.odc.builtin-resource.collaboration.environment.sit.name}
+  ruleName: ${com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.restrict-auto-increment-datatypes.name}
+  appliedDialectTypes:
+      - 'OB_MYSQL'
+  propertiesJson: '{"${com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.restrict-auto-increment-datatypes.allowed-datatypes}":["bigint"]}'
+- enabled: 1
+  level: 0
+  environmentName: ${com.oceanbase.odc.builtin-resource.collaboration.environment.sit.name}
   ruleName: ${com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.restrict-drop-object-types.name}
   appliedDialectTypes:
       - 'OB_MYSQL'
@@ -982,6 +989,13 @@
 - enabled: 1
   level: 0
   environmentName: ${com.oceanbase.odc.builtin-resource.collaboration.environment.dev.name}
+  ruleName: ${com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.restrict-auto-increment-datatypes.name}
+  appliedDialectTypes:
+      - 'OB_MYSQL'
+  propertiesJson: '{"${com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.restrict-auto-increment-datatypes.allowed-datatypes}":["bigint"]}'
+- enabled: 1
+  level: 0
+  environmentName: ${com.oceanbase.odc.builtin-resource.collaboration.environment.dev.name}
   ruleName: ${com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.restrict-drop-object-types.name}
   appliedDialectTypes:
       - 'OB_MYSQL'
@@ -1342,6 +1356,13 @@
 - enabled: 1
   level: 0
   environmentName: ${com.oceanbase.odc.builtin-resource.collaboration.environment.prod.name}
+  ruleName: ${com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.restrict-auto-increment-datatypes.name}
+  appliedDialectTypes:
+      - 'OB_MYSQL'
+  propertiesJson: '{"${com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.restrict-auto-increment-datatypes.allowed-datatypes}":["bigint"]}'
+- enabled: 1
+  level: 0
+  environmentName: ${com.oceanbase.odc.builtin-resource.collaboration.environment.prod.name}
   ruleName: ${com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.restrict-drop-object-types.name}
   appliedDialectTypes:
       - 'OB_MYSQL'
@@ -1691,6 +1712,13 @@
       - 'OB_MYSQL'
       - 'OB_ORACLE'
   propertiesJson: '{"${com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.restrict-index-datatypes.allowed-datatypes}":["int", "varchar2", "number", "float", "bigint"]}'
+- enabled: 1
+  level: 0
+  environmentName: ${com.oceanbase.odc.builtin-resource.collaboration.environment.default.name}
+  ruleName: ${com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.restrict-auto-increment-datatypes.name}
+  appliedDialectTypes:
+      - 'OB_MYSQL'
+  propertiesJson: '{"${com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.restrict-auto-increment-datatypes.allowed-datatypes}":["bigint"]}'
 - enabled: 1
   level: 0
   environmentName: ${com.oceanbase.odc.builtin-resource.collaboration.environment.default.name}

--- a/server/odc-migrate/src/main/resources/init-config/init/regulation-rule-metadata.yaml
+++ b/server/odc-migrate/src/main/resources/init-config/init/regulation-rule-metadata.yaml
@@ -1080,3 +1080,19 @@
             - TYPE BODY
             - TYPE
             - DATABASE
+- id: 54
+  name: ${com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.no-primary-key-name-exists.name}
+  description: ${com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.no-primary-key-name-exists.description}
+  type: SQL_CHECK
+  builtIn: 1
+  labels:
+      - label: SUB_TYPE
+        value: DDL
+      - label: SUB_TYPE
+        value: TABLE
+      - label: SUB_TYPE
+        value: ALTER
+      - label: SUPPORTED_DIALECT_TYPE
+        value: OB_MYSQL
+      - label: SUPPORTED_DIALECT_TYPE
+        value: OB_ORACLE

--- a/server/odc-migrate/src/main/resources/init-config/init/regulation-rule-metadata.yaml
+++ b/server/odc-migrate/src/main/resources/init-config/init/regulation-rule-metadata.yaml
@@ -1096,3 +1096,24 @@
         value: OB_MYSQL
       - label: SUPPORTED_DIALECT_TYPE
         value: OB_ORACLE
+- id: 55
+  name: ${com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.restrict-auto-increment-datatypes.name}
+  description: ${com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.restrict-auto-increment-datatypes.description}
+  type: SQL_CHECK
+  builtIn: 1
+  labels:
+      - label: SUB_TYPE
+        value: DDL
+      - label: SUB_TYPE
+        value: TABLE
+      - label: SUB_TYPE
+        value: ALTER
+      - label: SUPPORTED_DIALECT_TYPE
+        value: OB_MYSQL
+  propertyMetadatas:
+      - name: ${com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.restrict-auto-increment-datatypes.allowed-datatypes}
+        description: ${com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.restrict-auto-increment-datatypes.allowed-datatypes.description}
+        type: STRING_LIST
+        componentType: SELECT_TAGS
+        defaultValues:
+            - bigint

--- a/server/odc-migrate/src/main/resources/init-config/init/regulation-rule-metadata.yaml
+++ b/server/odc-migrate/src/main/resources/init-config/init/regulation-rule-metadata.yaml
@@ -519,7 +519,7 @@
         type: STRING_LIST
         componentType: SELECT_TAGS
         defaultValues:
-            - int
+            - varchar
             - varchar2
             - number
             - float

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/regulation/ruleset/RuleService.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/regulation/ruleset/RuleService.java
@@ -160,8 +160,6 @@ public class RuleService {
         return rule;
     }
 
-
-
     private List<Rule> internalList(@NonNull Long rulesetId, @NonNull QueryRuleMetadataParams params) {
         List<RuleMetadata> ruleMetadatas = metadataService.list(params);
         if (CollectionUtils.isEmpty(ruleMetadatas)) {

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/sqlcheck/factory/NoPrimaryKeyNameExistsFactory.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/sqlcheck/factory/NoPrimaryKeyNameExistsFactory.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2023 OceanBase.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.oceanbase.odc.service.sqlcheck.factory;
+
+import java.util.Map;
+
+import com.oceanbase.odc.core.shared.constant.DialectType;
+import com.oceanbase.odc.service.sqlcheck.SqlCheckRule;
+import com.oceanbase.odc.service.sqlcheck.SqlCheckRuleFactory;
+import com.oceanbase.odc.service.sqlcheck.model.SqlCheckRuleType;
+import com.oceanbase.odc.service.sqlcheck.rule.NoPrimaryKeyNameExists;
+
+import lombok.NonNull;
+
+public class NoPrimaryKeyNameExistsFactory implements SqlCheckRuleFactory {
+
+    @Override
+    public SqlCheckRuleType getSupportsType() {
+        return SqlCheckRuleType.NO_PRIMARY_KEY_NAME_EXISTS;
+    }
+
+    @Override
+    public SqlCheckRule generate(@NonNull DialectType dialectType, Map<String, Object> parameters) {
+        return new NoPrimaryKeyNameExists();
+    }
+
+}

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/sqlcheck/factory/RestrictAutoIncrementDataTypesFactory.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/sqlcheck/factory/RestrictAutoIncrementDataTypesFactory.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2023 OceanBase.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.oceanbase.odc.service.sqlcheck.factory;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import com.oceanbase.odc.core.shared.constant.DialectType;
+import com.oceanbase.odc.service.sqlcheck.SqlCheckRule;
+import com.oceanbase.odc.service.sqlcheck.SqlCheckRuleFactory;
+import com.oceanbase.odc.service.sqlcheck.model.SqlCheckRuleType;
+import com.oceanbase.odc.service.sqlcheck.rule.MySQLRestrictAutoIncrementDataTypes;
+
+import lombok.NonNull;
+
+public class RestrictAutoIncrementDataTypesFactory implements SqlCheckRuleFactory {
+
+    @Override
+    public SqlCheckRuleType getSupportsType() {
+        return SqlCheckRuleType.RESTRICT_AUTO_INCREMENT_DATATYPES;
+    }
+
+    @Override
+    @SuppressWarnings("all")
+    public SqlCheckRule generate(@NonNull DialectType dialectType, Map<String, Object> parameters) {
+        String key = getParameterNameKey("allowed-datatypes");
+        Set<String> types;
+        if (parameters == null || parameters.isEmpty() || parameters.get(key) == null) {
+            types = new HashSet<>(Collections.singletonList("bigint"));
+        } else {
+            types = new HashSet<>((List<String>) parameters.get(key));
+        }
+        return dialectType.isMysql() ? new MySQLRestrictAutoIncrementDataTypes(types) : null;
+    }
+
+}

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/sqlcheck/model/SqlCheckRuleType.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/sqlcheck/model/SqlCheckRuleType.java
@@ -227,7 +227,11 @@ public enum SqlCheckRuleType implements Translatable {
     /**
      * 没有主键约束的命名
      */
-    NO_PRIMARY_KEY_NAME_EXISTS("no-primary-key-name-exists");
+    NO_PRIMARY_KEY_NAME_EXISTS("no-primary-key-name-exists"),
+    /**
+     * 限制被声明为 auto-increment 的列的类型
+     */
+    RESTRICT_AUTO_INCREMENT_DATATYPES("restrict-auto-increment-datatypes");
 
     private final String name;
     private static final String NAME_CODE = "name";

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/sqlcheck/model/SqlCheckRuleType.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/sqlcheck/model/SqlCheckRuleType.java
@@ -223,7 +223,11 @@ public enum SqlCheckRuleType implements Translatable {
     /**
      * 不允许执行删除的数据库对象类型
      */
-    RESTRICT_DROP_OBJECT_TYPES("restrict-drop-object-types");
+    RESTRICT_DROP_OBJECT_TYPES("restrict-drop-object-types"),
+    /**
+     * 没有主键约束的命名
+     */
+    NO_PRIMARY_KEY_NAME_EXISTS("no-primary-key-name-exists");
 
     private final String name;
     private static final String NAME_CODE = "name";

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/sqlcheck/rule/MySQLRestrictAutoIncrementDataTypes.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/sqlcheck/rule/MySQLRestrictAutoIncrementDataTypes.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2023 OceanBase.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.oceanbase.odc.service.sqlcheck.rule;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.apache.commons.collections4.CollectionUtils;
+
+import com.oceanbase.odc.common.util.StringUtils;
+import com.oceanbase.odc.core.shared.constant.DialectType;
+import com.oceanbase.odc.service.sqlcheck.SqlCheckContext;
+import com.oceanbase.odc.service.sqlcheck.SqlCheckRule;
+import com.oceanbase.odc.service.sqlcheck.SqlCheckUtil;
+import com.oceanbase.odc.service.sqlcheck.model.CheckViolation;
+import com.oceanbase.odc.service.sqlcheck.model.SqlCheckRuleType;
+import com.oceanbase.tools.sqlparser.statement.Statement;
+import com.oceanbase.tools.sqlparser.statement.alter.table.AlterTable;
+import com.oceanbase.tools.sqlparser.statement.common.DataType;
+import com.oceanbase.tools.sqlparser.statement.createtable.ColumnAttributes;
+import com.oceanbase.tools.sqlparser.statement.createtable.ColumnDefinition;
+import com.oceanbase.tools.sqlparser.statement.createtable.CreateTable;
+
+import lombok.NonNull;
+
+/**
+ * {@link MySQLRestrictAutoIncrementDataTypes}
+ *
+ * @author yh263208
+ * @date 2023-09-11 14:28
+ * @since ODC_release_4.2.2
+ */
+public class MySQLRestrictAutoIncrementDataTypes implements SqlCheckRule {
+
+    private final Set<String> allowedTypeNames;
+
+    public MySQLRestrictAutoIncrementDataTypes(@NonNull Set<String> allowedTypeNames) {
+        this.allowedTypeNames = allowedTypeNames;
+    }
+
+    @Override
+    public SqlCheckRuleType getType() {
+        return SqlCheckRuleType.RESTRICT_AUTO_INCREMENT_DATATYPES;
+    }
+
+    @Override
+    public List<CheckViolation> check(@NonNull Statement statement, @NonNull SqlCheckContext context) {
+        if (statement instanceof CreateTable) {
+            return builds(statement.getText(), ((CreateTable) statement).getColumnDefinitions().stream());
+        } else if (statement instanceof AlterTable) {
+            return builds(statement.getText(), SqlCheckUtil.fromAlterTable((AlterTable) statement));
+        }
+        return Collections.emptyList();
+    }
+
+    @Override
+    public List<DialectType> getSupportsDialectTypes() {
+        return Arrays.asList(DialectType.MYSQL, DialectType.OB_MYSQL, DialectType.ODP_SHARDING_OB_MYSQL);
+    }
+
+    private List<CheckViolation> builds(String sql, Stream<ColumnDefinition> stream) {
+        return stream.filter(d -> {
+            ColumnAttributes ca = d.getColumnAttributes();
+            if (ca == null) {
+                return false;
+            }
+            return Boolean.TRUE.equals(ca.getAutoIncrement());
+        }).filter(d -> this.allowedTypeNames.stream()
+                .noneMatch(s -> StringUtils.equalsIgnoreCase(s, d.getDataType().getName())))
+                .map(d -> {
+                    DataType type = d.getDataType();
+                    String types = "N/A";
+                    if (CollectionUtils.isNotEmpty(this.allowedTypeNames)) {
+                        types = String.join(",", this.allowedTypeNames);
+                    }
+                    return SqlCheckUtil.buildViolation(sql, type, getType(),
+                            new Object[] {d.getColumnReference().getText(), type.getText(), types});
+                }).collect(Collectors.toList());
+    }
+
+}

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/sqlcheck/rule/NoIndexNameExists.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/sqlcheck/rule/NoIndexNameExists.java
@@ -64,7 +64,7 @@ public class NoIndexNameExists implements SqlCheckRule {
                 if (c.getConstraintName() != null || c.getIndexName() != null) {
                     return false;
                 }
-                return c.isPrimaryKey() || c.isUniqueKey();
+                return !c.isPrimaryKey();
             }).collect(Collectors.toList()));
             return statements.stream().map(s -> SqlCheckUtil.buildViolation(
                     statement.getText(), s, getType(), new Object[] {})).collect(Collectors.toList());
@@ -76,7 +76,7 @@ public class NoIndexNameExists implements SqlCheckRule {
                 if (c == null || c.getConstraintName() != null || c.getIndexName() != null) {
                     return false;
                 }
-                return c.isPrimaryKey() || c.isUniqueKey();
+                return !c.isPrimaryKey();
             }).collect(Collectors.toList()));
             statements.addAll(alterTable.getAlterTableActions().stream().filter(alterTableAction -> {
                 OutOfLineIndex i = alterTableAction.getAddIndex();
@@ -101,14 +101,12 @@ public class NoIndexNameExists implements SqlCheckRule {
                 return false;
             }
             return CollectionUtils.isNotEmpty(ca.getConstraints());
-        })
-                .flatMap(d -> d.getColumnAttributes().getConstraints().stream())
-                .filter(c -> {
-                    if (c.getConstraintName() != null) {
-                        return false;
-                    }
-                    return c.isUniqueKey() || c.isPrimaryKey();
-                }).collect(Collectors.toList());
+        }).flatMap(d -> d.getColumnAttributes().getConstraints().stream()).filter(c -> {
+            if (c.getConstraintName() != null) {
+                return false;
+            }
+            return !c.isPrimaryKey();
+        }).collect(Collectors.toList());
     }
 
 }

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/sqlcheck/rule/SqlCheckRules.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/sqlcheck/rule/SqlCheckRules.java
@@ -44,6 +44,7 @@ import com.oceanbase.odc.service.sqlcheck.factory.NoDefaultValueExistsFactory;
 import com.oceanbase.odc.service.sqlcheck.factory.NoIndexNameExistsFactory;
 import com.oceanbase.odc.service.sqlcheck.factory.NoNotNullAtInExpressionFactory;
 import com.oceanbase.odc.service.sqlcheck.factory.NoPrimaryKeyExistsFactory;
+import com.oceanbase.odc.service.sqlcheck.factory.NoPrimaryKeyNameExistsFactory;
 import com.oceanbase.odc.service.sqlcheck.factory.NoSpecificColumnExistsFactory;
 import com.oceanbase.odc.service.sqlcheck.factory.NoTableCommentExistsFactory;
 import com.oceanbase.odc.service.sqlcheck.factory.NoValidWhereClauseFactory;
@@ -135,6 +136,7 @@ public class SqlCheckRules {
         rules.add(new ProhibitedDatatypeExistsFactory());
         rules.add(new RestrictIndexDataTypesFactory(jdbc));
         rules.add(new RestrictDropObjectTypesFactory());
+        rules.add(new NoPrimaryKeyNameExistsFactory());
         return rules;
     }
 

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/sqlcheck/rule/SqlCheckRules.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/sqlcheck/rule/SqlCheckRules.java
@@ -52,6 +52,7 @@ import com.oceanbase.odc.service.sqlcheck.factory.NoWhereClauseExistsFactory;
 import com.oceanbase.odc.service.sqlcheck.factory.NotNullColumnWithoutDefaultValueFactory;
 import com.oceanbase.odc.service.sqlcheck.factory.PreferLocalOutOfLineIndexFactory;
 import com.oceanbase.odc.service.sqlcheck.factory.ProhibitedDatatypeExistsFactory;
+import com.oceanbase.odc.service.sqlcheck.factory.RestrictAutoIncrementDataTypesFactory;
 import com.oceanbase.odc.service.sqlcheck.factory.RestrictAutoIncrementUnsignedFactory;
 import com.oceanbase.odc.service.sqlcheck.factory.RestrictColumnNameCaseFactory;
 import com.oceanbase.odc.service.sqlcheck.factory.RestrictColumnNotNullFactory;
@@ -137,6 +138,7 @@ public class SqlCheckRules {
         rules.add(new RestrictIndexDataTypesFactory(jdbc));
         rules.add(new RestrictDropObjectTypesFactory());
         rules.add(new NoPrimaryKeyNameExistsFactory());
+        rules.add(new RestrictAutoIncrementDataTypesFactory());
         return rules;
     }
 

--- a/server/odc-service/src/test/java/com/oceanbase/odc/service/sqlcheck/MySQLCheckerTest.java
+++ b/server/odc-service/src/test/java/com/oceanbase/odc/service/sqlcheck/MySQLCheckerTest.java
@@ -51,6 +51,7 @@ import com.oceanbase.odc.service.sqlcheck.rule.MySQLZeroFillExists;
 import com.oceanbase.odc.service.sqlcheck.rule.NoDefaultValueExists;
 import com.oceanbase.odc.service.sqlcheck.rule.NoIndexNameExists;
 import com.oceanbase.odc.service.sqlcheck.rule.NoPrimaryKeyExists;
+import com.oceanbase.odc.service.sqlcheck.rule.NoPrimaryKeyNameExists;
 import com.oceanbase.odc.service.sqlcheck.rule.NoSpecificColumnExists;
 import com.oceanbase.odc.service.sqlcheck.rule.NoValidWhereClause;
 import com.oceanbase.odc.service.sqlcheck.rule.NoWhereClauseExists;
@@ -764,14 +765,34 @@ public class MySQLCheckerTest {
 
         SqlCheckRuleType type = SqlCheckRuleType.NO_INDEX_NAME_EXISTS;
         CheckViolation c1 = new CheckViolation(sqls[0], 1, 34, 34, 43, type, new Object[] {});
-        CheckViolation c2 = new CheckViolation(sqls[1], 1, 77, 77, 103, type, new Object[] {});
         CheckViolation c3 = new CheckViolation(sqls[2], 1, 62, 62, 87, type, new Object[] {});
         CheckViolation c4 = new CheckViolation(sqls[3], 1, 68, 68, 86, type, new Object[] {});
         CheckViolation c5 = new CheckViolation(sqls[3], 1, 27, 27, 40, type, new Object[] {});
-        CheckViolation c6 = new CheckViolation(sqls[4], 1, 58, 58, 77, type, new Object[] {});
         CheckViolation c7 = new CheckViolation(sqls[4], 1, 27, 27, 41, type, new Object[] {});
 
-        List<CheckViolation> expect = Arrays.asList(c1, c2, c3, c4, c5, c6, c7);
+        List<CheckViolation> expect = Arrays.asList(c1, c3, c4, c5, c7);
+        Assert.assertEquals(expect, actual);
+    }
+
+    @Test
+    public void check_noprimaryKeyNameExists_violationGenerated() {
+        String[] sqls = new String[] {
+                "CREATE TABLE aaaa (ID VARCHAR(64), index idx_name (ID), constraint check(1), constraint primary key (id))",
+                "CREATE TABLE bbbb (ID VARCHAR(64) primary key, fulltext index `AAA` (ID), constraint unique key (id))",
+                "CREATE TABLE cccc (ID VARCHAR(64), constraint abcdet primary key (id))",
+                "alter table test_unique_tb add index(name), add check(1), add primary key(id5)",
+                "alter table test_unique_tb add fulltext index `uuiyt`(name), add constraint uuuu primary key(id6)"
+        };
+        DefaultSqlChecker sqlChecker = new DefaultSqlChecker(DialectType.OB_MYSQL, "$$",
+                Collections.singletonList(new NoPrimaryKeyNameExists()));
+        List<CheckViolation> actual = sqlChecker.check(joinAndAppend(sqls, "$$"));
+
+        SqlCheckRuleType type = SqlCheckRuleType.NO_PRIMARY_KEY_NAME_EXISTS;
+        CheckViolation c1 = new CheckViolation(sqls[0], 1, 77, 77, 103, type, new Object[] {});
+        CheckViolation c3 = new CheckViolation(sqls[1], 1, 34, 34, 44, type, new Object[] {});
+        CheckViolation c4 = new CheckViolation(sqls[3], 1, 58, 58, 77, type, new Object[] {});
+
+        List<CheckViolation> expect = Arrays.asList(c1, c3, c4);
         Assert.assertEquals(expect, actual);
     }
 

--- a/server/odc-service/src/test/java/com/oceanbase/odc/service/sqlcheck/OracleSqlCheckerTest.java
+++ b/server/odc-service/src/test/java/com/oceanbase/odc/service/sqlcheck/OracleSqlCheckerTest.java
@@ -37,6 +37,7 @@ import com.oceanbase.odc.service.sqlcheck.rule.ForeignConstraintExists;
 import com.oceanbase.odc.service.sqlcheck.rule.NoDefaultValueExists;
 import com.oceanbase.odc.service.sqlcheck.rule.NoIndexNameExists;
 import com.oceanbase.odc.service.sqlcheck.rule.NoPrimaryKeyExists;
+import com.oceanbase.odc.service.sqlcheck.rule.NoPrimaryKeyNameExists;
 import com.oceanbase.odc.service.sqlcheck.rule.NoSpecificColumnExists;
 import com.oceanbase.odc.service.sqlcheck.rule.NoValidWhereClause;
 import com.oceanbase.odc.service.sqlcheck.rule.NoWhereClauseExists;
@@ -739,13 +740,30 @@ public class OracleSqlCheckerTest {
         SqlCheckRuleType type = SqlCheckRuleType.NO_INDEX_NAME_EXISTS;
         CheckViolation c1 = new CheckViolation(sqls[0], 1, 35, 35, 56, type, new Object[] {});
         CheckViolation c2 = new CheckViolation(sqls[1], 1, 37, 37, 42, type, new Object[] {});
-        CheckViolation c3 = new CheckViolation(sqls[1], 1, 53, 53, 63, type, new Object[] {});
-        CheckViolation c4 = new CheckViolation(sqls[3], 1, 36, 36, 50, type, new Object[] {});
         CheckViolation c5 = new CheckViolation(sqls[4], 1, 37, 37, 47, type, new Object[] {});
         CheckViolation c6 = new CheckViolation(sqls[5], 1, 27, 27, 42, type, new Object[] {});
-        CheckViolation c7 = new CheckViolation(sqls[6], 1, 41, 41, 60, type, new Object[] {});
 
-        List<CheckViolation> expect = Arrays.asList(c1, c2, c3, c4, c5, c6, c7);
+        List<CheckViolation> expect = Arrays.asList(c1, c2, c5, c6);
+        Assert.assertEquals(expect, actual);
+    }
+
+    @Test
+    public void check_noPrimaryKeyName_violationGenerated() {
+        String[] sqls = new String[] {
+                "create table abcdder(id varchar2(64) unique, id blob primary key, content varchar(64) constraint ancd unique)",
+                "CREATE TABLE bbbb (ID VARCHAR2(64), primary key(id), constraint aaaaa primary key (dd))",
+                "alter table test_unique_tb add check(1), add primary key(id5), add constraint aaa primary key(id6)",
+        };
+        DefaultSqlChecker sqlChecker = new DefaultSqlChecker(DialectType.OB_ORACLE, "$$",
+                Collections.singletonList(new NoPrimaryKeyNameExists()));
+        List<CheckViolation> actual = sqlChecker.check(joinAndAppend(sqls, "$$"));
+
+        SqlCheckRuleType type = SqlCheckRuleType.NO_PRIMARY_KEY_NAME_EXISTS;
+        CheckViolation c1 = new CheckViolation(sqls[0], 1, 53, 53, 63, type, new Object[] {});
+        CheckViolation c2 = new CheckViolation(sqls[1], 1, 36, 36, 50, type, new Object[] {});
+        CheckViolation c5 = new CheckViolation(sqls[2], 1, 41, 41, 60, type, new Object[] {});
+
+        List<CheckViolation> expect = Arrays.asList(c1, c2, c5);
         Assert.assertEquals(expect, actual);
     }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines.
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request.
3. Ensure you have added or ran the appropriate tests for your PR.
5. If the PR is unfinished, you may add or remove a WIP or [WIP] prefix to your pull request title.
-->

#### What type of PR is this?
type-enhancement
<!--
Add one of the following kinds:
type-bug
type-feature
type-docs
etc.

Optionally add one or more of the following kinds if applicable:
module-resultset
module-sql execution
etc.
-->

#### What this PR does / why we need it:

this pr gives two enhancements.

Index name exists check rule will be work at primary key. you may hit this rule with such a sql executing:
```SQL
create table abcd(
    id int primary key
)
```
This is a very common way of writing, it is not very reasonable to be detected, so that I separate index naming detection from primary key naming detection.

There is a difference in auto-increment between OceanBase and MySQL. 

In MySQL, columns declared as auto-increment will grow in steps of 1, but in OceanBase there may be value jumps, which may increase by 1000000 all of a sudden. if you use `int` as the column of auto-increment, it may cause overflow. In order to solve this problem, ODC added a rule to constrain the data type of auto-increment columns.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #102 #255 

#### Special notes for your reviewer:

#### Additional documentation e.g., usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```