### PR TITLE
fix(mvc): api response content type converts to  xml

### DIFF
--- a/server/odc-server/src/main/java/com/oceanbase/odc/server/config/MvcConfiguration.java
+++ b/server/odc-server/src/main/java/com/oceanbase/odc/server/config/MvcConfiguration.java
@@ -30,6 +30,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.core.Ordered;
 import org.springframework.format.FormatterRegistry;
 import org.springframework.format.datetime.standard.DateTimeFormatterRegistrar;
+import org.springframework.http.MediaType;
 import org.springframework.http.converter.HttpMessageConverter;
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 import org.springframework.web.context.request.RequestContextListener;
@@ -95,7 +96,7 @@ public class MvcConfiguration implements WebMvcConfigurer {
 
     @Override
     public void configureContentNegotiation(ContentNegotiationConfigurer config) {
-        config.favorPathExtension(false);
+        config.defaultContentType(MediaType.APPLICATION_JSON, MediaType.ALL);
     }
 
     /**


### PR DESCRIPTION
#### What type of PR is this?
type-bug

#### What this PR does / why we need it:
After the #338 commit was merged, I find the api response is converted into XML format, causing the ODC server cannot be used by front-end.
In this PR, I fix this issue by set `application/json` as the default content type by implements the `WebMvcConfigurer`:
```java
    @Override
    public void configureContentNegotiation(ContentNegotiationConfigurer config) {
        config.defaultContentType(MediaType.APPLICATION_JSON, MediaType.ALL);
    }
```