### PR TITLE
feat: make odc adapt to OceanBase 4.2

### DIFF
--- a/server/odc-core/src/main/java/com/oceanbase/odc/core/shared/model/TraceSpan.java
+++ b/server/odc-core/src/main/java/com/oceanbase/odc/core/shared/model/TraceSpan.java
@@ -21,7 +21,6 @@ import java.time.format.DateTimeFormatterBuilder;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
-import java.util.Map;
 
 import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -44,7 +43,7 @@ public class TraceSpan {
     @JsonAlias("logs")
     private String logs;
     @JsonAlias("tags")
-    private List<Map<String, Object>> tags;
+    private List<Object> tags;
     @JsonAlias("elapse")
     private Long elapseMicroSeconds;
     @JsonAlias("parent")

--- a/server/odc-core/src/main/java/com/oceanbase/odc/core/sql/util/FullLinkTraceUtil.java
+++ b/server/odc-core/src/main/java/com/oceanbase/odc/core/sql/util/FullLinkTraceUtil.java
@@ -70,7 +70,7 @@ public class FullLinkTraceUtil {
                     return v;
                 });
             }
-            if (traceId == null && findLogTraceId(span.getTags()) != null) {
+            if (traceId == null) {
                 traceId = findLogTraceId(span.getTags());
             }
             span.setNode(Node.from(span.getSpanName()));

--- a/server/odc-core/src/main/java/com/oceanbase/odc/core/sql/util/FullLinkTraceUtil.java
+++ b/server/odc-core/src/main/java/com/oceanbase/odc/core/sql/util/FullLinkTraceUtil.java
@@ -18,6 +18,7 @@ package com.oceanbase.odc.core.sql.util;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -31,6 +32,8 @@ import com.oceanbase.odc.core.shared.model.TraceSpan.Node;
 import com.oceanbase.odc.core.sql.execute.model.SqlExecTime;
 
 public class FullLinkTraceUtil {
+
+    private final static String TRACE_ID_KEY = "log_trace_id";
 
     public static SqlExecTime getFullLinkTraceDetail(Statement statement) throws SQLException {
         OceanBaseConnection connection = (OceanBaseConnection) statement.getConnection();
@@ -67,8 +70,8 @@ public class FullLinkTraceUtil {
                     return v;
                 });
             }
-            if (traceId == null && parseLogTraceId(span.getTags()) != null) {
-                traceId = parseLogTraceId(span.getTags());
+            if (traceId == null && findLogTraceId(span.getTags()) != null) {
+                traceId = findLogTraceId(span.getTags());
             }
             span.setNode(Node.from(span.getSpanName()));
             if ("com_query_process".equals(span.getSpanName())) {
@@ -89,13 +92,18 @@ public class FullLinkTraceUtil {
         return execDetail;
     }
 
-    private static String parseLogTraceId(List<Map<String, Object>> tags) {
-        if (tags == null) {
+    private static String findLogTraceId(Object tags) {
+        if (tags instanceof Map) {
+            if (((Map<?, ?>) tags).containsKey(TRACE_ID_KEY)) {
+                return ((Map<?, ?>) tags).get(TRACE_ID_KEY).toString();
+            }
             return null;
-        }
-        for (Map<String, Object> tag : tags) {
-            if (tag.containsKey("log_trace_id")) {
-                return (String) tag.get("log_trace_id");
+        } else if (tags instanceof Collection) {
+            for (Object obj : (Collection<?>) tags) {
+                String value = findLogTraceId(obj);
+                if (value != null) {
+                    return value;
+                }
             }
         }
         return null;

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/db/DBRecyclebinService.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/db/DBRecyclebinService.java
@@ -138,7 +138,8 @@ public class DBRecyclebinService {
             }
             sqlBuilder.identifier(recycleObject.getObjName()).append(" to before drop");
             if (StringUtils.isNotBlank(recycleObject.getNewName())) {
-                sqlBuilder.append(" rename to ").identifier(recycleObject.getNewName());
+                sqlBuilder.append(" rename to ").identifier(recycleObject.getSchema())
+                        .append(".").identifier(recycleObject.getNewName());
             }
             sqlBuilder.append(";\r\n");
         }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines.
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request.
3. Ensure you have added or ran the appropriate tests for your PR.
5. If the PR is unfinished, you may add or remove a WIP or [WIP] prefix to your pull request title.
-->

#### What type of PR is this?

type-feature
feat-adapt to ob 4.2
<!--
Add one of the following kinds:
type-bug
type-feature
type-docs
etc.

Optionally add one or more of the following kinds if applicable:
module-resultset
module-sql execution
etc.
-->

#### What this PR does / why we need it:

this pr makes odc adapt to OceanBase 4.2. we do things in this pr as follow:

1. add schema in generated flashback sql.

the front end will create a new session when using recyclebin so that the observer will flashback the object to the schema where the connection connect to.

To avoid flashbacking a db object to an uncertain schema, we should add schema to the generated sql. 

Here is an example:
```SQL
flashback table `abcd` to before drop rename to `new_name`; -- before
flashback table `abcd` to before drop rename to `schema`.`new_name`; -- after
```

2. refactor the pojo object's (`TraceSpan`) structure of full-link trace and convert the field `tags`'s type from `List<Map<String, Object>>` to `List<Object>`. 

we will get the json string on OceanBase 4.1 when `show trace format='json'` is executed:

```json
[
    {
        "logs": null,
        "tags": [
           ...
            {
                "log_trace_id": "Y2F170BA2D939-000602A2DA7F897E-0-0"
            }
        ],
        ...
```

we do the same thing on OceanBase 4.2.1 and get a json string as follow:

```json
[
    {
        "logs": null,
        "tags": [
            [
                ...
                {
                    "log_trace_id": "Y2FB70BA2D939-000608DF99AE2C76-0-0"
                }
            ]
        ],
       ...
```

as you can see: the structure of the json has been changed, and that is why the full-link trace does not work on OceanBase 4.2.

I change the structure of the pojo object and find another way to avoid this change.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #94 #506 

#### Special notes for your reviewer:

<!--
This section is used to describe how this PR is implemented. 
If this is a PR that fixes a bug, this section describes how the bug was fixed.
If it's a new feature, this section briefly describes how to implement the new feature.
etc.
-->

#### Additional documentation e.g., usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```