### PR TITLE
fix(data-security): use disabeld recognition rules when select all rules

### DIFF
--- a/server/odc-service/src/main/java/com/oceanbase/odc/metadb/datasecurity/SensitiveRuleRepository.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/metadb/datasecurity/SensitiveRuleRepository.java
@@ -28,7 +28,7 @@ import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 public interface SensitiveRuleRepository
         extends JpaRepository<SensitiveRuleEntity, Long>, JpaSpecificationExecutor<SensitiveRuleEntity> {
 
-    List<SensitiveRuleEntity> findByProjectId(Long projectId);
+    List<SensitiveRuleEntity> findByProjectIdAndEnabled(Long projectId, Boolean enabled);
 
     List<SensitiveRuleEntity> findByIdIn(Collection<Long> ids);
 

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/datasecurity/SensitiveColumnService.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/datasecurity/SensitiveColumnService.java
@@ -349,7 +349,7 @@ public class SensitiveColumnService {
         List<Database> databases = databaseService.listDatabasesByIds(databaseIds);
         List<SensitiveRule> rules;
         if (req.getAllSensitiveRules()) {
-            rules = ruleService.getByProjectId(projectId);
+            rules = ruleService.getByProjectIdAndEnabled(projectId);
         } else {
             PreConditions.notEmpty(req.getSensitiveRuleIds(), "sensitiveRuleIds");
             rules = ruleService.batchNullSafeGetModel(new HashSet<>(req.getSensitiveRuleIds()));

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/datasecurity/SensitiveRuleService.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/datasecurity/SensitiveRuleService.java
@@ -209,8 +209,8 @@ public class SensitiveRuleService {
     }
 
     @SkipAuthorize("odc internal usages")
-    public List<SensitiveRule> getByProjectId(@NotNull Long projectId) {
-        List<SensitiveRuleEntity> entities = ruleRepository.findByProjectId(projectId);
+    public List<SensitiveRule> getByProjectIdAndEnabled(@NotNull Long projectId) {
+        List<SensitiveRuleEntity> entities = ruleRepository.findByProjectIdAndEnabled(projectId, true);
         return entities.stream().map(ruleMapper::entityToModel).collect(Collectors.toList());
     }
 


### PR DESCRIPTION
#### What type of PR is this?
type-bug
module-data security

#### Which issue(s) this PR fixes:
Here is a bug: when all recognition rules are selected, the disabled rules will be recognized together.
This PR will fix it by add `enbaled` into filtering condition
Fixes #433 
Close #433 