### PR TITLE
fix(unit-test): unsafe log output and unstable test case

### DIFF
--- a/server/integration-test/src/test/java/com/oceanbase/odc/service/flow/ExpiredDocumentProviderTest.java
+++ b/server/integration-test/src/test/java/com/oceanbase/odc/service/flow/ExpiredDocumentProviderTest.java
@@ -116,7 +116,7 @@ public class ExpiredDocumentProviderTest {
         Assert.assertTrue(file1.createNewFile());
         Assert.assertTrue(file1.isFile());
 
-        Thread.sleep(1000);
+        Thread.sleep(100);
 
         TestExpiredDocumentProvider provider = new TestExpiredDocumentProvider(1, TimeUnit.MILLISECONDS, rootDir);
         List<File> fileList = provider.provide();

--- a/server/integration-test/src/test/java/com/oceanbase/odc/service/flow/ExpiredDocumentProviderTest.java
+++ b/server/integration-test/src/test/java/com/oceanbase/odc/service/flow/ExpiredDocumentProviderTest.java
@@ -103,7 +103,7 @@ public class ExpiredDocumentProviderTest {
     }
 
     @Test
-    public void provide_BothExpired_ReturnAll() throws IOException {
+    public void provide_BothExpired_ReturnAll() throws IOException, InterruptedException {
         File rootDir = new File(ROOT_FILE_DIR);
         FileUtils.forceMkdir(rootDir);
         Assert.assertTrue(rootDir.exists());
@@ -115,6 +115,8 @@ public class ExpiredDocumentProviderTest {
         File file1 = new File(rootDir.getAbsolutePath() + "/read1.txt");
         Assert.assertTrue(file1.createNewFile());
         Assert.assertTrue(file1.isFile());
+
+        Thread.sleep(1000);
 
         TestExpiredDocumentProvider provider = new TestExpiredDocumentProvider(1, TimeUnit.MILLISECONDS, rootDir);
         List<File> fileList = provider.provide();

--- a/server/odc-common/src/test/java/com/oceanbase/odc/common/util/SystemUtilsTest.java
+++ b/server/odc-common/src/test/java/com/oceanbase/odc/common/util/SystemUtilsTest.java
@@ -21,38 +21,29 @@ import java.util.Properties;
 import org.junit.Assert;
 import org.junit.Test;
 
-import com.oceanbase.odc.common.json.JsonUtils;
-
-import lombok.extern.slf4j.Slf4j;
-
-@Slf4j
 public class SystemUtilsTest {
 
     @Test
     public void getHostName_NotEmpty() {
         String hostName = SystemUtils.getHostName();
-        log.info("hostName={}", hostName);
         Assert.assertTrue(hostName.length() > 0);
     }
 
     @Test
     public void getLocalIpAddress_NotEmpty() {
         String localIpAddress = SystemUtils.getLocalIpAddress();
-        log.info("localIpAddress={}", localIpAddress);
         Assert.assertTrue(localIpAddress.length() > 0);
     }
 
     @Test
     public void getSystemEnv() {
         Map<String, String> systemEnv = SystemUtils.getSystemEnv();
-        log.info("systemEnv:\n{}", JsonUtils.prettyToJson(systemEnv));
         Assert.assertFalse(systemEnv.isEmpty());
     }
 
     @Test
     public void getSystemProperties() {
         Properties systemProperties = SystemUtils.getSystemProperties();
-        log.info("systemProperties:\n{}", JsonUtils.prettyToJson(systemProperties));
         Assert.assertFalse(systemProperties.isEmpty());
     }
 


### PR DESCRIPTION
#### What type of PR is this?
type-bug
module-unit test

#### What this PR does / why we need it:
The `SystemUtilsTest` has unsafe log output, which will expose sensitive env variables.
The `ExpiredDocumentProviderTest#provide_BothExpired_ReturnAll` is unstable due to not strictly logical.
This PR fix these two issues.