### PR TITLE
fix(data-security): exist sensitive is not filtered and view desensitization data failed

### DIFF
--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/datasecurity/extractor/OBColumnExtractor.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/datasecurity/extractor/OBColumnExtractor.java
@@ -731,14 +731,16 @@ public class OBColumnExtractor implements ColumnExtractor {
     private String processIdentifier(String identifier) {
         if (Objects.nonNull(dialectType) && dialectType.isMysql()) {
             String unquoted = StringUtils.unquoteMySqlIdentifier(identifier);
-            return StringUtils.isBlank(unquoted) ? unquoted : unquoted.toLowerCase();
+            if (StringUtils.isBlank(unquoted)) {
+                return unquoted;
+            }
+            return StringUtils.checkMysqlIdentifierQuoted(identifier) ? unquoted : unquoted.toLowerCase();
         } else if (dialectType == DialectType.OB_ORACLE) {
             String unquoted = StringUtils.unquoteOracleIdentifier(identifier);
             if (StringUtils.isBlank(unquoted)) {
                 return unquoted;
-            } else {
-                return StringUtils.checkOracleIdentifierQuoted(identifier) ? unquoted : unquoted.toUpperCase();
             }
+            return StringUtils.checkOracleIdentifierQuoted(identifier) ? unquoted : unquoted.toUpperCase();
         } else {
             throw new IllegalStateException("Unknown dialect type: " + dialectType);
         }

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/datasecurity/extractor/OBColumnExtractor.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/datasecurity/extractor/OBColumnExtractor.java
@@ -410,11 +410,11 @@ public class OBColumnExtractor implements ColumnExtractor {
                     // 2.1. 列名为 *，即只要库名和表名匹配的都输出
                     // 先查 fromTable，再查 fromTable#tableList
                     for (LogicalTable table : tables) {
-                        if (tableName.equals(table.getAlias())
-                                || tableName.equals(table.getName())) {
+                        if (tableName.equalsIgnoreCase(table.getAlias())
+                                || tableName.equalsIgnoreCase(table.getName())) {
                             for (LogicalColumn column : table.getColumnList()) {
                                 if (StringUtils.isNotBlank(databaseName)
-                                        && !databaseName.equals(column.getDatabaseName())) {
+                                        && !databaseName.equalsIgnoreCase(column.getDatabaseName())) {
                                     break;
                                 }
                                 result.add(inheritColumn(column));
@@ -425,11 +425,11 @@ public class OBColumnExtractor implements ColumnExtractor {
                     // 2.2 列名不为 *，即需要唯一确定一列（这里暂且不处理列名冲突的情况，因为运行此代码的前提是 SQL 语句被成功执行）
                     // 先查 fromTable，再查 fromTable#tableList
                     for (LogicalTable table : tables) {
-                        if (tableName.equals(table.getAlias())
-                                || tableName.equals(table.getName())) {
+                        if (tableName.equalsIgnoreCase(table.getAlias())
+                                || tableName.equalsIgnoreCase(table.getName())) {
                             for (LogicalColumn column : table.getColumnList()) {
                                 if (StringUtils.isNotBlank(databaseName)
-                                        && !databaseName.equals(column.getDatabaseName())) {
+                                        && !databaseName.equalsIgnoreCase(column.getDatabaseName())) {
                                     break;
                                 }
                                 if (StringUtils.firstNonBlank(column.getAlias(), column.getName())
@@ -575,7 +575,7 @@ public class OBColumnExtractor implements ColumnExtractor {
             for (int j = 0; j < rightColumns.size(); j++) {
                 LogicalColumn rightColumn = rightColumns.get(j);
                 String rightLabel = StringUtils.firstNonBlank(rightColumn.getAlias(), rightColumn.getName());
-                if (leftLabel.equals(rightLabel)) {
+                if (leftLabel.equalsIgnoreCase(rightLabel)) {
                     LogicalColumn c = LogicalColumn.empty();
                     c.setName(leftLabel);
                     c.setType(ColumnType.JOIN);
@@ -691,7 +691,7 @@ public class OBColumnExtractor implements ColumnExtractor {
     private List<LogicalColumn> getColumnsFromCteTable(String tableName) throws NotFoundException {
         List<LogicalColumn> result = new ArrayList<>();
         for (LogicalTable table : cteTables) {
-            if (tableName.equals(table.getName())) {
+            if (tableName.equalsIgnoreCase(table.getName())) {
                 for (LogicalColumn column : table.getColumnList()) {
                     result.add(inheritColumn(column));
                 }

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/datasecurity/extractor/model/DBColumn.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/datasecurity/extractor/model/DBColumn.java
@@ -15,9 +15,11 @@
  */
 package com.oceanbase.odc.service.datasecurity.extractor.model;
 
+import java.util.Objects;
+
+
 import lombok.AllArgsConstructor;
 import lombok.Data;
-import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 
 /**
@@ -25,7 +27,6 @@ import lombok.NoArgsConstructor;
  * @date 2023/6/12 15:23
  */
 @Data
-@EqualsAndHashCode
 @AllArgsConstructor
 @NoArgsConstructor
 public class DBColumn {
@@ -40,4 +41,21 @@ public class DBColumn {
         column.setColumnName(logicalColumn.getName());
         return column;
     }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(databaseName.toLowerCase(), tableName.toLowerCase(), columnName.toLowerCase());
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj instanceof DBColumn) {
+            DBColumn other = (DBColumn) obj;
+            return Objects.equals(databaseName.toLowerCase(), other.databaseName.toLowerCase())
+                    && Objects.equals(tableName.toLowerCase(), other.tableName.toLowerCase())
+                    && Objects.equals(columnName.toLowerCase(), other.columnName.toLowerCase());
+        }
+        return false;
+    }
+
 }

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/datasecurity/extractor/model/DBColumn.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/datasecurity/extractor/model/DBColumn.java
@@ -17,7 +17,6 @@ package com.oceanbase.odc.service.datasecurity.extractor.model;
 
 import java.util.Objects;
 
-
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/datasecurity/model/SensitiveColumnMeta.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/datasecurity/model/SensitiveColumnMeta.java
@@ -22,7 +22,6 @@ import com.oceanbase.odc.metadb.datasecurity.SensitiveColumnEntity;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;
-import lombok.EqualsAndHashCode;
 
 /**
  * @author gaoda.xy

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/datasecurity/model/SensitiveColumnMeta.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/datasecurity/model/SensitiveColumnMeta.java
@@ -29,7 +29,6 @@ import lombok.EqualsAndHashCode;
  * @date 2023/9/14 10:33
  */
 @Data
-@EqualsAndHashCode
 @AllArgsConstructor
 public class SensitiveColumnMeta {
     private Long databaseId;

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/datasecurity/model/SensitiveColumnMeta.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/datasecurity/model/SensitiveColumnMeta.java
@@ -16,6 +16,8 @@
 
 package com.oceanbase.odc.service.datasecurity.model;
 
+import java.util.Objects;
+
 import com.oceanbase.odc.metadb.datasecurity.SensitiveColumnEntity;
 
 import lombok.AllArgsConstructor;
@@ -38,6 +40,22 @@ public class SensitiveColumnMeta {
         this.databaseId = entity.getDatabaseId();
         this.tableName = entity.getTableName();
         this.columnName = entity.getColumnName();
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(databaseId, tableName.toLowerCase(), columnName.toLowerCase());
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj instanceof SensitiveColumnMeta) {
+            SensitiveColumnMeta other = (SensitiveColumnMeta) obj;
+            return Objects.equals(databaseId, other.databaseId)
+                    && Objects.equals(tableName.toLowerCase(), other.tableName.toLowerCase())
+                    && Objects.equals(columnName.toLowerCase(), other.columnName.toLowerCase());
+        }
+        return false;
     }
 
 }


### PR DESCRIPTION
#### What type of PR is this?
type-bug
module-data security

#### What this PR does / why we need it:
There are two bug:
1. If the table name or database name is uppercase in MySQL  mode, the data masking will failed. The root cause is that ODC will change DB object name to lowcase in MySQL mode. If the table name is uppercase in DB Server, then ODC cannot find the right table. 
2. The exists sensitive is not filtered.
This PR fix above two bugs. Table name and column name stored in ODC metaDB is case-insensitive. So ODC cannot deal with sensitive columns with same name in different case. So, ODC will  defaultly change the object name to lowcase in MySQL mode and uppercase in Oracle mode. If the object name is quoted, then ODC will keep the case themselves.

#### Which issue(s) this PR fixes:
Fixes #475 

#### Special notes for your reviewer:
Self-test passed