### PR TITLE
fix(sql-execute): fix table with rowid datatype cannot be edited

### DIFF
--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/session/model/SqlExecuteResult.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/session/model/SqlExecuteResult.java
@@ -146,6 +146,9 @@ public class SqlExecuteResult {
         boolean editable = true;
         OdcTable resultTable = null;
         Set<OdcTable> relatedTablesOrViews = new HashSet<>();
+        Set<String> rowid_column_names = new HashSet<>();
+        rowid_column_names.add(OdcConstants.ODC_INTERNAL_ROWID);
+        rowid_column_names.add(OdcConstants.ROWID);
         if (Objects.isNull(this.resultSetMetaData)) {
             return null;
         }
@@ -176,7 +179,8 @@ public class SqlExecuteResult {
             } else {
                 columnNames.add(columnName);
             }
-            if (Types.ROWID == odcFieldMetaData.getColumnType()) {
+            if (Types.ROWID == odcFieldMetaData.getColumnType()
+                    && rowid_column_names.contains(odcFieldMetaData.getColumnName())) {
                 // not editable if there is more than one RowId
                 if (Objects.nonNull(resultTable)) {
                     editable = false;
@@ -203,10 +207,12 @@ public class SqlExecuteResult {
         resultSetMetaData.setTable(resultTable);
         // set rows of the table with rowid editable
         for (JdbcColumnMetaData odcFieldMetaData : resultSetMetaData.getFieldMetaDataList()) {
+            boolean isRowid = Types.ROWID == odcFieldMetaData.getColumnType()
+                    && rowid_column_names.contains(odcFieldMetaData.getColumnName());
             odcFieldMetaData.setEditable(
                     odcFieldMetaData.schemaName().equals(resultTable.getDatabaseName())
                             && odcFieldMetaData.getTableName().equals(resultTable.getTableName())
-                            && Types.ROWID != odcFieldMetaData.getColumnType());
+                            && !isRowid);
         }
         return resultTable;
     }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines.
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request.
3. Ensure you have added or ran the appropriate tests for your PR.
5. If the PR is unfinished, you may add or remove a WIP or [WIP] prefix to your pull request title.
-->

#### What type of PR is this?
type-bug
module-sql execution
module-resultset
#### What this PR does / why we need it:
table with rowid datatype cannot be edited both in query table data and in sql-execute resultset.
table ddl:
```
CREATE TABLE "JINGTIAN"."ROWID_COL" (
  "ID1" UROWID(4000),
  "ID2" UROWID(4000)
)
```
this table's data cannot be edited both in query table data and in sql-execute resultset.
when executing sql like `' select * from ROWID_COL'`, the resultset cannot be edited.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #370

#### Special notes for your reviewer:

#### Additional documentation e.g., usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```