### PR TITLE
fix(clientMode): odc fail to start on clientMode

### DIFF
--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/collaboration/DefaultOrganizationResourceMigrator.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/collaboration/DefaultOrganizationResourceMigrator.java
@@ -22,6 +22,7 @@ import java.util.Optional;
 import javax.sql.DataSource;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.support.TransactionTemplate;
 
@@ -43,6 +44,7 @@ import lombok.extern.slf4j.Slf4j;
  * @Date: 2023/5/30 10:53
  * @Description: []
  */
+@Profile("alipay")
 @ConditionalOnProperty(value = {"odc.iam.auth.type"}, havingValues = {"local", "alipay"})
 @Service("organizationResourceMigrator")
 @Slf4j

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/collaboration/DefaultOrganizationResourceMigrator.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/collaboration/DefaultOrganizationResourceMigrator.java
@@ -22,7 +22,6 @@ import java.util.Optional;
 import javax.sql.DataSource;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.support.TransactionTemplate;
 
@@ -44,7 +43,6 @@ import lombok.extern.slf4j.Slf4j;
  * @Date: 2023/5/30 10:53
  * @Description: []
  */
-@Profile("alipay")
 @ConditionalOnProperty(value = {"odc.iam.auth.type"}, havingValues = {"local", "alipay"})
 @Service("organizationResourceMigrator")
 @Slf4j

--- a/server/starters/desktop-starter/src/main/java/com/oceanbase/odc/service/collaboration/DesktopOrganizationResourceMigrator.java
+++ b/server/starters/desktop-starter/src/main/java/com/oceanbase/odc/service/collaboration/DesktopOrganizationResourceMigrator.java
@@ -19,5 +19,5 @@ package com.oceanbase.odc.service.collaboration;
 import org.springframework.context.annotation.Profile;
 
 @Profile("clientMode")
-public class DesktopOrganizationResourceMigrator extends DefaultOrganizationResourceMigrator{
+public class DesktopOrganizationResourceMigrator extends DefaultOrganizationResourceMigrator {
 }

--- a/server/starters/desktop-starter/src/main/java/com/oceanbase/odc/service/collaboration/DesktopOrganizationResourceMigrator.java
+++ b/server/starters/desktop-starter/src/main/java/com/oceanbase/odc/service/collaboration/DesktopOrganizationResourceMigrator.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2023 OceanBase.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.oceanbase.odc.service.collaboration;
+
+import org.springframework.context.annotation.Profile;
+
+@Profile("clientMode")
+public class DesktopOrganizationResourceMigrator extends DefaultOrganizationResourceMigrator{
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines.
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request.
3. Ensure you have added or ran the appropriate tests for your PR.
5. If the PR is unfinished, you may add or remove a WIP or [WIP] prefix to your pull request title.
-->

#### What type of PR is this?
type-bug

<!--
Add one of the following kinds:
type-bug
type-feature
type-docs
etc.

Optionally add one or more of the following kinds if applicable:
module-resultset
module-sql execution
etc.
-->

#### What this PR does / why we need it:
ODC failed to start on clientMode for ` No qualifying bean of type 'com.oceanbase.odc.service.collaboration.OrganizationResourceMigrator' available:`
After remove the `@Profile` annotation, ODC can start normally.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/oceanbase/odc/issues/343

#### Special notes for your reviewer:

#### Additional documentation e.g., usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```