### PR TITLE
fix(data-security): error metadata of built-in sensitive algorithm

### DIFF
--- a/server/odc-migrate/src/main/resources/migrate/common/V_4_2_0_28__add_masking_algorithm_segment.yaml
+++ b/server/odc-migrate/src/main/resources/migrate/common/V_4_2_0_28__add_masking_algorithm_segment.yaml
@@ -495,7 +495,7 @@ templates:
             ref_file: migrate/common/V_4_2_0_27__add_masking_algorithm.yaml
             field_path: templates.10.specs.0.value
       - column_name: is_mask
-        value: true
+        value: false
         data_type: java.lang.Boolean
       - column_name: type
         value: LEFT_OVER

--- a/server/odc-migrate/src/main/resources/migrate/common/V_4_2_2_2__update_segment_metadata.sql
+++ b/server/odc-migrate/src/main/resources/migrate/common/V_4_2_2_2__update_segment_metadata.sql
@@ -1,0 +1,17 @@
+--
+-- Update sensitive algorithm segment metadata for license plate number masking algorithm
+--
+UPDATE
+  `data_security_masking_algorithm_segment` AS `ds_mas`
+SET
+  `ds_mas`.`is_mask` = false
+WHERE
+  `ds_mas`.masking_algorithm_id IN (
+    SELECT
+      `ds_ma`.`id`
+    FROM
+      `data_security_masking_algorithm` AS `ds_ma`
+    WHERE
+      `ds_ma`.`name` = '${com.oceanbase.odc.builtin-resource.masking-algorithm.license-plate-number.name}'
+  )
+  AND `ds_mas`.ordinal = 2;


### PR DESCRIPTION
#### What type of PR is this?
type-bug
module-data security

#### What this PR does / why we need it:
The metadata of built-in sensitive algorithm segments is wrong. Which make the preview masking results is not right:
![image](https://github.com/oceanbase/odc/assets/84772536/245d2596-ee0a-4943-a7a8-19ffb4db020f)
This PR will fix it by correcting erroneous metadata using SQL script.

#### Which issue(s) this PR fixes:
Fixes #446 

#### Special notes for your reviewer:
Passed the self-test

#### Additional documentation e.g., usage docs, etc.:
