### PR TITLE
feat(connection): add initialization configuration capabilities for data sources

### DIFF
--- a/server/integration-test/src/test/java/com/oceanbase/odc/metadb/connection/ConnectionAttributeRepositoryTest.java
+++ b/server/integration-test/src/test/java/com/oceanbase/odc/metadb/connection/ConnectionAttributeRepositoryTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2023 OceanBase.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.oceanbase.odc.metadb.connection;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import com.oceanbase.odc.ServiceTestEnv;
+import com.oceanbase.odc.test.tool.TestRandom;
+
+/**
+ * Test cases for {@link ConnectionAttributeRepository}
+ *
+ * @author yh263208
+ * @date 2023-09-12 15:46
+ * @since ODC_release_4.2.2
+ */
+public class ConnectionAttributeRepositoryTest extends ServiceTestEnv {
+
+    @Autowired
+    private ConnectionAttributeRepository repository;
+
+    @Before
+    public void setUp() {
+        this.repository.deleteAll();
+    }
+
+    @Test
+    public void save_saveAnAttribute_savedSucceed() {
+        ConnectionAttributeEntity entity = TestRandom.nextObject(ConnectionAttributeEntity.class);
+        entity = this.repository.save(entity);
+        Assert.assertNotNull(entity);
+    }
+
+    @Test
+    public void save_saveAttributes_saveSucceed() {
+        List<ConnectionAttributeEntity> entities = new ArrayList<>();
+        entities.add(TestRandom.nextObject(ConnectionAttributeEntity.class));
+        entities.add(TestRandom.nextObject(ConnectionAttributeEntity.class));
+        entities = this.repository.saveAll(entities);
+        Assert.assertEquals(2, entities.size());
+    }
+
+    @Test
+    public void delete_deleteByConnectionId_deleteSucceed() {
+        List<ConnectionAttributeEntity> entities = new ArrayList<>();
+        entities.add(TestRandom.nextObject(ConnectionAttributeEntity.class));
+        entities.add(TestRandom.nextObject(ConnectionAttributeEntity.class));
+        Long connectionId = 100L;
+        entities.forEach(e -> e.setConnectionId(connectionId));
+        entities = this.repository.saveAll(entities);
+        int affectRows = this.repository.deleteByConnectionId(connectionId);
+        Assert.assertEquals(entities.size(), affectRows);
+    }
+
+    @Test
+    public void delete_deleteByConnectionIds_deleteSucceed() {
+        List<ConnectionAttributeEntity> entities = new ArrayList<>();
+        entities.add(TestRandom.nextObject(ConnectionAttributeEntity.class));
+        entities.add(TestRandom.nextObject(ConnectionAttributeEntity.class));
+        entities = this.repository.saveAll(entities);
+
+        Set<Long> connectionIds = entities.stream().map(
+                ConnectionAttributeEntity::getConnectionId).collect(Collectors.toSet());
+        int affectRows = this.repository.deleteByConnectionIds(connectionIds);
+        Assert.assertEquals(entities.size(), affectRows);
+    }
+
+    @Test
+    public void find_findByConnectionId_findSucceed() {
+        List<ConnectionAttributeEntity> entities = new ArrayList<>();
+        entities.add(TestRandom.nextObject(ConnectionAttributeEntity.class));
+        entities.add(TestRandom.nextObject(ConnectionAttributeEntity.class));
+        Long connectionId = 100L;
+        entities.forEach(e -> e.setConnectionId(connectionId));
+        entities = this.repository.saveAll(entities);
+
+        List<ConnectionAttributeEntity> results = this.repository.findByConnectionId(connectionId);
+        Set<ConnectionAttributeEntity> actual = new HashSet<>(results);
+        Set<ConnectionAttributeEntity> expect = new HashSet<>(entities);
+        Assert.assertEquals(actual, expect);
+    }
+
+    @Test
+    public void find_findByConnectionIdAndOrganizationId_findSucceed() {
+        List<ConnectionAttributeEntity> entities = new ArrayList<>();
+        entities.add(TestRandom.nextObject(ConnectionAttributeEntity.class));
+        entities.add(TestRandom.nextObject(ConnectionAttributeEntity.class));
+        Long connectionId = 100L;
+        entities.forEach(e -> e.setConnectionId(connectionId));
+        entities = this.repository.saveAll(entities);
+
+        ConnectionAttributeEntity expect = entities.get(0);
+        List<ConnectionAttributeEntity> actual = this.repository
+                .findByConnectionIdAndOrganizationId(connectionId, expect.getOrganizationId());
+        Assert.assertEquals(actual.get(0), expect);
+    }
+
+}

--- a/server/integration-test/src/test/java/com/oceanbase/odc/metadb/connection/ConnectionAttributeRepositoryTest.java
+++ b/server/integration-test/src/test/java/com/oceanbase/odc/metadb/connection/ConnectionAttributeRepositoryTest.java
@@ -34,7 +34,7 @@ import com.oceanbase.odc.test.tool.TestRandom;
  * Test cases for {@link ConnectionAttributeRepository}
  *
  * @author yh263208
- * @date 2023-09-12 15:46
+ * @date 2023-10-16 11:45
  * @since ODC_release_4.2.2
  */
 public class ConnectionAttributeRepositoryTest extends ServiceTestEnv {

--- a/server/integration-test/src/test/java/com/oceanbase/odc/metadb/connection/ConnectionAttributeRepositoryTest.java
+++ b/server/integration-test/src/test/java/com/oceanbase/odc/metadb/connection/ConnectionAttributeRepositoryTest.java
@@ -103,19 +103,4 @@ public class ConnectionAttributeRepositoryTest extends ServiceTestEnv {
         Assert.assertEquals(actual, expect);
     }
 
-    @Test
-    public void find_findByConnectionIdAndOrganizationId_findSucceed() {
-        List<ConnectionAttributeEntity> entities = new ArrayList<>();
-        entities.add(TestRandom.nextObject(ConnectionAttributeEntity.class));
-        entities.add(TestRandom.nextObject(ConnectionAttributeEntity.class));
-        Long connectionId = 100L;
-        entities.forEach(e -> e.setConnectionId(connectionId));
-        entities = this.repository.saveAll(entities);
-
-        ConnectionAttributeEntity expect = entities.get(0);
-        List<ConnectionAttributeEntity> actual = this.repository
-                .findByConnectionIdAndOrganizationId(connectionId, expect.getOrganizationId());
-        Assert.assertEquals(actual.get(0), expect);
-    }
-
 }

--- a/server/odc-core/src/main/java/com/oceanbase/odc/core/shared/constant/ErrorCodes.java
+++ b/server/odc-core/src/main/java/com/oceanbase/odc/core/shared/constant/ErrorCodes.java
@@ -101,6 +101,7 @@ public enum ErrorCodes implements ErrorCode {
     SysTenantAccountInvalid,
     ConnectionVerifyFailed,
     ConnectionDatabaseTypeMismatched,
+    ConnectionInitScriptFailed,
     ConnectionInsufficientPermissions,
     ConnectionTooManyPermissions,
     ConnectionReadonly,

--- a/server/odc-core/src/main/resources/i18n/ErrorMessages.properties
+++ b/server/odc-core/src/main/resources/i18n/ErrorMessages.properties
@@ -130,6 +130,7 @@ com.oceanbase.odc.ErrorCodes.ObInvalidObjectTypesForRecyclebin=The type of the c
 com.oceanbase.odc.ErrorCodes.OracleBlankColumnDefaultValue=Default value of column cannot be blank, column name: {0}, please check if inputs blank char
 com.oceanbase.odc.ErrorCodes.ConnectionVerifyFailed=Verify account privileges failed, details: {0}
 com.oceanbase.odc.ErrorCodes.ConnectionDatabaseTypeMismatched=Unmatched database type, please confirm that the connected database is {0}
+com.oceanbase.odc.ErrorCodes.ConnectionInitScriptFailed=Connection initialization script running error, details: {0}
 com.oceanbase.odc.ErrorCodes.ConnectionInsufficientPermissions=Insufficient authority, lack of {0}
 com.oceanbase.odc.ErrorCodes.ConnectionTooManyPermissions=Too many permissions, details: {0}
 com.oceanbase.odc.ErrorCodes.ExportExcelFileFailed=Export Excel failed, we recommend you to export CSV file, error details：{0}

--- a/server/odc-core/src/main/resources/i18n/ErrorMessages_zh_CN.properties
+++ b/server/odc-core/src/main/resources/i18n/ErrorMessages_zh_CN.properties
@@ -128,6 +128,7 @@ com.oceanbase.odc.ErrorCodes.ObInvalidObjectTypesForRecyclebin=当前操作的�
 com.oceanbase.odc.ErrorCodes.ObCopySchemaFailed=复制 Schema 失败，错误详情：{0}
 com.oceanbase.odc.ErrorCodes.OracleBlankColumnDefaultValue=列的默认值不能为空，列名称: {0}，请确认是否输入了空白字符
 com.oceanbase.odc.ErrorCodes.ConnectionVerifyFailed=验证账号权限失败，错误详情：{0}
+com.oceanbase.odc.ErrorCodes.ConnectionInitScriptFailed=连接初始化脚本运行错误，详情：{0}
 com.oceanbase.odc.ErrorCodes.ConnectionDatabaseTypeMismatched=数据库类型不匹配，请确认连接的目标数据库类型是 {0}
 com.oceanbase.odc.ErrorCodes.ConnectionInsufficientPermissions=权限不足，缺乏权限 {0}
 com.oceanbase.odc.ErrorCodes.ConnectionTooManyPermissions=过多的权限，权限详情：{0}

--- a/server/odc-core/src/main/resources/i18n/ErrorMessages_zh_TW.properties
+++ b/server/odc-core/src/main/resources/i18n/ErrorMessages_zh_TW.properties
@@ -127,6 +127,7 @@ com.oceanbase.odc.ErrorCodes.ObCopySchemaFailed=複製 Schema 失敗，錯誤詳
 com.oceanbase.odc.ErrorCodes.ObInvalidObjectTypesForRecyclebin=當前操作的回收站對象 {0} 的類型為 {1}，不在支持的對像類型範圍內，支持的類型：{2}
 com.oceanbase.odc.ErrorCodes.OracleBlankColumnDefaultValue=列的缺省值不能為空，列名稱: {0}，請確認是否輸入了空白字符
 com.oceanbase.odc.ErrorCodes.ConnectionVerifyFailed=驗證賬號權限失敗，錯誤詳情：{0}
+com.oceanbase.odc.ErrorCodes.ConnectionInitScriptFailed=連接初始化腳本運行錯誤，詳情：{0}
 com.oceanbase.odc.ErrorCodes.ConnectionDatabaseTypeMismatched=數據庫類型不匹配，請確認連接的目標數據庫類型是 {0}
 com.oceanbase.odc.ErrorCodes.ConnectionInsufficientPermissions=權限不足，缺乏權限 {0}
 com.oceanbase.odc.ErrorCodes.ConnectionTooManyPermissions=過多的權限，權限詳情：{0}

--- a/server/odc-migrate/src/main/resources/migrate/common/V_4_2_2_3__add_connect_connection_attribute.sql
+++ b/server/odc-migrate/src/main/resources/migrate/common/V_4_2_2_3__add_connect_connection_attribute.sql
@@ -1,0 +1,15 @@
+---
+--- v4.2.2
+---
+CREATE TABLE IF NOT EXISTS `connect_connection_attribute` (
+    `id` bigint(20) NOT NULL AUTO_INCREMENT COMMENT 'Id for connection attribute',
+    `create_time` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT 'Record insertion time',
+  	`update_time` datetime DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT 'Record modification time',
+    `name` varchar(1024) NOT NULL COMMENT 'Name for an attribute',
+    `organization_id` bigint(20) NOT NULL COMMENT 'Organization id',
+		`connection_id` bigint(20) NOT NULL COMMENT 'Related connection id, reference connect_connection(id)',
+    `content` mediumtext DEFAULT NULL COMMENT 'Content for key',
+    CONSTRAINT `pk_connect_connection_attribute` PRIMARY KEY (`id`),
+    KEY `idx_connect_connection_attribute` (`connection_id`, `organization_id`),
+    UNIQUE KEY `uk_connect_connection_attribute` (`name`, `connection_id`, `organization_id`)
+);

--- a/server/odc-migrate/src/main/resources/migrate/common/V_4_2_2_3__add_connect_connection_attribute.sql
+++ b/server/odc-migrate/src/main/resources/migrate/common/V_4_2_2_3__add_connect_connection_attribute.sql
@@ -6,10 +6,8 @@ CREATE TABLE IF NOT EXISTS `connect_connection_attribute` (
     `create_time` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT 'Record insertion time',
   	`update_time` datetime DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT 'Record modification time',
     `name` varchar(1024) NOT NULL COMMENT 'Name for an attribute',
-    `organization_id` bigint(20) NOT NULL COMMENT 'Organization id',
 		`connection_id` bigint(20) NOT NULL COMMENT 'Related connection id, reference connect_connection(id)',
     `content` mediumtext DEFAULT NULL COMMENT 'Content for key',
     CONSTRAINT `pk_connect_connection_attribute` PRIMARY KEY (`id`),
-    KEY `idx_connect_connection_attribute` (`connection_id`, `organization_id`),
-    UNIQUE KEY `uk_connect_connection_attribute` (`name`, `connection_id`, `organization_id`)
+    UNIQUE KEY `uk_connect_connection_attribute` (`connection_id`, `name`)
 );

--- a/server/odc-service/src/main/java/com/oceanbase/odc/metadb/connection/ConnectionAttributeEntity.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/metadb/connection/ConnectionAttributeEntity.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2023 OceanBase.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.oceanbase.odc.metadb.connection;
+
+import java.util.Date;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+import org.hibernate.annotations.Generated;
+import org.hibernate.annotations.GenerationTime;
+
+import lombok.Data;
+
+/**
+ * {@link ConnectionAttributeEntity}
+ *
+ * @author yh263208
+ * @date 2023-09-12 15:33
+ * @since ODC_release_4.2.2
+ */
+@Data
+@Entity
+@Table(name = "connect_connection_attribute")
+public class ConnectionAttributeEntity {
+
+    @Id
+    @Column(name = "id", nullable = false)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "name", nullable = false)
+    private String name;
+
+    @Column(name = "organization_id", updatable = false, nullable = false)
+    private Long organizationId;
+
+    @Column(name = "connection_id", updatable = false, nullable = false)
+    private Long connectionId;
+
+    @Column(name = "content")
+    private String content;
+
+    @Generated(GenerationTime.ALWAYS)
+    @Column(name = "create_time", insertable = false, updatable = false,
+            columnDefinition = "datetime NOT NULL DEFAULT CURRENT_TIMESTAMP")
+    private Date createTime;
+
+    @Generated(GenerationTime.ALWAYS)
+    @Column(name = "update_time", insertable = false, updatable = false,
+            columnDefinition = "datetime DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP")
+    private Date updateTime;
+
+}

--- a/server/odc-service/src/main/java/com/oceanbase/odc/metadb/connection/ConnectionAttributeEntity.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/metadb/connection/ConnectionAttributeEntity.java
@@ -50,9 +50,6 @@ public class ConnectionAttributeEntity {
     @Column(name = "name", nullable = false)
     private String name;
 
-    @Column(name = "organization_id", updatable = false, nullable = false)
-    private Long organizationId;
-
     @Column(name = "connection_id", updatable = false, nullable = false)
     private Long connectionId;
 

--- a/server/odc-service/src/main/java/com/oceanbase/odc/metadb/connection/ConnectionAttributeRepository.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/metadb/connection/ConnectionAttributeRepository.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2023 OceanBase.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.oceanbase.odc.metadb.connection;
+
+import java.util.List;
+import java.util.Set;
+
+import javax.transaction.Transactional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+
+import lombok.NonNull;
+
+/**
+ * {@link ConnectionAttributeRepository}
+ *
+ * @author yh263208
+ * @date 2023-09-12 15:44
+ * @since ODC_release_4.2.2
+ */
+public interface ConnectionAttributeRepository extends JpaRepository<ConnectionAttributeEntity, Long>,
+        JpaSpecificationExecutor<ConnectionAttributeEntity> {
+
+    List<ConnectionAttributeEntity> findByConnectionId(Long connectionId);
+
+    List<ConnectionAttributeEntity> findByConnectionIdAndOrganizationId(Long connectionId, Long organizationId);
+
+    @Transactional
+    @Modifying
+    @Query(value = "delete from connect_connection_attribute where connection_id=?1", nativeQuery = true)
+    int deleteByConnectionId(@NonNull Long connectionId);
+
+    @Transactional
+    @Modifying
+    @Query(value = "delete from connect_connection_attribute where connection_id in (?1)", nativeQuery = true)
+    int deleteByConnectionIds(Set<Long> connectionIds);
+
+}

--- a/server/odc-service/src/main/java/com/oceanbase/odc/metadb/connection/ConnectionAttributeRepository.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/metadb/connection/ConnectionAttributeRepository.java
@@ -40,8 +40,6 @@ public interface ConnectionAttributeRepository extends JpaRepository<ConnectionA
 
     List<ConnectionAttributeEntity> findByConnectionId(Long connectionId);
 
-    List<ConnectionAttributeEntity> findByConnectionIdAndOrganizationId(Long connectionId, Long organizationId);
-
     @Transactional
     @Modifying
     @Query(value = "delete from connect_connection_attribute where connection_id=?1", nativeQuery = true)

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/connection/ConnectionService.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/connection/ConnectionService.java
@@ -54,6 +54,7 @@ import org.springframework.transaction.support.DefaultTransactionDefinition;
 import org.springframework.validation.annotation.Validated;
 
 import com.oceanbase.odc.common.i18n.I18n;
+import com.oceanbase.odc.common.json.JsonUtils;
 import com.oceanbase.odc.core.authority.SecurityManager;
 import com.oceanbase.odc.core.authority.model.DefaultSecurityResource;
 import com.oceanbase.odc.core.authority.model.SecurityResource;
@@ -64,6 +65,7 @@ import com.oceanbase.odc.core.authority.util.Authenticated;
 import com.oceanbase.odc.core.authority.util.PreAuthenticate;
 import com.oceanbase.odc.core.authority.util.SkipAuthorize;
 import com.oceanbase.odc.core.shared.PreConditions;
+import com.oceanbase.odc.core.shared.Verify;
 import com.oceanbase.odc.core.shared.constant.ConnectionStatus;
 import com.oceanbase.odc.core.shared.constant.ConnectionVisibleScope;
 import com.oceanbase.odc.core.shared.constant.ErrorCodes;
@@ -72,6 +74,8 @@ import com.oceanbase.odc.core.shared.constant.ResourceType;
 import com.oceanbase.odc.core.shared.exception.BadRequestException;
 import com.oceanbase.odc.core.shared.exception.NotFoundException;
 import com.oceanbase.odc.metadb.collaboration.EnvironmentRepository;
+import com.oceanbase.odc.metadb.connection.ConnectionAttributeEntity;
+import com.oceanbase.odc.metadb.connection.ConnectionAttributeRepository;
 import com.oceanbase.odc.metadb.connection.ConnectionConfigRepository;
 import com.oceanbase.odc.metadb.connection.ConnectionEntity;
 import com.oceanbase.odc.metadb.connection.ConnectionSpecs;
@@ -114,6 +118,7 @@ import lombok.extern.slf4j.Slf4j;
 @Validated
 @Authenticated
 public class ConnectionService {
+
     @Autowired
     private ConnectionConfigRepository repository;
 
@@ -183,11 +188,12 @@ public class ConnectionService {
     @Autowired
     private PlatformTransactionManager transactionManager;
 
+    @Autowired
+    private ConnectionAttributeRepository attributeRepository;
 
     private final ConnectionMapper mapper = ConnectionMapper.INSTANCE;
 
     public static final String DEFAULT_MIN_PRIVILEGE = "read";
-
 
     @PreAuthenticate(actions = "create", resourceType = "ODC_CONNECTION", isForAll = true)
     public ConnectionConfig create(@NotNull @Valid ConnectionConfig connection) {
@@ -262,6 +268,10 @@ public class ConnectionService {
             ConnectionEntity entity = modelToEntity(connection);
             ConnectionEntity savedEntity = repository.saveAndFlush(entity);
             created = entityToModel(savedEntity, true);
+            created.setAttributes(connection.getAttributes());
+            List<ConnectionAttributeEntity> attrEntities = connToAttrEntities(created);
+            attrEntities = this.attributeRepository.saveAll(attrEntities);
+            created.setAttributes(attrEntitiesToMap(attrEntities));
         } catch (Exception ex) {
             transactionManager.rollback(transactionStatus);
             throw ex;
@@ -280,6 +290,8 @@ public class ConnectionService {
         log.info("Delete datasource-related permission entity, id={}", id);
         int affectRows = databaseService.deleteByDataSourceId(id);
         log.info("delete datasource-related databases successfully, affectRows={}, id={}", affectRows, id);
+        affectRows = this.attributeRepository.deleteByConnectionId(id);
+        log.info("delete related attributes successfully, affectRows={}, id={}", affectRows, id);
         return connection;
     }
 
@@ -307,6 +319,8 @@ public class ConnectionService {
         log.info("delete datasource-related databases successfully, affectRows={}", affectRows);
         affectRows = repository.deleteByIds(ids);
         log.info("delete datasources successfully, affectRows={}", affectRows);
+        affectRows = this.attributeRepository.deleteByConnectionIds(ids);
+        log.info("delete related attributes successfully, affectRows={}", affectRows);
         return connections;
     }
 
@@ -432,7 +446,6 @@ public class ConnectionService {
         return repository.findIdsByHost(host);
     }
 
-
     @SkipAuthorize("internal usage")
     public List<ConnectionConfig> listAllConnections() {
         return repository.findAll().stream().map(mapper::entityToModel).collect(Collectors.toList());
@@ -535,6 +548,12 @@ public class ConnectionService {
 
         ConnectionConfig updated = entityToModel(savedEntity, true);
         databaseSyncManager.submitSyncDataSourceTask(updated);
+
+        this.attributeRepository.deleteByConnectionId(updated.getId());
+        updated.setAttributes(connection.getAttributes());
+        List<ConnectionAttributeEntity> attrEntities = connToAttrEntities(updated);
+        attrEntities = this.attributeRepository.saveAll(attrEntities);
+        updated.setAttributes(attrEntitiesToMap(attrEntities));
         log.info("Connection updated, connection={}", updated);
         return updated;
     }
@@ -711,7 +730,10 @@ public class ConnectionService {
     }
 
     private ConnectionConfig internalGetSkipUserCheck(Long id, boolean withEnvironment) {
-        return entityToModel(getEntity(id), withEnvironment);
+        ConnectionConfig config = entityToModel(getEntity(id), withEnvironment);
+        List<ConnectionAttributeEntity> entities = this.attributeRepository.findByConnectionId(config.getId());
+        config.setAttributes(attrEntitiesToMap(entities));
+        return config;
     }
 
     private ConnectionEntity getEntity(@NonNull Long id) {
@@ -726,10 +748,8 @@ public class ConnectionService {
             connection.setEnvironmentStyle(environment.getStyle());
             String environmentName = environment.getName();
             if (environmentName.startsWith("${") && environmentName.endsWith("}")) {
-                connection
-                        .setEnvironmentName(
-                                I18n.translate(environmentName.substring(2, environmentName.length() - 1), null,
-                                        LocaleContextHolder.getLocale()));
+                connection.setEnvironmentName(I18n.translate(environmentName.substring(2,
+                        environmentName.length() - 1), null, LocaleContextHolder.getLocale()));
             } else {
                 connection.setEnvironmentName(environmentName);
             }
@@ -739,6 +759,32 @@ public class ConnectionService {
 
     private ConnectionEntity modelToEntity(@NonNull ConnectionConfig model) {
         return mapper.modelToEntity(model);
+    }
+
+    private List<ConnectionAttributeEntity> connToAttrEntities(@NonNull ConnectionConfig model) {
+        Verify.notNull(model.getId(), "ConnectionId");
+        Verify.notNull(model.getOrganizationId(), "OrganizationId");
+        Map<String, Object> attributes = model.getAttributes();
+        if (attributes == null || attributes.size() == 0) {
+            return Collections.emptyList();
+        }
+        return attributes.entrySet().stream().map(entry -> {
+            ConnectionAttributeEntity entity = new ConnectionAttributeEntity();
+            entity.setConnectionId(model.getId());
+            entity.setOrganizationId(model.getOrganizationId());
+            entity.setName(entry.getKey());
+            entity.setContent(JsonUtils.toJson(entry.getValue()));
+            return entity;
+        }).collect(Collectors.toList());
+    }
+
+    private Map<String, Object> attrEntitiesToMap(@NonNull List<ConnectionAttributeEntity> entities) {
+        Map<Long, List<ConnectionAttributeEntity>> map = entities.stream().collect(
+                Collectors.groupingBy(ConnectionAttributeEntity::getConnectionId));
+        Verify.verify(map.size() <= 1, "Attributes's size is illegal, actual: " + map.size());
+        return entities.stream().filter(e -> JsonUtils.fromJson(e.getContent(), Object.class) != null)
+                .collect(Collectors.toMap(ConnectionAttributeEntity::getName, e -> JsonUtils.fromJson(
+                        e.getContent(), Object.class)));
     }
 
     private Long currentOrganizationId() {

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/connection/ConnectionService.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/connection/ConnectionService.java
@@ -763,7 +763,6 @@ public class ConnectionService {
 
     private List<ConnectionAttributeEntity> connToAttrEntities(@NonNull ConnectionConfig model) {
         Verify.notNull(model.getId(), "ConnectionId");
-        Verify.notNull(model.getOrganizationId(), "OrganizationId");
         Map<String, Object> attributes = model.getAttributes();
         if (attributes == null || attributes.size() == 0) {
             return Collections.emptyList();
@@ -771,7 +770,6 @@ public class ConnectionService {
         return attributes.entrySet().stream().map(entry -> {
             ConnectionAttributeEntity entity = new ConnectionAttributeEntity();
             entity.setConnectionId(model.getId());
-            entity.setOrganizationId(model.getOrganizationId());
             entity.setName(entry.getKey());
             entity.setContent(JsonUtils.toJson(entry.getValue()));
             return entity;

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/connection/ConnectionTesting.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/connection/ConnectionTesting.java
@@ -15,7 +15,12 @@
  */
 package com.oceanbase.odc.service.connection;
 
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Statement;
 import java.util.Objects;
+import java.util.Properties;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
@@ -26,6 +31,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.validation.annotation.Validated;
 
 import com.oceanbase.odc.common.util.StringUtils;
+import com.oceanbase.odc.core.datasource.ConnectionInitializer;
 import com.oceanbase.odc.core.shared.PreConditions;
 import com.oceanbase.odc.core.shared.constant.ConnectType;
 import com.oceanbase.odc.core.shared.constant.ConnectionAccountType;
@@ -43,6 +49,7 @@ import com.oceanbase.odc.service.connection.ssl.ConnectionSSLAdaptor;
 import com.oceanbase.odc.service.connection.util.ConnectTypeUtil;
 import com.oceanbase.odc.service.plugin.ConnectionPluginUtil;
 import com.oceanbase.odc.service.session.factory.OBConsoleDataSourceFactory;
+import com.oceanbase.odc.service.session.initializer.SessionCreatedInitializer;
 
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
@@ -177,6 +184,11 @@ public class ConnectionTesting {
             if (type != null && connectType != null && !Objects.equals(connectType, type)) {
                 return ConnectionTestResult.connectTypeMismatch(connectType);
             }
+            try {
+                testInitScript(connectionExtensionPoint, schema, config, accountType);
+            } catch (Exception e) {
+                return ConnectionTestResult.initScriptFailed(e);
+            }
             return testResult;
         } catch (Exception e) {
             return new ConnectionTestResult(TestResult.unknownError(e), null);
@@ -199,6 +211,8 @@ public class ConnectionTesting {
         config.setUsername(req.getUsername());
         config.setPassword(req.getPassword());
         config.setDefaultSchema(req.getDefaultSchema());
+        config.setSessionInitScript(req.getSessionInitScript());
+        config.setJdbcUrlParameters(req.getJdbcUrlParameters());
 
         OBTenantEndpoint endpoint = req.getEndpoint();
         if (Objects.nonNull(endpoint) && OceanBaseAccessMode.IC_PROXY == endpoint.getAccessMode()) {
@@ -212,4 +226,34 @@ public class ConnectionTesting {
         config.setSslConfig(req.getSslConfig());
         return config;
     }
+
+    private void testInitScript(ConnectionExtensionPoint extensionPoint, String schema,
+            ConnectionConfig config, ConnectionAccountType accountType) throws SQLException {
+        if (StringUtils.isEmpty(config.getSessionInitScript())) {
+            return;
+        }
+        String jdbcUrl = extensionPoint.generateJdbcUrl(config.getHost(),
+                config.getPort(), schema, OBConsoleDataSourceFactory.getJdbcParams(config));
+        String username = OBConsoleDataSourceFactory.getUsername(config, accountType);
+        String password = OBConsoleDataSourceFactory.getPassword(config, accountType);
+        Properties properties = new Properties();
+        properties.setProperty("user", username);
+        if (password == null) {
+            properties.setProperty("password", "");
+        } else {
+            properties.setProperty("password", password);
+        }
+        properties.setProperty("socketTimeout", ConnectTypeUtil.REACHABLE_TIMEOUT_MILLIS + "");
+        properties.setProperty("connectTimeout", ConnectTypeUtil.REACHABLE_TIMEOUT_MILLIS + "");
+
+        ConnectionInitializer initializer = new SessionCreatedInitializer(config, false);
+        try (Connection connection = DriverManager.getConnection(jdbcUrl, properties);
+                Statement statement = connection.createStatement()) {
+            if (queryTimeoutSeconds >= 0) {
+                statement.setQueryTimeout(queryTimeoutSeconds);
+            }
+            initializer.init(connection);
+        }
+    }
+
 }

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/connection/model/ConnectionConfig.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/connection/model/ConnectionConfig.java
@@ -17,6 +17,7 @@ package com.oceanbase.odc.service.connection.model;
 
 import java.io.Serializable;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -65,6 +66,8 @@ import lombok.ToString;
 public class ConnectionConfig
         implements SecurityResource, OrganizationIsolated, CloudConnectionConfig, SSLConnectionConfig, Serializable {
 
+    private static final String SESSION_INIT_SCRIPT_KEY = "SESSION_INIT_SCRIPT";
+    private static final String JDBC_URL_PARAMETERS_KEY = "JDBC_URL_PARAMETERS";
     /**
      * 连接ID，对应 /api/v1 的 sid 字段，注意这里和使用连接时的 sid 概念是不一样的，之前版本未区分，另外之前是 String 类型，现在统一为 Long 类型
      */
@@ -279,6 +282,9 @@ public class ConnectionConfig
     @JsonIgnore
     private String OBTenantName;
 
+    @JsonIgnore
+    private Map<String, Object> attributes;
+
     /**
      * SSL 安全设置
      */
@@ -396,6 +402,40 @@ public class ConnectionConfig
             return OdcConstants.DEFAULT_QUERY_TIMEOUT_SECONDS;
         }
         return queryTimeoutSeconds;
+    }
+
+    public String getSessionInitScript() {
+        if (this.attributes == null) {
+            return null;
+        }
+        Object value = this.attributes.get(SESSION_INIT_SCRIPT_KEY);
+        return value == null ? null : value.toString();
+    }
+
+    @SuppressWarnings("all")
+    public Map<String, Object> getJdbcUrlParameters() {
+        if (this.attributes == null) {
+            return new HashMap<>();
+        }
+        Object value = this.attributes.get(JDBC_URL_PARAMETERS_KEY);
+        if (value instanceof Map) {
+            return (Map<String, Object>) value;
+        }
+        return new HashMap<>();
+    }
+
+    public void setSessionInitScript(String sessionInitScript) {
+        if (this.attributes == null) {
+            this.attributes = new HashMap<>();
+        }
+        this.attributes.put(SESSION_INIT_SCRIPT_KEY, sessionInitScript);
+    }
+
+    public void setJdbcUrlParameters(Map<String, Object> jdbcUrlParameters) {
+        if (this.attributes == null) {
+            this.attributes = new HashMap<>();
+        }
+        this.attributes.put(JDBC_URL_PARAMETERS_KEY, jdbcUrlParameters);
     }
 
     @Data

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/connection/model/ConnectionConfig.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/connection/model/ConnectionConfig.java
@@ -283,7 +283,7 @@ public class ConnectionConfig
     private String OBTenantName;
 
     @JsonIgnore
-    private Map<String, Object> attributes;
+    private transient Map<String, Object> attributes;
 
     /**
      * SSL 安全设置

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/connection/model/ConnectionTestResult.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/connection/model/ConnectionTestResult.java
@@ -68,6 +68,14 @@ public class ConnectionTestResult extends TestResult {
         return new ConnectionTestResult(TestResult.unknownError(throwable), null);
     }
 
+    public static ConnectionTestResult initScriptFailed(Throwable throwable) {
+        String message = "Unknown error";
+        if (throwable != null) {
+            message = throwable.getLocalizedMessage();
+        }
+        return fail(ErrorCodes.ConnectionInitScriptFailed, new String[] {message});
+    }
+
     public static ConnectionTestResult connectTypeMismatch() {
         String args = ConnectType.CLOUD_OB_MYSQL.name() + "/" + ConnectType.CLOUD_OB_ORACLE.name();
         return fail(ErrorCodes.ConnectionDatabaseTypeMismatched, new String[] {args});

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/connection/model/TestConnectionReq.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/connection/model/TestConnectionReq.java
@@ -15,6 +15,7 @@
  */
 package com.oceanbase.odc.service.connection.model;
 
+import java.util.Map;
 import java.util.Objects;
 
 import javax.validation.constraints.Max;
@@ -112,6 +113,10 @@ public class TestConnectionReq implements CloudConnectionConfig, SSLConnectionCo
 
     @JsonIgnore
     private SSLFileEntry sslFileEntry;
+
+    private String sessionInitScript;
+
+    private Map<String, Object> jdbcUrlParameters;
 
     public DialectType getDialectType() {
         if (Objects.nonNull(this.type)) {

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/connection/util/ConnectTypeUtil.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/connection/util/ConnectTypeUtil.java
@@ -49,7 +49,7 @@ public class ConnectTypeUtil {
      * {@code oceanbase.cloud} 结尾，以此为标志判断是否处于多云环境
      */
     public static final String[] CLOUD_SUFFIX = new String[] {"oceanbase.aliyuncs.com", "oceanbase.cloud"};
-    private static final Integer REACHABLE_TIMEOUT_MILLIS = 10000;
+    public static final Integer REACHABLE_TIMEOUT_MILLIS = 10000;
 
     public static ConnectType getConnectType(@NonNull String jdbcUrl, @NonNull String username,
             String password, int queryTimeout) throws SQLException {

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/session/factory/DruidDataSourceFactory.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/session/factory/DruidDataSourceFactory.java
@@ -15,16 +15,22 @@
  */
 package com.oceanbase.odc.service.session.factory;
 
-import java.util.Collections;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.Map;
 
 import javax.sql.DataSource;
 
 import com.alibaba.druid.pool.DruidDataSource;
 import com.oceanbase.odc.core.datasource.CloneableDataSourceFactory;
+import com.oceanbase.odc.core.datasource.ConnectionInitializer;
 import com.oceanbase.odc.core.datasource.DataSourceFactory;
 import com.oceanbase.odc.core.shared.constant.ConnectionAccountType;
 import com.oceanbase.odc.service.connection.model.ConnectionConfig;
 import com.oceanbase.odc.service.connection.util.ConnectionMapper;
+import com.oceanbase.odc.service.session.initializer.SessionCreatedInitializer;
+
+import lombok.NonNull;
 
 /**
  * {@link DruidDataSourceFactory} used to init {@link DruidDataSource}
@@ -36,6 +42,7 @@ import com.oceanbase.odc.service.connection.util.ConnectionMapper;
  * @see OBConsoleDataSourceFactory
  */
 public class DruidDataSourceFactory extends OBConsoleDataSourceFactory {
+
     private long queryTimeOut;
 
     public DruidDataSourceFactory(ConnectionConfig connectionConfig, ConnectionAccountType accountType,
@@ -53,7 +60,7 @@ public class DruidDataSourceFactory extends OBConsoleDataSourceFactory {
         String jdbcUrl = getJdbcUrl();
         String username = getUsername();
         String password = getPassword();
-        DruidDataSource dataSource = new DruidDataSource();
+        DruidDataSource dataSource = new InnerDataSource(new SessionCreatedInitializer(connectionConfig));
         dataSource.setUrl(jdbcUrl);
         dataSource.setUsername(username);
         dataSource.setPassword(password);
@@ -71,9 +78,6 @@ public class DruidDataSourceFactory extends OBConsoleDataSourceFactory {
         dataSource.setDefaultAutoCommit(true);
         dataSource.setMaxActive(5);
         dataSource.setInitialSize(2);
-        if (queryTimeOut > 0 && getConnectType().getDialectType().isOceanbase()) {
-            dataSource.setConnectionInitSqls(Collections.singletonList("SET OB_QUERY_TIMEOUT=" + queryTimeOut));
-        }
         // wait for get available connection from connection pool
         dataSource.setMaxWait(10_000L);
     }
@@ -82,6 +86,29 @@ public class DruidDataSourceFactory extends OBConsoleDataSourceFactory {
     public CloneableDataSourceFactory deepCopy() {
         ConnectionMapper mapper = ConnectionMapper.INSTANCE;
         return new DruidDataSourceFactory(mapper.clone(connectionConfig), this.accountType, queryTimeOut);
+    }
+
+    static class InnerDataSource extends DruidDataSource {
+
+        private final ConnectionInitializer initializer;
+
+        private InnerDataSource(@NonNull ConnectionInitializer initializer) {
+            this.initializer = initializer;
+        }
+
+        @Override
+        public void initPhysicalConnection(Connection conn, Map<String, Object> variables,
+                Map<String, Object> globalVariables) throws SQLException {
+            try {
+                super.initPhysicalConnection(conn, variables, globalVariables);
+            } finally {
+                try {
+                    this.initializer.init(conn);
+                } catch (Exception e) {
+                    // eat exception
+                }
+            }
+        }
     }
 
 }

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/session/factory/OBConsoleDataSourceFactory.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/session/factory/OBConsoleDataSourceFactory.java
@@ -21,7 +21,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.stream.Collectors;
 
 import javax.sql.DataSource;
 
@@ -46,6 +45,7 @@ import com.oceanbase.odc.service.connection.model.ConnectionConfig.SSLFileEntry;
 import com.oceanbase.odc.service.connection.model.OBTenantEndpoint;
 import com.oceanbase.odc.service.connection.util.ConnectionMapper;
 import com.oceanbase.odc.service.plugin.ConnectionPluginUtil;
+import com.oceanbase.odc.service.session.initializer.SessionCreatedInitializer;
 
 import lombok.NonNull;
 import lombok.Setter;
@@ -172,7 +172,11 @@ public class OBConsoleDataSourceFactory implements CloneableDataSourceFactory {
         } else {
             jdbcUrlParams.put("useSSL", "false");
         }
-
+        connectionConfig.getJdbcUrlParameters().forEach((key, value) -> {
+            if (value != null) {
+                jdbcUrlParams.putIfAbsent(key, value.toString());
+            }
+        });
         return jdbcUrlParams;
     }
 
@@ -194,6 +198,7 @@ public class OBConsoleDataSourceFactory implements CloneableDataSourceFactory {
             if (!CollectionUtils.isEmpty(initializers)) {
                 initializers.forEach(dataSource::addInitializer);
             }
+            dataSource.addInitializer(new SessionCreatedInitializer(connectionConfig));
         }
         return dataSource;
     }
@@ -280,8 +285,4 @@ public class OBConsoleDataSourceFactory implements CloneableDataSourceFactory {
         return defaultSchema;
     }
 
-    private static String getJdbcUrlParameters(Map<String, String> jdbcUrlParams) {
-        return jdbcUrlParams.entrySet().stream().map(entry -> entry.getKey() + "=" + entry.getValue())
-                .collect(Collectors.joining("&"));
-    }
 }

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/session/initializer/SessionCreatedInitializer.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/session/initializer/SessionCreatedInitializer.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2023 OceanBase.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.oceanbase.odc.service.session.initializer;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.List;
+
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.lang.StringUtils;
+
+import com.oceanbase.odc.core.datasource.ConnectionInitializer;
+import com.oceanbase.odc.core.sql.split.SqlCommentProcessor;
+import com.oceanbase.odc.service.connection.model.ConnectionConfig;
+
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * {@link SessionCreatedInitializer}
+ *
+ * @author yh263208
+ * @date 2023-09-12 17:31
+ * @since ODC_release_4.2.2
+ */
+@Slf4j
+public class SessionCreatedInitializer implements ConnectionInitializer {
+
+    private final ConnectionConfig connectionConfig;
+    private final boolean eatException;
+
+    public SessionCreatedInitializer(ConnectionConfig connectionConfig) {
+        this(connectionConfig, true);
+    }
+
+    public SessionCreatedInitializer(@NonNull ConnectionConfig connectionConfig, boolean eatException) {
+        this.eatException = eatException;
+        this.connectionConfig = connectionConfig;
+    }
+
+    @Override
+    public void init(Connection connection) throws SQLException {
+        long start = System.currentTimeMillis();
+        String initScript = connectionConfig.getSessionInitScript();
+        if (StringUtils.isEmpty(initScript)) {
+            return;
+        }
+        List<String> sqls = SqlCommentProcessor.removeSqlComments(
+                initScript, ";", connectionConfig.getDialectType(), false);
+        if (CollectionUtils.isEmpty(sqls)) {
+            return;
+        }
+        for (String sql : sqls) {
+            try (Statement statement = connection.createStatement()) {
+                statement.setQueryTimeout(3);
+                statement.execute(sql);
+            } catch (SQLException e) {
+                log.warn("Failed to execute init sql, sql={}", sql, e);
+                if (!this.eatException) {
+                    throw e;
+                }
+            }
+        }
+        log.info("Init connection by custom script succeed, sqlCount={}, cost={} millis",
+                sqls.size(), System.currentTimeMillis() - start);
+    }
+
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines.
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request.
3. Ensure you have added or ran the appropriate tests for your PR.
5. If the PR is unfinished, you may add or remove a WIP or [WIP] prefix to your pull request title.
-->

#### What type of PR is this?

type-feature
<!--
Add one of the following kinds:
type-bug
type-feature
type-docs
etc.

Optionally add one or more of the following kinds if applicable:
module-resultset
module-sql execution
etc.
-->

#### What this PR does / why we need it:

this pr add initialization configuration capabilities for data sources.

User can give a sql script that executed when jdbc connection created to init the connection. 

eg. if you want to set your sql execution timeout, you can give a sql script like this:
```SQL
set session ob_query_timeout=60000000;
set session ob_trx_timeout=60000000;
```
odc will execute them one by one when you want to create a session on this datasource.

odc connects to observer by jdbc, if you want to add some your custom jdbc parameters, you can to this by this pr. odc will append your custom jdbc parameters to the url.

this init config will work in every session creation scenario.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #93 

#### Special notes for your reviewer:

I create a new table named `connec_connection_attribute`, this table will be not only used by this feature, but also used in other scenario.

the `SessionCreatedInitializer` is used to execute user's custom sql init script, and `OBConsoleDataSourceFactory#getJdbcParams` is used to append users' custom jdbc parameters to odc's default parameters, odc's jdbc url parameters got the highest priority.

this init for connection will work in two scenarios:
1. session creation: if you want to create a session for a datasource, this init will work.
2. datasource test: when you test a datesource,  these init measures will also work.

#### Additional documentation e.g., usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```