### PR TITLE
fix(datasource): optimize datasource synchronization

### DIFF
--- a/libs/db-browser/src/main/java/com/oceanbase/tools/dbbrowser/schema/mysql/OBMySQLBetween2277And3XSchemaAccessor.java
+++ b/libs/db-browser/src/main/java/com/oceanbase/tools/dbbrowser/schema/mysql/OBMySQLBetween2277And3XSchemaAccessor.java
@@ -18,7 +18,6 @@ package com.oceanbase.tools.dbbrowser.schema.mysql;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import org.springframework.jdbc.core.JdbcOperations;
 import org.springframework.lang.NonNull;
@@ -81,20 +80,6 @@ public class OBMySQLBetween2277And3XSchemaAccessor extends OBMySQLSchemaAccessor
             database.setCollation(rs.getString("DEFAULT_COLLATION_NAME"));
         });
         return database;
-    }
-
-    @Override
-    public List<DBDatabase> listDatabases() {
-        String sql = "select a.database_id, a.database_name, b.DEFAULT_CHARACTER_SET_NAME, b.DEFAULT_COLLATION_NAME "
-                + "from oceanbase.gv$database a inner join information_schema.schemata b on a.database_name=b.SCHEMA_NAME where a.tenant_id=EFFECTIVE_TENANT_ID()";
-        return jdbcOperations.query(sql, (rs, num) -> {
-            DBDatabase database = new DBDatabase();
-            database.setId(rs.getString("database_id"));
-            database.setName(rs.getString("database_name"));
-            database.setCharset(rs.getString("DEFAULT_CHARACTER_SET_NAME"));
-            database.setCollation(rs.getString("DEFAULT_COLLATION_NAME"));
-            return database;
-        }).stream().filter(database -> !ESCAPE_SCHEMA_SET.contains(database.getName())).collect(Collectors.toList());
     }
 
     @Override

--- a/libs/db-browser/src/main/java/com/oceanbase/tools/dbbrowser/schema/mysql/OBMySQLSchemaAccessor.java
+++ b/libs/db-browser/src/main/java/com/oceanbase/tools/dbbrowser/schema/mysql/OBMySQLSchemaAccessor.java
@@ -42,7 +42,6 @@ import com.oceanbase.tools.dbbrowser.util.StringUtils;
 import lombok.extern.slf4j.Slf4j;
 
 /**
- *
  * 适用 OB 版本：[4.0.0, ~)
  *
  * @author jingtian
@@ -96,15 +95,12 @@ public class OBMySQLSchemaAccessor extends MySQLNoGreaterThan5740SchemaAccessor 
 
     @Override
     public List<DBDatabase> listDatabases() {
-        String sql = "select a.object_name, a.timestamp, b.DEFAULT_CHARACTER_SET_NAME, b.DEFAULT_COLLATION_NAME "
-                + "from oceanbase.DBA_OBJECTS a inner join information_schema.schemata b on a.object_name=b.SCHEMA_NAME and a"
-                + ".object_type='DATABASE';";
+        String sql =
+                "SELECT SCHEMA_NAME, DEFAULT_CHARACTER_SET_NAME, DEFAULT_COLLATION_NAME FROM information_schema.schemata;";
         return jdbcOperations.query(sql, (rs, num) -> {
             DBDatabase database = new DBDatabase();
-            String objectName = rs.getString("object_name");
-            String timestamp = rs.getString("timestamp");
-            database.setName(objectName);
-            database.setId(objectName + "_" + timestamp);
+            database.setId(rs.getString("SCHEMA_NAME"));
+            database.setName(rs.getString("SCHEMA_NAME"));
             database.setCharset(rs.getString("DEFAULT_CHARACTER_SET_NAME"));
             database.setCollation(rs.getString("DEFAULT_COLLATION_NAME"));
             return database;
@@ -269,6 +265,5 @@ public class OBMySQLSchemaAccessor extends MySQLNoGreaterThan5740SchemaAccessor 
         return sequenceNames.stream().map(name -> DBObjectIdentity.of(schemaName, DBObjectType.SEQUENCE, name)).collect(
                 Collectors.toList());
     }
-
 
 }

--- a/libs/db-browser/src/main/java/com/oceanbase/tools/dbbrowser/schema/oracle/OBOracleSchemaAccessor.java
+++ b/libs/db-browser/src/main/java/com/oceanbase/tools/dbbrowser/schema/oracle/OBOracleSchemaAccessor.java
@@ -111,11 +111,12 @@ public class OBOracleSchemaAccessor extends OracleSchemaAccessor {
     @Override
     public List<DBDatabase> listDatabases() {
         List<DBDatabase> databases = new ArrayList<>();
-        String sql = "SELECT USERNAME, USERID from ALL_USERS;";
+        String sql = "SELECT USERNAME from ALL_USERS;";
         jdbcOperations.query(sql, rs -> {
             DBDatabase database = new DBDatabase();
-            database.setId(rs.getString("USERID"));
-            database.setName(rs.getString("USERNAME"));
+            String userName = rs.getString("USERNAME");
+            database.setId(userName);
+            database.setName(userName);
             databases.add(database);
         });
         sql = "select value from v$nls_parameters where PARAMETER = 'NLS_CHARACTERSET'";

--- a/server/odc-migrate/src/main/resources/migrate/common/V_4_2_1_6__alter_connect_database.sql
+++ b/server/odc-migrate/src/main/resources/migrate/common/V_4_2_1_6__alter_connect_database.sql
@@ -1,0 +1,4 @@
+alter table `connect_database` modify `charset_name` varchar(128) default null comment 'database charset name';
+alter table `connect_database` modify `collation_name` varchar(128) default null comment 'database collation name';
+alter table `connect_database` modify `table_count` bigint(20) default null comment 'table count which belongs to the database';
+alter table `connect_database` modify `last_sync_time` datetime not null default CURRENT_TIMESTAMP comment 'table count which belongs to the database';

--- a/server/odc-migrate/src/main/resources/migrate/common/V_4_2_1_6__alter_connect_database.sql
+++ b/server/odc-migrate/src/main/resources/migrate/common/V_4_2_1_6__alter_connect_database.sql
@@ -1,4 +1,4 @@
 alter table `connect_database` modify `charset_name` varchar(128) default null comment 'database charset name';
 alter table `connect_database` modify `collation_name` varchar(128) default null comment 'database collation name';
 alter table `connect_database` modify `table_count` bigint(20) default null comment 'table count which belongs to the database';
-alter table `connect_database` modify `last_sync_time` datetime not null default CURRENT_TIMESTAMP comment 'table count which belongs to the database';
+alter table `connect_database` modify `last_sync_time` datetime not null default CURRENT_TIMESTAMP comment 'last synchronizing time';

--- a/server/odc-service/src/main/java/com/oceanbase/odc/config/RestTemplateConfig.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/config/RestTemplateConfig.java
@@ -63,7 +63,7 @@ public class RestTemplateConfig {
                         MediaType.APPLICATION_FORM_URLENCODED));
         RestTemplate restTemplate = new RestTemplateBuilder()
                 .additionalMessageConverters(stringHttpMc, fastJsonHttpMc)
-                .setConnectTimeout(Duration.ofSeconds(10))
+                .setConnectTimeout(Duration.ofSeconds(5))
                 .setReadTimeout(Duration.ofSeconds(10))
                 .build();
         return new OdcRestTemplate(restTemplate, "ocpApi");

--- a/server/odc-service/src/main/java/com/oceanbase/odc/config/RestTemplateConfig.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/config/RestTemplateConfig.java
@@ -63,8 +63,8 @@ public class RestTemplateConfig {
                         MediaType.APPLICATION_FORM_URLENCODED));
         RestTemplate restTemplate = new RestTemplateBuilder()
                 .additionalMessageConverters(stringHttpMc, fastJsonHttpMc)
-                .setConnectTimeout(Duration.ofSeconds(5))
-                .setReadTimeout(Duration.ofSeconds(5))
+                .setConnectTimeout(Duration.ofSeconds(10))
+                .setReadTimeout(Duration.ofSeconds(10))
                 .build();
         return new OdcRestTemplate(restTemplate, "ocpApi");
     }

--- a/server/odc-service/src/main/java/com/oceanbase/odc/config/ScheduleConfiguration.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/config/ScheduleConfiguration.java
@@ -168,7 +168,7 @@ public class ScheduleConfiguration {
     @Bean(name = "syncDatabaseTaskExecutor")
     public ThreadPoolTaskExecutor syncDatabaseTaskExecutor() {
         ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
-        int poolSize = 64;
+        int poolSize = Math.max(SystemUtils.availableProcessors() * 8, 64);
         executor.setCorePoolSize(poolSize);
         executor.setMaxPoolSize(poolSize);
         executor.setQueueCapacity(0);

--- a/server/odc-service/src/main/java/com/oceanbase/odc/config/ScheduleConfiguration.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/config/ScheduleConfiguration.java
@@ -168,7 +168,7 @@ public class ScheduleConfiguration {
     @Bean(name = "syncDatabaseTaskExecutor")
     public ThreadPoolTaskExecutor syncDatabaseTaskExecutor() {
         ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
-        int poolSize = Math.max(SystemUtils.availableProcessors(), 5);
+        int poolSize = 64;
         executor.setCorePoolSize(poolSize);
         executor.setMaxPoolSize(poolSize);
         executor.setQueueCapacity(0);

--- a/server/odc-service/src/main/java/com/oceanbase/odc/metadb/connection/ConnectionConfigRepository.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/metadb/connection/ConnectionConfigRepository.java
@@ -62,6 +62,8 @@ public interface ConnectionConfigRepository
     List<ConnectionEntity> findByVisibleScopeAndCreatorId(ConnectionVisibleScope visibleScope,
             Long creatorId);
 
+    List<ConnectionEntity> findByVisibleScope(ConnectionVisibleScope visibleScope);
+
     @Transactional
     int deleteByVisibleScopeAndOwnerId(ConnectionVisibleScope visibleScope, Long ownerId);
 

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/connection/ConnectionService.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/connection/ConnectionService.java
@@ -65,6 +65,7 @@ import com.oceanbase.odc.core.authority.util.PreAuthenticate;
 import com.oceanbase.odc.core.authority.util.SkipAuthorize;
 import com.oceanbase.odc.core.shared.PreConditions;
 import com.oceanbase.odc.core.shared.constant.ConnectionStatus;
+import com.oceanbase.odc.core.shared.constant.ConnectionVisibleScope;
 import com.oceanbase.odc.core.shared.constant.ErrorCodes;
 import com.oceanbase.odc.core.shared.constant.PermissionType;
 import com.oceanbase.odc.core.shared.constant.ResourceType;
@@ -437,7 +438,11 @@ public class ConnectionService {
         return repository.findAll().stream().map(mapper::entityToModel).collect(Collectors.toList());
     }
 
-
+    @SkipAuthorize("internal usage")
+    public List<ConnectionConfig> listByVisibleScope(ConnectionVisibleScope visibleScope) {
+        return repository.findByVisibleScope(visibleScope).stream().map(mapper::entityToModel)
+                .collect(Collectors.toList());
+    }
 
     @Transactional(rollbackFor = Exception.class)
     @SkipAuthorize("permission check inside")
@@ -529,6 +534,7 @@ public class ConnectionService {
         entityManager.refresh(savedEntity);
 
         ConnectionConfig updated = entityToModel(savedEntity, true);
+        databaseSyncManager.submitSyncDataSourceTask(updated);
         log.info("Connection updated, connection={}", updated);
         return updated;
     }

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/connection/DatabaseSyncSchedules.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/connection/DatabaseSyncSchedules.java
@@ -52,9 +52,9 @@ public class DatabaseSyncSchedules {
         for (ConnectionConfig dataSource : orgDataSources) {
             try {
                 databaseSyncManager.submitSyncDataSourceTask(dataSource);
-                log.debug("sync datasource successfully, connectionId={}", dataSource.getId());
+                log.debug("submit sync datasource task successfully, connectionId={}", dataSource.getId());
             } catch (Exception ex) {
-                log.debug("sync datasource failed, datasourceId={}", dataSource.getId(), ex);
+                log.debug("submit sync datasource task failed, datasourceId={}", dataSource.getId(), ex);
             }
         }
     }

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/connection/DatabaseSyncSchedules.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/connection/DatabaseSyncSchedules.java
@@ -22,9 +22,9 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import org.springframework.util.CollectionUtils;
 
+import com.oceanbase.odc.core.shared.constant.ConnectionVisibleScope;
 import com.oceanbase.odc.service.connection.database.DatabaseSyncManager;
 import com.oceanbase.odc.service.connection.model.ConnectionConfig;
-import com.oceanbase.odc.service.iam.util.SecurityContextUtils;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -44,17 +44,17 @@ public class DatabaseSyncSchedules {
 
     @Scheduled(fixedDelayString = "${odc.connect.session.sync-databases-interval-millis:180000}")
     public void syncDatabases() {
-        List<ConnectionConfig> allConnections = connectionService.listAllConnections();
-        if (CollectionUtils.isEmpty(allConnections)) {
+        List<ConnectionConfig> orgDataSources =
+                connectionService.listByVisibleScope(ConnectionVisibleScope.ORGANIZATION);
+        if (CollectionUtils.isEmpty(orgDataSources)) {
             return;
         }
-        for (ConnectionConfig connection : allConnections) {
+        for (ConnectionConfig dataSource : orgDataSources) {
             try {
-                SecurityContextUtils.setCurrentUser(connection.getCreatorId(), connection.getOrganizationId(), null);
-                databaseSyncManager.syncDataSource(connection.getId());
-                log.debug("sync datasource successfully, connectionId={}", connection.getId());
+                databaseSyncManager.submitSyncDataSourceTask(dataSource);
+                log.debug("sync datasource successfully, connectionId={}", dataSource.getId());
             } catch (Exception ex) {
-                log.debug("sync datasource failed, datasourceId={}", connection.getId(), ex);
+                log.debug("sync datasource failed, datasourceId={}", dataSource.getId(), ex);
             }
         }
     }

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/connection/database/DatabaseService.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/connection/database/DatabaseService.java
@@ -436,8 +436,10 @@ public class DatabaseService {
             Map<String, List<DatabaseEntity>> existedDatabaseName2Database =
                     existedDatabasesInDb.stream().collect(Collectors.groupingBy(DatabaseEntity::getName));
 
+            Set<String> existedDatabaseNames = existedDatabaseName2Database.keySet();
+            Set<String> latestDatabaseNames = latestDatabaseName2Database.keySet();
             List<Object[]> toAdd = latestDatabases.stream()
-                    .filter(database -> !existedDatabaseName2Database.keySet().contains(database.getName()))
+                    .filter(database -> !existedDatabaseNames.contains(database.getName()))
                     .map(database -> new Object[] {
                             database.getDatabaseId(),
                             database.getOrganizationId(),
@@ -461,7 +463,7 @@ public class DatabaseService {
             }
             List<Object[]> toDelete =
                     existedDatabasesInDb.stream()
-                            .filter(database -> !latestDatabaseName2Database.keySet().contains(database.getName()))
+                            .filter(database -> !latestDatabaseNames.contains(database.getName()))
                             .map(database -> new Object[] {database.getId()})
                             .collect(Collectors.toList());
             /**
@@ -474,7 +476,7 @@ public class DatabaseService {
             }
 
             List<Object[]> toUpdate = existedDatabasesInDb.stream()
-                    .filter(database -> latestDatabaseName2Database.keySet().contains(database.getName()))
+                    .filter(database -> latestDatabaseNames.contains(database.getName()))
                     .map(database -> {
                         DatabaseEntity latest = latestDatabaseName2Database.get(database.getName()).get(0);
                         return new Object[] {latest.getTableCount(), latest.getCollationName(), latest.getCharsetName(),
@@ -507,9 +509,10 @@ public class DatabaseService {
                                     Collectors.toList());
             Map<String, List<DatabaseEntity>> existedDatabaseName2Database =
                     existedDatabasesInDb.stream().collect(Collectors.groupingBy(DatabaseEntity::getName));
+            Set<String> existedDatabaseNames = existedDatabaseName2Database.keySet();
 
             List<Object[]> toAdd = latestDatabaseNames.stream()
-                    .filter(latestDatabaseName -> !existedDatabaseName2Database.keySet().contains(latestDatabaseName))
+                    .filter(latestDatabaseName -> !existedDatabaseNames.contains(latestDatabaseName))
                     .map(latestDatabaseName -> new Object[] {
                             com.oceanbase.odc.common.util.StringUtils.uuid(),
                             connection.getOrganizationId(),

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/connection/database/DatabaseService.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/connection/database/DatabaseService.java
@@ -24,13 +24,13 @@ import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Lock;
 import java.util.stream.Collectors;
 
+import javax.sql.DataSource;
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
 
@@ -41,6 +41,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.integration.jdbc.lock.JdbcLockRegistry;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.CollectionUtils;
@@ -52,7 +53,6 @@ import com.oceanbase.odc.core.authority.util.PreAuthenticate;
 import com.oceanbase.odc.core.authority.util.SkipAuthorize;
 import com.oceanbase.odc.core.session.ConnectionSession;
 import com.oceanbase.odc.core.session.ConnectionSessionConstants;
-import com.oceanbase.odc.core.shared.constant.ConnectionVisibleScope;
 import com.oceanbase.odc.core.shared.constant.ErrorCodes;
 import com.oceanbase.odc.core.shared.constant.OrganizationType;
 import com.oceanbase.odc.core.shared.constant.ResourceRoleName;
@@ -62,7 +62,6 @@ import com.oceanbase.odc.core.shared.exception.BadRequestException;
 import com.oceanbase.odc.core.shared.exception.ConflictException;
 import com.oceanbase.odc.core.shared.exception.NotFoundException;
 import com.oceanbase.odc.metadb.connection.ConnectionConfigRepository;
-import com.oceanbase.odc.metadb.connection.ConnectionEntity;
 import com.oceanbase.odc.metadb.connection.DatabaseEntity;
 import com.oceanbase.odc.metadb.connection.DatabaseRepository;
 import com.oceanbase.odc.metadb.connection.DatabaseSpecs;
@@ -82,6 +81,7 @@ import com.oceanbase.odc.service.connection.model.ConnectionConfig;
 import com.oceanbase.odc.service.db.DBIdentitiesService;
 import com.oceanbase.odc.service.db.DBSchemaService;
 import com.oceanbase.odc.service.iam.HorizontalDataPermissionValidator;
+import com.oceanbase.odc.service.iam.OrganizationService;
 import com.oceanbase.odc.service.iam.auth.AuthenticationFacade;
 import com.oceanbase.odc.service.iam.auth.AuthorizationFacade;
 import com.oceanbase.odc.service.session.factory.DefaultConnectSessionFactory;
@@ -139,6 +139,12 @@ public class DatabaseService {
     @Autowired
     private ConnectionConfigRepository connectionConfigRepository;
 
+    @Autowired
+    private DataSource dataSource;
+
+    @Autowired
+    private OrganizationService organizationService;
+
     @Transactional(rollbackFor = Exception.class)
     @SkipAuthorize("internal authenticated")
     public Database detail(@NonNull Long id) {
@@ -173,7 +179,14 @@ public class DatabaseService {
     @Transactional(rollbackFor = Exception.class)
     @SkipAuthorize("internal authenticated")
     public Page<Database> list(@NonNull QueryDatabaseParams params, @NotNull Pageable pageable) {
-        if (authenticationFacade.currentUser().getOrganizationType() == OrganizationType.INDIVIDUAL) {
+        if (Objects.nonNull(params.getDataSourceId())
+                && authenticationFacade.currentUser().getOrganizationType() == OrganizationType.INDIVIDUAL) {
+            try {
+                internalSyncDataSourceSchemas(params.getDataSourceId());
+            } catch (Exception ex) {
+                log.warn("sync data sources in individual space failed when listing databases, errorMessage={}",
+                        ex.getLocalizedMessage());
+            }
             params.setContainsUnassigned(true);
         }
         Specification<DatabaseEntity> specs = DatabaseSpecs
@@ -371,32 +384,40 @@ public class DatabaseService {
         if (!lock.tryLock(3, TimeUnit.SECONDS)) {
             throw new ConflictException(ErrorCodes.ResourceModifying, "Can not acquire jdbc lock");
         }
+        ConnectionConfig connection = connectionService.getForConnectionSkipPermissionCheck(dataSourceId);
+        horizontalDataPermissionValidator.checkCurrentOrganization(connection);
+        try {
+            organizationService.get(connection.getOrganizationId()).ifPresent(organization -> {
+                if (organization.getType() == OrganizationType.INDIVIDUAL) {
+                    syncIndividualDataSources(connection);
+                } else {
+                    syncTeamDataSources(connection);
+                }
+            });
+            return true;
+        } catch (Exception ex) {
+            log.info("sync database failed, dataSourceId={}, error message={}", dataSourceId,
+                    ex.getLocalizedMessage());
+            return false;
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    private void syncTeamDataSources(ConnectionConfig connection) {
         ConnectionSession connectionSession = null;
         try {
-            Optional<ConnectionEntity> connectionOpt = connectionConfigRepository.findById(dataSourceId);
-            if (!connectionOpt.isPresent()) {
-                return false;
-            }
-            ConnectionEntity saved = connectionOpt.get();
-            if (saved.getEnvironmentId().longValue() == -1L
-                    || saved.getVisibleScope() == ConnectionVisibleScope.PRIVATE) {
-                return false;
-            }
-
-            ConnectionConfig connection = connectionService.getForConnectionSkipPermissionCheck(dataSourceId);
-            horizontalDataPermissionValidator.checkCurrentOrganization(connection);
             DefaultConnectSessionFactory factory = new DefaultConnectSessionFactory(connection);
             connectionSession = factory.generateSession();
             List<DatabaseEntity> latestDatabases =
                     dbSchemaService.listDatabases(connectionSession).stream().map(database -> {
                         DatabaseEntity entity = new DatabaseEntity();
-                        entity.setDatabaseId(database.getId());
+                        entity.setDatabaseId(com.oceanbase.odc.common.util.StringUtils.uuid());
                         entity.setExisted(Boolean.TRUE);
                         entity.setName(database.getName());
                         entity.setCharsetName(database.getCharset());
                         entity.setCollationName(database.getCollation());
                         entity.setTableCount(0L);
-                        entity.setLastSyncTime(new Date(System.currentTimeMillis()));
                         entity.setOrganizationId(connection.getOrganizationId());
                         entity.setEnvironmentId(connection.getEnvironmentId());
                         entity.setConnectionId(connection.getId());
@@ -404,54 +425,117 @@ public class DatabaseService {
                         entity.setProjectId(null);
                         return entity;
                     }).collect(Collectors.toList());
-            Map<String, List<DatabaseEntity>> latestDatabaseId2Database =
+
+            Map<String, List<DatabaseEntity>> latestDatabaseName2Database =
                     latestDatabases.stream().filter(Objects::nonNull)
-                            .collect(Collectors.groupingBy(DatabaseEntity::getDatabaseId));
-            if (CollectionUtils.isEmpty(latestDatabaseId2Database)) {
-                return true;
-            }
-            List<DatabaseEntity> databasesInDb = databaseRepository.findByConnectionId(connection.getId());
-            Set<String> databaseIdsInDb =
-                    databasesInDb.stream().filter(Objects::nonNull).map(DatabaseEntity::getDatabaseId).collect(
-                            Collectors.toSet());
+                            .collect(Collectors.groupingBy(DatabaseEntity::getName));
+            List<DatabaseEntity> existedDatabasesInDb =
+                    databaseRepository.findByConnectionId(connection.getId()).stream()
+                            .filter(database -> database.getExisted()).collect(
+                                    Collectors.toList());
+            Map<String, List<DatabaseEntity>> existedDatabaseName2Database =
+                    existedDatabasesInDb.stream().collect(Collectors.groupingBy(DatabaseEntity::getName));
 
-            List<DatabaseEntity> toAdd = latestDatabases.stream()
-                    .filter(database -> !databaseIdsInDb.contains(database.getDatabaseId()))
+            List<Object[]> toAdd = latestDatabases.stream()
+                    .filter(database -> !existedDatabaseName2Database.keySet().contains(database.getName()))
+                    .map(database -> new Object[] {
+                            database.getDatabaseId(),
+                            database.getOrganizationId(),
+                            database.getName(),
+                            database.getProjectId(),
+                            database.getConnectionId(),
+                            database.getEnvironmentId(),
+                            database.getSyncStatus().name(),
+                            database.getCharsetName(),
+                            database.getCollationName(),
+                            database.getTableCount(),
+                            database.getExisted()
+                    })
                     .collect(Collectors.toList());
-            databaseRepository.saveAll(toAdd);
 
-            List<Long> toDelete =
-                    databasesInDb.stream()
-                            .filter(database -> !latestDatabaseId2Database.keySet().contains(database.getDatabaseId()))
-                            .map(DatabaseEntity::getId)
+            JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
+            if (org.apache.commons.collections4.CollectionUtils.isNotEmpty(toAdd)) {
+                jdbcTemplate.batchUpdate(
+                        "insert into connect_database(database_id, organization_id, name, project_id, connection_id, environment_id, sync_status, charset_name, collation_name, table_count, is_existed) values(?,?,?,?,?,?,?,?,?,?,?)",
+                        toAdd);
+            }
+            List<Object[]> toDelete =
+                    existedDatabasesInDb.stream()
+                            .filter(database -> !latestDatabaseName2Database.keySet().contains(database.getName()))
+                            .map(database -> new Object[] {database.getId()})
                             .collect(Collectors.toList());
             /**
              * just set existed to false if the database has been dropped instead of deleting it directly
              */
             if (!CollectionUtils.isEmpty(toDelete)) {
-                databaseRepository.setExistedByIdIn(Boolean.FALSE, toDelete);
+                String deleteSql =
+                        "update connect_database set is_existed = 0 where id = ?";
+                jdbcTemplate.batchUpdate(deleteSql, toDelete);
             }
 
-            List<DatabaseEntity> toUpdate = databasesInDb.stream()
-                    .filter(database -> latestDatabaseId2Database.keySet().contains(database.getDatabaseId()))
+            List<Object[]> toUpdate = existedDatabasesInDb.stream()
+                    .filter(database -> latestDatabaseName2Database.keySet().contains(database.getName()))
                     .map(database -> {
-                        if (latestDatabaseId2Database.get(database.getDatabaseId()).size() == 1) {
-                            DatabaseEntity latest = latestDatabaseId2Database.get(database.getDatabaseId()).get(0);
-                            database.setTableCount(latest.getTableCount());
-                            database.setCollationName(latest.getCollationName());
-                            database.setCharsetName(latest.getCharsetName());
-                            database.setLastSyncTime(latest.getLastSyncTime());
-                            database.setExisted(Boolean.TRUE);
-                        }
-                        return database;
-                    }).collect(Collectors.toList());
-            databaseRepository.saveAll(toUpdate);
-            return true;
-        } catch (Exception ex) {
-            log.info("sync database failed, dataSourceId={}, error message={}", dataSourceId, ex.getLocalizedMessage());
-            return false;
+                        DatabaseEntity latest = latestDatabaseName2Database.get(database.getName()).get(0);
+                        return new Object[] {latest.getTableCount(), latest.getCollationName(), latest.getCharsetName(),
+                                database.getId()};
+                    })
+                    .collect(Collectors.toList());
+
+            if (org.apache.commons.collections4.CollectionUtils.isNotEmpty(toUpdate)) {
+                String update =
+                        "update connect_database set table_count=?, collation_name=?, charset_name=? where id = ?";
+                jdbcTemplate.batchUpdate(update, toUpdate);
+            }
         } finally {
-            lock.unlock();
+            if (Objects.nonNull(connectionSession)) {
+                connectionSession.expire();
+            }
+        }
+    }
+
+    private void syncIndividualDataSources(ConnectionConfig connection) {
+        ConnectionSession connectionSession = null;
+        try {
+            DefaultConnectSessionFactory factory = new DefaultConnectSessionFactory(connection);
+            connectionSession = factory.generateSession();
+            Set<String> latestDatabaseNames = dbSchemaService.showDatabases(connectionSession).stream().collect(
+                    Collectors.toSet());
+            List<DatabaseEntity> existedDatabasesInDb =
+                    databaseRepository.findByConnectionId(connection.getId()).stream()
+                            .filter(database -> database.getExisted()).collect(
+                                    Collectors.toList());
+            Map<String, List<DatabaseEntity>> existedDatabaseName2Database =
+                    existedDatabasesInDb.stream().collect(Collectors.groupingBy(DatabaseEntity::getName));
+
+            List<Object[]> toAdd = latestDatabaseNames.stream()
+                    .filter(latestDatabaseName -> !existedDatabaseName2Database.keySet().contains(latestDatabaseName))
+                    .map(latestDatabaseName -> new Object[] {
+                            com.oceanbase.odc.common.util.StringUtils.uuid(),
+                            connection.getOrganizationId(),
+                            latestDatabaseName,
+                            connection.getId(),
+                            connection.getEnvironmentId(),
+                            DatabaseSyncStatus.SUCCEEDED.name()
+                    })
+                    .collect(Collectors.toList());
+
+            JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
+            if (org.apache.commons.collections4.CollectionUtils.isNotEmpty(toAdd)) {
+                jdbcTemplate.batchUpdate(
+                        "insert into connect_database(database_id, organization_id, name, connection_id, environment_id, sync_status) values(?,?,?,?,?,?)",
+                        toAdd);
+            }
+
+            List<Object[]> toDelete =
+                    existedDatabasesInDb.stream()
+                            .filter(database -> !latestDatabaseNames.contains(database.getName()))
+                            .map(database -> new Object[] {database.getId()})
+                            .collect(Collectors.toList());
+            if (!CollectionUtils.isEmpty(toDelete)) {
+                jdbcTemplate.batchUpdate("delete from connect_database where id = ?", toDelete);
+            }
+        } finally {
             if (Objects.nonNull(connectionSession)) {
                 connectionSession.expire();
             }

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/connection/database/DatabaseSyncManager.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/connection/database/DatabaseSyncManager.java
@@ -54,11 +54,6 @@ public class DatabaseSyncManager {
         }));
     }
 
-    @SkipAuthorize("internal usage")
-    public Boolean syncDataSource(@NonNull Long dataSourceId) throws InterruptedException {
-        return databaseService.internalSyncDataSourceSchemas(dataSourceId);
-    }
-
     private Future<Boolean> doExecute(Supplier<Future<Boolean>> supplier) {
         try {
             return supplier.get();

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/db/DBSchemaService.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/db/DBSchemaService.java
@@ -37,6 +37,11 @@ public class DBSchemaService {
         return accessor.listDatabases();
     }
 
+    public List<String> showDatabases(ConnectionSession connectionSession) {
+        DBSchemaAccessor accessor = DBSchemaAccessors.create(connectionSession);
+        return accessor.showDatabases();
+    }
+
 
 
     public DBDatabase detail(ConnectionSession connectionSession, String dbName) {


### PR DESCRIPTION
#### What type of PR is this?
type-bug

#### What this PR does / why we need it:
This PR fixed these issues:
1. The individual space databases cannot be displayed in real-time.
2. Oceanbase MySQL datasource synchronization heavily depends on oceanbase.gv$database select privilege.
3. The datasource synchronization is not triggered when modifying the data source.
4. The datasource synchronization schedule is unexpectedly slow.

#### How this PR fixed the above issues respectively:
1. When listing databases, we do a datasource synchronization automatically
2. Use information_schema.schemata instead of oceanbase.gv$database. Additionally, we do not rely on a real unique database_id anymore, we just simply use the database name as the database_id instead.
3. After modifying datasource configuration, we trigger a datasource synchronization.
4. Add the thread pool size to 64.

#### Other changes:
1. Change the timeout of internalProxyRestTemplate from 5s to 10s to avoid possible timeout.