### PR TITLE
fix(clientMode): fail to start for lack of Service annotations

### DIFF
--- a/server/starters/desktop-starter/src/main/java/com/oceanbase/odc/service/collaboration/DesktopOrganizationResourceMigrator.java
+++ b/server/starters/desktop-starter/src/main/java/com/oceanbase/odc/service/collaboration/DesktopOrganizationResourceMigrator.java
@@ -17,7 +17,12 @@
 package com.oceanbase.odc.service.collaboration;
 
 import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Service;
+
+import com.oceanbase.odc.core.authority.util.SkipAuthorize;
 
 @Profile("clientMode")
+@Service("organizationResourceMigrator")
+@SkipAuthorize
 public class DesktopOrganizationResourceMigrator extends DefaultOrganizationResourceMigrator {
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines.
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request.
3. Ensure you have added or ran the appropriate tests for your PR.
5. If the PR is unfinished, you may add or remove a WIP or [WIP] prefix to your pull request title.
-->

#### What type of PR is this?
type-bug 
<!--
Add one of the following kinds:
type-bug
type-feature
type-docs
etc.

Optionally add one or more of the following kinds if applicable:
module-resultset
module-sql execution
etc.
-->

#### What this PR does / why we need it:

In PR #345  , we added a service named DesktopOrganizationResourceMigrator. But it missed `@Service` annotation, leading to start failure for desktop.
Now it would be completed.

#### Special notes for your reviewer:

#### Additional documentation e.g., usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```