### PR TITLE
fix(db-browser): cannot get table charset in native mysql mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,8 +16,8 @@ build-resource/
 target
 _build/
 conf/
-plugins/
-starters/
+/plugins
+/starters
 server/odc-server/src/main/resources/static/
 server/odc-common/src/test/resources/generate-input.properties
 server/integration-test/oss_temp_dir/

--- a/libs/db-browser/src/main/java/com/oceanbase/tools/dbbrowser/schema/mysql/MySQLNoGreaterThan5740SchemaAccessor.java
+++ b/libs/db-browser/src/main/java/com/oceanbase/tools/dbbrowser/schema/mysql/MySQLNoGreaterThan5740SchemaAccessor.java
@@ -594,7 +594,6 @@ public class MySQLNoGreaterThan5740SchemaAccessor implements DBSchemaAccessor {
                 columnNames.add(rs.getString("COLUMN_NAME"));
                 index.setColumnNames(columnNames);
                 index.setGlobal(true);
-                handleIndexAvailability(index, rs.getString("COMMENT"));
                 fullIndexName2Index.put(tableName + indexName, index);
             } else {
                 fullIndexName2Index.get(tableName + indexName).getColumnNames()

--- a/libs/db-browser/src/main/java/com/oceanbase/tools/dbbrowser/schema/mysql/MySQLNoGreaterThan5740SchemaAccessor.java
+++ b/libs/db-browser/src/main/java/com/oceanbase/tools/dbbrowser/schema/mysql/MySQLNoGreaterThan5740SchemaAccessor.java
@@ -1005,7 +1005,11 @@ public class MySQLNoGreaterThan5740SchemaAccessor implements DBSchemaAccessor {
     public DBTableOptions getTableOptions(String schemaName, String tableName, @lombok.NonNull String ddl) {
         DBTableOptions dbTableOptions = new DBTableOptions();
         obtainOptionsByQuery(schemaName, tableName, dbTableOptions);
-        obtainOptionsByParser(dbTableOptions, ddl);
+        try {
+            obtainOptionsByParser(dbTableOptions, ddl);
+        } catch (Exception e) {
+            log.warn("Failed to get table options by parse table ddl, message={}", e.getMessage());
+        }
         return dbTableOptions;
     }
 
@@ -1024,14 +1028,17 @@ public class MySQLNoGreaterThan5740SchemaAccessor implements DBSchemaAccessor {
         SQLParser sqlParser = new OBMySQLParser();
         CreateTable stmt = (CreateTable) sqlParser.parse(new StringReader(ddl));
         TableOptions options = stmt.getTableOptions();
-        dbTableOptions.setCharsetName(options.getCharset());
-        dbTableOptions.setRowFormat(options.getRowFormat());
-        dbTableOptions.setCompressionOption(options.getCompression());
-        dbTableOptions.setReplicaNum(options.getReplicaNum());
-        dbTableOptions.setBlockSize(options.getBlockSize());
-        dbTableOptions.setUseBloomFilter(options.getUseBloomFilter());
-        dbTableOptions
-                .setTabletSize(Objects.nonNull(options.getTabletSize()) ? options.getTabletSize().longValue() : null);
+        if (Objects.nonNull(options)) {
+            dbTableOptions.setCharsetName(options.getCharset());
+            dbTableOptions.setRowFormat(options.getRowFormat());
+            dbTableOptions.setCompressionOption(options.getCompression());
+            dbTableOptions.setReplicaNum(options.getReplicaNum());
+            dbTableOptions.setBlockSize(options.getBlockSize());
+            dbTableOptions.setUseBloomFilter(options.getUseBloomFilter());
+            dbTableOptions
+                    .setTabletSize(
+                            Objects.nonNull(options.getTabletSize()) ? options.getTabletSize().longValue() : null);
+        }
     }
 
     @Override

--- a/libs/db-browser/src/main/java/com/oceanbase/tools/dbbrowser/schema/mysql/OBMySQLSchemaAccessor.java
+++ b/libs/db-browser/src/main/java/com/oceanbase/tools/dbbrowser/schema/mysql/OBMySQLSchemaAccessor.java
@@ -29,6 +29,7 @@ import com.oceanbase.tools.dbbrowser.model.DBIndexAlgorithm;
 import com.oceanbase.tools.dbbrowser.model.DBObjectIdentity;
 import com.oceanbase.tools.dbbrowser.model.DBObjectType;
 import com.oceanbase.tools.dbbrowser.model.DBObjectWarningDescriptor;
+import com.oceanbase.tools.dbbrowser.model.DBTable.DBTableOptions;
 import com.oceanbase.tools.dbbrowser.model.DBTableColumn;
 import com.oceanbase.tools.dbbrowser.model.DBTableIndex;
 import com.oceanbase.tools.dbbrowser.parser.SqlParser;
@@ -133,6 +134,13 @@ public class OBMySQLSchemaAccessor extends MySQLNoGreaterThan5740SchemaAccessor 
         }
 
         return results;
+    }
+
+    @Override
+    public DBTableOptions getTableOptions(String schemaName, String tableName, @lombok.NonNull String ddl) {
+        DBTableOptions dbTableOptions = super.getTableOptions(schemaName, tableName, ddl);
+        DBSchemaAccessorUtil.obtainOptionsByParse(dbTableOptions, ddl);
+        return dbTableOptions;
     }
 
     @Override

--- a/libs/db-browser/src/main/java/com/oceanbase/tools/dbbrowser/schema/mysql/OBMySQLSchemaAccessor.java
+++ b/libs/db-browser/src/main/java/com/oceanbase/tools/dbbrowser/schema/mysql/OBMySQLSchemaAccessor.java
@@ -29,7 +29,6 @@ import com.oceanbase.tools.dbbrowser.model.DBIndexAlgorithm;
 import com.oceanbase.tools.dbbrowser.model.DBObjectIdentity;
 import com.oceanbase.tools.dbbrowser.model.DBObjectType;
 import com.oceanbase.tools.dbbrowser.model.DBObjectWarningDescriptor;
-import com.oceanbase.tools.dbbrowser.model.DBTable.DBTableOptions;
 import com.oceanbase.tools.dbbrowser.model.DBTableColumn;
 import com.oceanbase.tools.dbbrowser.model.DBTableIndex;
 import com.oceanbase.tools.dbbrowser.parser.SqlParser;
@@ -134,13 +133,6 @@ public class OBMySQLSchemaAccessor extends MySQLNoGreaterThan5740SchemaAccessor 
         }
 
         return results;
-    }
-
-    @Override
-    public DBTableOptions getTableOptions(String schemaName, String tableName, @lombok.NonNull String ddl) {
-        DBTableOptions dbTableOptions = super.getTableOptions(schemaName, tableName, ddl);
-        DBSchemaAccessorUtil.obtainOptionsByParse(dbTableOptions, ddl);
-        return dbTableOptions;
     }
 
     @Override

--- a/libs/db-browser/src/test/java/com/oceanbase/tools/dbbrowser/schema/MySQLNoGreaterThan5740SchemaAccessorTest.java
+++ b/libs/db-browser/src/test/java/com/oceanbase/tools/dbbrowser/schema/MySQLNoGreaterThan5740SchemaAccessorTest.java
@@ -162,7 +162,6 @@ public class MySQLNoGreaterThan5740SchemaAccessorTest extends BaseTestEnv {
         Map<String, List<DBTableIndex>> map = accessor.listTableIndexes(getMySQLDataBaseName());
         Assert.assertNotNull(map);
         Assert.assertTrue(map.size() > 0);
-        Assert.assertTrue(map.get("test_index_type").get(0).getAvailable());
     }
 
     @Test

--- a/libs/db-browser/src/test/java/com/oceanbase/tools/dbbrowser/schema/MySQLNoGreaterThan5740SchemaAccessorTest.java
+++ b/libs/db-browser/src/test/java/com/oceanbase/tools/dbbrowser/schema/MySQLNoGreaterThan5740SchemaAccessorTest.java
@@ -21,6 +21,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 import org.junit.AfterClass;
@@ -62,6 +63,7 @@ public class MySQLNoGreaterThan5740SchemaAccessorTest extends BaseTestEnv {
     private static List<MySQLNoGreaterThan5740SchemaAccessorTest.DataType> verifyDataTypes = new ArrayList<>();
     private static List<MySQLNoGreaterThan5740SchemaAccessorTest.ColumnAttributes> columnAttributes = new ArrayList<>();
     private static JdbcTemplate jdbcTemplate = new JdbcTemplate(getMySQLDataSource());
+    private static DBSchemaAccessor accessor = new DBSchemaAccessors(getMySQLDataSource()).createMysql();
 
     @BeforeClass
     public static void setUp() throws Exception {
@@ -96,21 +98,18 @@ public class MySQLNoGreaterThan5740SchemaAccessorTest extends BaseTestEnv {
 
     @Test
     public void getDatabase_Success() {
-        DBSchemaAccessor accessor = new DBSchemaAccessors(getMySQLDataSource()).createMysql();
         DBDatabase database = accessor.getDatabase(getMySQLDataBaseName());
         Assert.assertNotNull(database);
     }
 
     @Test
     public void listDatabases_Success() {
-        DBSchemaAccessor accessor = new DBSchemaAccessors(getMySQLDataSource()).createMysql();
         List<DBDatabase> databases = accessor.listDatabases();
         Assert.assertTrue(databases.size() > 0);
     }
 
     @Test
     public void listTableColumns_TestAllColumnDataTypes_Success() {
-        DBSchemaAccessor accessor = new DBSchemaAccessors(getMySQLDataSource()).createMysql();
         List<DBTableColumn> columns =
                 accessor.listTableColumns(getMySQLDataBaseName(), "test_data_type");
         Assert.assertEquals(columns.size(), verifyDataTypes.size());
@@ -124,7 +123,6 @@ public class MySQLNoGreaterThan5740SchemaAccessorTest extends BaseTestEnv {
 
     @Test
     public void listTableColumns_TestColumnAttributesOtherThanDataType_Success() {
-        DBSchemaAccessor accessor = new DBSchemaAccessors(getMySQLDataSource()).createMysql();
         List<DBTableColumn> columns =
                 accessor.listTableColumns(getMySQLDataBaseName(), "test_other_than_data_type");
         Assert.assertEquals(columns.size(), columnAttributes.size());
@@ -140,7 +138,6 @@ public class MySQLNoGreaterThan5740SchemaAccessorTest extends BaseTestEnv {
 
     @Test
     public void listTableIndex_TestIndexType_Success() {
-        DBSchemaAccessor accessor = new DBSchemaAccessors(getMySQLDataSource()).createMysql();
         List<DBTableIndex> indexList = accessor.listTableIndexes(getMySQLDataBaseName(), "test_index_type");
         Assert.assertEquals(5, indexList.size());
         Assert.assertEquals(DBIndexAlgorithm.BTREE, indexList.get(0).getAlgorithm());
@@ -156,14 +153,12 @@ public class MySQLNoGreaterThan5740SchemaAccessorTest extends BaseTestEnv {
 
     @Test
     public void listTableIndex_TestIndexAvailable_Success() {
-        DBSchemaAccessor accessor = new DBSchemaAccessors(getMySQLDataSource()).createMysql();
         List<DBTableIndex> indexList = accessor.listTableIndexes(getMySQLDataBaseName(), "test_index_type");
         Assert.assertTrue(indexList.get(0).getAvailable());
     }
 
     @Test
     public void listTableIndex_get_all_index_in_schema_Success() {
-        DBSchemaAccessor accessor = new DBSchemaAccessors(getMySQLDataSource()).createMysql();
         Map<String, List<DBTableIndex>> map = accessor.listTableIndexes(getMySQLDataBaseName());
         Assert.assertNotNull(map);
         Assert.assertTrue(map.size() > 0);
@@ -172,7 +167,6 @@ public class MySQLNoGreaterThan5740SchemaAccessorTest extends BaseTestEnv {
 
     @Test
     public void listTableConstraint_TestForeignKey_Success() {
-        DBSchemaAccessor accessor = new DBSchemaAccessors(getMySQLDataSource()).createMysql();
         List<DBTableConstraint> constraintListList =
                 accessor.listTableConstraints(getMySQLDataBaseName(), "test_fk_child");
         Assert.assertEquals(1, constraintListList.size());
@@ -182,7 +176,6 @@ public class MySQLNoGreaterThan5740SchemaAccessorTest extends BaseTestEnv {
 
     @Test
     public void listTableConstraint_TestPrimaryKey_Success() {
-        DBSchemaAccessor accessor = new DBSchemaAccessors(getMySQLDataSource()).createMysql();
         List<DBTableConstraint> constraintListList =
                 accessor.listTableConstraints(getMySQLDataBaseName(), "test_fk_parent");
         Assert.assertEquals(1, constraintListList.size());
@@ -192,28 +185,24 @@ public class MySQLNoGreaterThan5740SchemaAccessorTest extends BaseTestEnv {
 
     @Test
     public void listSystemViews_information_schema_not_empty() {
-        DBSchemaAccessor accessor = new DBSchemaAccessors(getMySQLDataSource()).createMysql();
         List<String> viewNames = accessor.showSystemViews("information_schema");
         Assert.assertTrue(!viewNames.isEmpty());
     }
 
     @Test
     public void listAllSystemViews_Success() {
-        DBSchemaAccessor accessor = new DBSchemaAccessors(getMySQLDataSource()).createMysql();
         List<DBObjectIdentity> sysViews = accessor.listAllSystemViews();
         Assert.assertTrue(sysViews != null && sysViews.size() > 0);
     }
 
     @Test
     public void listSystemViews_databaseNotFound_empty() {
-        DBSchemaAccessor accessor = new DBSchemaAccessors(getMySQLDataSource()).createMysql();
         List<String> viewNames = accessor.showSystemViews("databaseNotExists");
         Assert.assertTrue(viewNames.isEmpty());
     }
 
     @Test
     public void getPartition_Hash_Success() {
-        DBSchemaAccessor accessor = new DBSchemaAccessors(getMySQLDataSource()).createMysql();
         DBTablePartition partition =
                 accessor.getPartition(getMySQLDataBaseName(), "part_hash");
         Assert.assertEquals(5L, partition.getPartitionOption().getPartitionsNum().longValue());
@@ -222,7 +211,6 @@ public class MySQLNoGreaterThan5740SchemaAccessorTest extends BaseTestEnv {
 
     @Test
     public void getPartition_List_Success() {
-        DBSchemaAccessor accessor = new DBSchemaAccessors(getMySQLDataSource()).createMysql();
         DBTablePartition partition =
                 accessor.getPartition(getMySQLDataBaseName(), "part_list");
         Assert.assertEquals(5L, partition.getPartitionOption().getPartitionsNum().longValue());
@@ -232,7 +220,6 @@ public class MySQLNoGreaterThan5740SchemaAccessorTest extends BaseTestEnv {
 
     @Test
     public void getPartition_Range_Success() {
-        DBSchemaAccessor accessor = new DBSchemaAccessors(getMySQLDataSource()).createMysql();
         DBTablePartition partition =
                 accessor.getPartition(getMySQLDataBaseName(), "part_range");
         Assert.assertEquals(3L, partition.getPartitionOption().getPartitionsNum().longValue());
@@ -242,7 +229,6 @@ public class MySQLNoGreaterThan5740SchemaAccessorTest extends BaseTestEnv {
 
     @Test
     public void listTableOptions_Success() {
-        DBSchemaAccessor accessor = new DBSchemaAccessors(getMySQLDataSource()).createMysql();
         Map<String, DBTableOptions> table2Options =
                 accessor.listTableOptions(getMySQLDataBaseName());
         Assert.assertTrue(table2Options.containsKey("part_hash"));
@@ -250,28 +236,24 @@ public class MySQLNoGreaterThan5740SchemaAccessorTest extends BaseTestEnv {
 
     @Test
     public void showTablelike_Success() {
-        DBSchemaAccessor accessor = new DBSchemaAccessors(getMySQLDataSource()).createMysql();
         List<DBObjectIdentity> tables = accessor.listTables(getMySQLDataBaseName(), null);
         Assert.assertTrue(tables != null && tables.size() > 0);
     }
 
     @Test
     public void showViews_Success() {
-        DBSchemaAccessor accessor = new DBSchemaAccessors(getMySQLDataSource()).createMysql();
         List<DBObjectIdentity> views = accessor.listViews(getMySQLDataBaseName());
         Assert.assertTrue(views != null && views.size() == 2);
     }
 
     @Test
     public void getView_Success() {
-        DBSchemaAccessor accessor = new DBSchemaAccessors(getMySQLDataSource()).createMysql();
         DBView view = accessor.getView(getMySQLDataBaseName(), "view_test1");
         Assert.assertTrue(view != null && view.getColumns().size() == 2);
     }
 
     @Test
     public void showVariables_Success() {
-        DBSchemaAccessor accessor = new DBSchemaAccessors(getMySQLDataSource()).createMysql();
         List<DBVariable> variables = accessor.showVariables();
         List<DBVariable> sessionVariables = accessor.showSessionVariables();
         List<DBVariable> globalVariables = accessor.showGlobalVariables();
@@ -282,7 +264,6 @@ public class MySQLNoGreaterThan5740SchemaAccessorTest extends BaseTestEnv {
 
     @Test
     public void getFunction_Success() {
-        DBSchemaAccessor accessor = new DBSchemaAccessors(getMySQLDataSource()).createMysql();
         DBFunction function = accessor.getFunction(getMySQLDataBaseName(), "function_test");
         Assert.assertTrue(function != null
                 && function.getParams().size() == 2
@@ -291,7 +272,6 @@ public class MySQLNoGreaterThan5740SchemaAccessorTest extends BaseTestEnv {
 
     @Test
     public void getProcedure_Success() {
-        DBSchemaAccessor accessor = new DBSchemaAccessors(getMySQLDataSource()).createMysql();
         DBProcedure procedure = accessor.getProcedure(getMySQLDataBaseName(), "procedure_detail_test");
         Assert.assertTrue(procedure != null
                 && procedure.getParams().size() == 2
@@ -300,9 +280,16 @@ public class MySQLNoGreaterThan5740SchemaAccessorTest extends BaseTestEnv {
 
     @Test
     public void showTables_unknowDatabase_Success() {
-        DBSchemaAccessor accessor = new DBSchemaAccessors(getMySQLDataSource()).createMysql();
         List<String> tables = accessor.showTables("abc");
         Assert.assertTrue(tables.size() == 0);
+    }
+
+    @Test
+    public void getTableOptions_Success() {
+        DBTableOptions options =
+                accessor.getTableOptions(getMySQLDataBaseName(), "test_data_type");
+        Assert.assertTrue(Objects.nonNull(options.getCharsetName()));
+        Assert.assertTrue(Objects.nonNull(options.getCollationName()));
     }
 
     private static void initVerifyColumnAttributes() {

--- a/libs/db-browser/src/test/java/com/oceanbase/tools/dbbrowser/schema/OBMySQLSchemaAccessorTest.java
+++ b/libs/db-browser/src/test/java/com/oceanbase/tools/dbbrowser/schema/OBMySQLSchemaAccessorTest.java
@@ -62,6 +62,7 @@ public class OBMySQLSchemaAccessorTest extends BaseTestEnv {
     private static List<DataType> verifyDataTypes = new ArrayList<>();
     private static List<ColumnAttributes> columnAttributes = new ArrayList<>();
     private static final JdbcTemplate jdbcTemplate = new JdbcTemplate(getOBMySQLDataSource());
+    private static DBSchemaAccessor accessor = new DBSchemaAccessors(getOBMySQLDataSource()).createOBMysql();
 
     @BeforeClass
     public static void setUp() throws Exception {
@@ -95,7 +96,6 @@ public class OBMySQLSchemaAccessorTest extends BaseTestEnv {
 
     @Test
     public void listUsers_Success() {
-        DBSchemaAccessor accessor = new DBSchemaAccessors(getOBMySQLDataSource()).createOBMysql();
         List<DBObjectIdentity> dbUsers = accessor.listUsers();
         Assert.assertFalse(dbUsers.isEmpty());
         Assert.assertSame(DBObjectType.USER, dbUsers.get(0).getType());
@@ -104,7 +104,6 @@ public class OBMySQLSchemaAccessorTest extends BaseTestEnv {
 
     @Test
     public void listBasicSchemaColumns_TestAllColumnDataTypes_Success() {
-        DBSchemaAccessor accessor = new DBSchemaAccessors(getOBMySQLDataSource()).createOBMysql();
         Map<String, List<DBTableColumn>> columns = accessor.listBasicTableColumns(getOBMySQLDataBaseName());
         Assert.assertTrue(columns.containsKey("test_data_type"));
         Assert.assertEquals(verifyDataTypes.size(), columns.get("test_data_type").size());
@@ -112,7 +111,6 @@ public class OBMySQLSchemaAccessorTest extends BaseTestEnv {
 
     @Test
     public void listBasicTableColumns_TestAllColumnDataTypes_Success() {
-        DBSchemaAccessor accessor = new DBSchemaAccessors(getOBMySQLDataSource()).createOBMysql();
         List<DBTableColumn> columns =
                 accessor.listBasicTableColumns(getOBMySQLDataBaseName(), "test_data_type");
         Assert.assertEquals(columns.size(), verifyDataTypes.size());
@@ -124,7 +122,6 @@ public class OBMySQLSchemaAccessorTest extends BaseTestEnv {
 
     @Test
     public void listBasicViewColumns_SchemaViewColumns_Success() {
-        DBSchemaAccessor accessor = new DBSchemaAccessors(getOBMySQLDataSource()).createOBMysql();
         Map<String, List<DBTableColumn>> columns = accessor.listBasicViewColumns(getOBMySQLDataBaseName());
         Assert.assertTrue(columns.containsKey("view_test1"));
         Assert.assertTrue(columns.containsKey("view_test2"));
@@ -134,14 +131,12 @@ public class OBMySQLSchemaAccessorTest extends BaseTestEnv {
 
     @Test
     public void listBasicViewColumns_ViewColumns_Success() {
-        DBSchemaAccessor accessor = new DBSchemaAccessors(getOBMySQLDataSource()).createOBMysql();
         List<DBTableColumn> columns = accessor.listBasicViewColumns(getOBMySQLDataBaseName(), "view_test1");
         Assert.assertEquals(2, columns.size());
     }
 
     @Test
     public void listTableColumns_TestAllColumnDataTypes_Success() {
-        DBSchemaAccessor accessor = new DBSchemaAccessors(getOBMySQLDataSource()).createOBMysql();
         List<DBTableColumn> columns =
                 accessor.listTableColumns(getOBMySQLDataBaseName(), "test_data_type");
         Assert.assertEquals(columns.size(), verifyDataTypes.size());
@@ -155,7 +150,6 @@ public class OBMySQLSchemaAccessorTest extends BaseTestEnv {
 
     @Test
     public void listTableColumns_TestColumnAttributesOtherThanDataType_Success() {
-        DBSchemaAccessor accessor = new DBSchemaAccessors(getOBMySQLDataSource()).createOBMysql();
         List<DBTableColumn> columns =
                 accessor.listTableColumns(getOBMySQLDataBaseName(), "test_other_than_data_type");
         Assert.assertEquals(columns.size(), columnAttributes.size());
@@ -171,7 +165,6 @@ public class OBMySQLSchemaAccessorTest extends BaseTestEnv {
 
     @Test
     public void listTableIndex_TestIndexType_Success() {
-        DBSchemaAccessor accessor = new DBSchemaAccessors(getOBMySQLDataSource()).createOBMysql();
         List<DBTableIndex> indexList = accessor.listTableIndexes(getOBMySQLDataBaseName(), "test_index_type");
         Assert.assertEquals(2, indexList.size());
         Assert.assertEquals(DBIndexAlgorithm.BTREE, indexList.get(0).getAlgorithm());
@@ -180,7 +173,6 @@ public class OBMySQLSchemaAccessorTest extends BaseTestEnv {
 
     @Test
     public void listTableIndex_TestIndexRange_Success() {
-        DBSchemaAccessor accessor = new DBSchemaAccessors(getOBMySQLDataSource()).createOBMysql();
         List<DBTableIndex> indexList = accessor.listTableIndexes(getOBMySQLDataBaseName(), "test_index_range");
         Assert.assertEquals(2, indexList.size());
         Assert.assertEquals(true, indexList.get(0).getGlobal());
@@ -189,7 +181,6 @@ public class OBMySQLSchemaAccessorTest extends BaseTestEnv {
 
     @Test
     public void listTableIndex_TestIndexAvailable_Success() {
-        DBSchemaAccessor accessor = new DBSchemaAccessors(getOBMySQLDataSource()).createOBMysql();
         List<DBTableIndex> indexList = accessor.listTableIndexes(getOBMySQLDataBaseName(), "test_index_type");
         Assert.assertTrue(indexList.get(0).getAvailable());
     }
@@ -197,7 +188,6 @@ public class OBMySQLSchemaAccessorTest extends BaseTestEnv {
     @Test
     @Ignore("TODO: fix this test case")
     public void listTableIndex_Success() {
-        DBSchemaAccessor accessor = new DBSchemaAccessors(getOBMySQLDataSource()).createOBMysql();
         Map<String, List<DBTableIndex>> indexes = accessor.listTableIndexes(getOBMySQLDataBaseName());
         Assert.assertTrue(indexes.size() > 0);
         Assert.assertTrue(indexes.get("test_index_type").get(0).getAvailable());
@@ -205,7 +195,6 @@ public class OBMySQLSchemaAccessorTest extends BaseTestEnv {
 
     @Test
     public void listTableConstraint_TestForeignKey_Success() {
-        DBSchemaAccessor accessor = new DBSchemaAccessors(getOBMySQLDataSource()).createOBMysql();
         List<DBTableConstraint> constraintListList =
                 accessor.listTableConstraints(getOBMySQLDataBaseName(), "test_fk_child");
         Assert.assertEquals(1, constraintListList.size());
@@ -215,7 +204,6 @@ public class OBMySQLSchemaAccessorTest extends BaseTestEnv {
 
     @Test
     public void listTableConstraint_TestPrimaryKey_Success() {
-        DBSchemaAccessor accessor = new DBSchemaAccessors(getOBMySQLDataSource()).createOBMysql();
         List<DBTableConstraint> constraintListList =
                 accessor.listTableConstraints(getOBMySQLDataBaseName(), "test_fk_parent");
         Assert.assertEquals(1, constraintListList.size());
@@ -244,28 +232,24 @@ public class OBMySQLSchemaAccessorTest extends BaseTestEnv {
 
     @Test
     public void listSystemViews_information_schema_not_empty() {
-        DBSchemaAccessor accessor = new DBSchemaAccessors(getOBMySQLDataSource()).createOBMysql();
         List<String> viewNames = accessor.showSystemViews("information_schema");
         Assert.assertTrue(!viewNames.isEmpty());
     }
 
     @Test
     public void listAllSystemViews_Success() {
-        DBSchemaAccessor accessor = new DBSchemaAccessors(getOBMySQLDataSource()).createOBMysql();
         List<DBObjectIdentity> sysViews = accessor.listAllSystemViews();
         Assert.assertTrue(sysViews != null && sysViews.size() > 0);
     }
 
     @Test
     public void listSystemViews_databaseNotFound_empty() {
-        DBSchemaAccessor accessor = new DBSchemaAccessors(getOBMySQLDataSource()).createOBMysql();
         List<String> viewNames = accessor.showSystemViews("databaseNotExists");
         Assert.assertTrue(viewNames.isEmpty());
     }
 
     @Test
     public void getPartition_Hash_Success() {
-        DBSchemaAccessor accessor = new DBSchemaAccessors(getOBMySQLDataSource()).createOBMysql();
         DBTablePartition partition =
                 accessor.getPartition(getOBMySQLDataBaseName(), "part_hash");
         Assert.assertEquals(5L, partition.getPartitionOption().getPartitionsNum().longValue());
@@ -274,7 +258,6 @@ public class OBMySQLSchemaAccessorTest extends BaseTestEnv {
 
     @Test
     public void getTableOptions_Success() {
-        DBSchemaAccessor accessor = new DBSchemaAccessors(getOBMySQLDataSource()).createOBMysql();
         DBTableOptions options =
                 accessor.getTableOptions(getOBMySQLDataBaseName(), "part_hash");
         Assert.assertEquals("utf8mb4", options.getCharsetName());
@@ -282,7 +265,6 @@ public class OBMySQLSchemaAccessorTest extends BaseTestEnv {
 
     @Test
     public void listTableOptions_Success() {
-        DBSchemaAccessor accessor = new DBSchemaAccessors(getOBMySQLDataSource()).createOBMysql();
         Map<String, DBTableOptions> table2Options =
                 accessor.listTableOptions(getOBMySQLDataBaseName());
         Assert.assertTrue(table2Options.containsKey("part_hash"));
@@ -290,28 +272,24 @@ public class OBMySQLSchemaAccessorTest extends BaseTestEnv {
 
     @Test
     public void showTablelike_Success() {
-        DBSchemaAccessor accessor = new DBSchemaAccessors(getOBMySQLDataSource()).createOBMysql();
         List<DBObjectIdentity> tables = accessor.listTables(getOBMySQLDataBaseName(), null);
         Assert.assertTrue(tables != null && tables.size() > 0);
     }
 
     @Test
     public void showViews_Success() {
-        DBSchemaAccessor accessor = new DBSchemaAccessors(getOBMySQLDataSource()).createOBMysql();
         List<DBObjectIdentity> views = accessor.listViews(getOBMySQLDataBaseName());
         Assert.assertTrue(views != null && views.size() == 2);
     }
 
     @Test
     public void getView_Success() {
-        DBSchemaAccessor accessor = new DBSchemaAccessors(getOBMySQLDataSource()).createOBMysql();
         DBView view = accessor.getView(getOBMySQLDataBaseName(), "view_test1");
         Assert.assertTrue(view != null && view.getColumns().size() == 2);
     }
 
     @Test
     public void showVariables_Success() {
-        DBSchemaAccessor accessor = new DBSchemaAccessors(getOBMySQLDataSource()).createOBMysql();
         List<DBVariable> variables = accessor.showVariables();
         List<DBVariable> sessionVariables = accessor.showSessionVariables();
         List<DBVariable> globalVariables = accessor.showGlobalVariables();
@@ -322,28 +300,24 @@ public class OBMySQLSchemaAccessorTest extends BaseTestEnv {
 
     @Test
     public void showCharset_Success() {
-        DBSchemaAccessor accessor = new DBSchemaAccessors(getOBMySQLDataSource()).createOBMysql();
         List<String> charset = accessor.showCharset();
         Assert.assertTrue(charset != null && charset.size() > 0);
     }
 
     @Test
     public void showCollation_Success() {
-        DBSchemaAccessor accessor = new DBSchemaAccessors(getOBMySQLDataSource()).createOBMysql();
         List<String> collation = accessor.showCollation();
         Assert.assertTrue(collation != null && collation.size() > 0);
     }
 
     @Test
     public void listFunctions_Success() {
-        DBSchemaAccessor accessor = new DBSchemaAccessors(getOBMySQLDataSource()).createOBMysql();
         List<DBPLObjectIdentity> functions = accessor.listFunctions(getOBMySQLDataBaseName());
         Assert.assertTrue(functions != null && functions.size() == 1);
     }
 
     @Test
     public void getFunction_Success() {
-        DBSchemaAccessor accessor = new DBSchemaAccessors(getOBMySQLDataSource()).createOBMysql();
         DBFunction function = accessor.getFunction(getOBMySQLDataBaseName(), "function_test");
         Assert.assertTrue(function != null
                 && function.getParams().size() == 2
@@ -352,14 +326,12 @@ public class OBMySQLSchemaAccessorTest extends BaseTestEnv {
 
     @Test
     public void listProcedures_Success() {
-        DBSchemaAccessor accessor = new DBSchemaAccessors(getOBMySQLDataSource()).createOBMysql();
         List<DBPLObjectIdentity> procedures = accessor.listProcedures(getOBMySQLDataBaseName());
         Assert.assertTrue(!procedures.isEmpty());
     }
 
     @Test
     public void getProcedure_Success() {
-        DBSchemaAccessor accessor = new DBSchemaAccessors(getOBMySQLDataSource()).createOBMysql();
         DBProcedure procedure = accessor.getProcedure(getOBMySQLDataBaseName(), "procedure_detail_test");
         Assert.assertTrue(procedure != null
                 && procedure.getParams().size() == 2
@@ -368,7 +340,6 @@ public class OBMySQLSchemaAccessorTest extends BaseTestEnv {
 
     @Test
     public void getProcedure_without_parameters_Success() {
-        DBSchemaAccessor accessor = new DBSchemaAccessors(getOBMySQLDataSource()).createOBMysql();
         DBProcedure procedure = accessor.getProcedure(getOBMySQLDataBaseName(), "procedure_without_parameters");
         Assert.assertTrue(procedure != null
                 && procedure.getParams().size() == 0
@@ -377,21 +348,18 @@ public class OBMySQLSchemaAccessorTest extends BaseTestEnv {
 
     @Test
     public void getDatabase_Success() {
-        DBSchemaAccessor accessor = new DBSchemaAccessors(getOBMySQLDataSource()).createOBMysql();
         DBDatabase database = accessor.getDatabase(getOBMySQLDataBaseName());
         Assert.assertNotNull(database);
     }
 
     @Test
     public void listDatabases_Success() {
-        DBSchemaAccessor accessor = new DBSchemaAccessors(getOBMySQLDataSource()).createOBMysql();
         List<DBDatabase> databases = accessor.listDatabases();
         Assert.assertTrue(databases.size() > 0);
     }
 
     @Test
     public void getPartition_List_Success() {
-        DBSchemaAccessor accessor = new DBSchemaAccessors(getOBMySQLDataSource()).createOBMysql();
         DBTablePartition partition =
                 accessor.getPartition(getOBMySQLDataBaseName(), "part_list");
         Assert.assertEquals(5L, partition.getPartitionOption().getPartitionsNum().longValue());
@@ -401,7 +369,6 @@ public class OBMySQLSchemaAccessorTest extends BaseTestEnv {
 
     @Test
     public void getPartition_Range_Success() {
-        DBSchemaAccessor accessor = new DBSchemaAccessors(getOBMySQLDataSource()).createOBMysql();
         DBTablePartition partition =
                 accessor.getPartition(getOBMySQLDataBaseName(), "part_range");
         Assert.assertEquals(3L, partition.getPartitionOption().getPartitionsNum().longValue());
@@ -411,7 +378,6 @@ public class OBMySQLSchemaAccessorTest extends BaseTestEnv {
 
     @Test
     public void listTableColumns_test_in_mysql_schema_view_as_base_table_Success() {
-        DBSchemaAccessor accessor = new DBSchemaAccessors(getOBMySQLDataSource()).createOBMysql();
         List<DBTableColumn> columns = accessor.listTableColumns("mysql", "time_zone_transition");
         Assert.assertEquals(3, columns.size());
     }

--- a/libs/db-browser/src/test/java/com/oceanbase/tools/dbbrowser/schema/OBMySQLSchemaAccessorTest.java
+++ b/libs/db-browser/src/test/java/com/oceanbase/tools/dbbrowser/schema/OBMySQLSchemaAccessorTest.java
@@ -25,7 +25,6 @@ import java.util.Map;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.springframework.jdbc.core.JdbcTemplate;
 
@@ -186,11 +185,9 @@ public class OBMySQLSchemaAccessorTest extends BaseTestEnv {
     }
 
     @Test
-    @Ignore("TODO: fix this test case")
     public void listTableIndex_Success() {
         Map<String, List<DBTableIndex>> indexes = accessor.listTableIndexes(getOBMySQLDataBaseName());
         Assert.assertTrue(indexes.size() > 0);
-        Assert.assertTrue(indexes.get("test_index_type").get(0).getAvailable());
     }
 
     @Test

--- a/libs/db-browser/src/test/java/com/oceanbase/tools/dbbrowser/schema/OBOracleSchemaAccessorTest.java
+++ b/libs/db-browser/src/test/java/com/oceanbase/tools/dbbrowser/schema/OBOracleSchemaAccessorTest.java
@@ -76,6 +76,7 @@ public class OBOracleSchemaAccessorTest extends BaseTestEnv {
     private static List<ColumnAttributes> columnAttributes = new ArrayList<>();
     private static JdbcTemplate jdbcTemplate = new JdbcTemplate(getOBOracleDataSource());
     private static final String typeName = "emp_type_" + new Random().nextInt(10000);
+    private static final DBSchemaAccessor accessor = new DBSchemaAccessors(getOBOracleDataSource()).createOBOracle();
 
 
     @BeforeClass
@@ -116,7 +117,6 @@ public class OBOracleSchemaAccessorTest extends BaseTestEnv {
 
     @Test
     public void listUsers_Success() {
-        DBSchemaAccessor accessor = new DBSchemaAccessors(getOBOracleDataSource()).createOBOracle();
         List<DBObjectIdentity> dbUsers = accessor.listUsers();
         Assert.assertFalse(dbUsers.isEmpty());
         Assert.assertSame(DBObjectType.USER, dbUsers.get(0).getType());
@@ -125,14 +125,12 @@ public class OBOracleSchemaAccessorTest extends BaseTestEnv {
 
     @Test
     public void listDatabases_Success() {
-        DBSchemaAccessor accessor = new DBSchemaAccessors(getOBOracleDataSource()).createOBOracle();
         List<DBDatabase> databases = accessor.listDatabases();
         Assert.assertTrue(databases.size() > 0);
     }
 
     @Test
     public void listBasicSchemaColumns_TestAllColumnDataTypes_Success() {
-        DBSchemaAccessor accessor = new DBSchemaAccessors(getOBOracleDataSource()).createOBOracle();
         Map<String, List<DBTableColumn>> columns = accessor.listBasicTableColumns(getOBOracleSchema());
         Assert.assertTrue(columns.containsKey("TEST_DATA_TYPE"));
         Assert.assertEquals(verifyDataTypes.size(), columns.get("TEST_DATA_TYPE").size());
@@ -140,7 +138,6 @@ public class OBOracleSchemaAccessorTest extends BaseTestEnv {
 
     @Test
     public void listBasicTableColumns_TestAllColumnDataTypes_Success() {
-        DBSchemaAccessor accessor = new DBSchemaAccessors(getOBOracleDataSource()).createOBOracle();
         List<DBTableColumn> columns =
                 accessor.listBasicTableColumns(getOBOracleSchema(), "TEST_DATA_TYPE");
         Assert.assertEquals(columns.size(), verifyDataTypes.size());
@@ -152,7 +149,6 @@ public class OBOracleSchemaAccessorTest extends BaseTestEnv {
 
     @Test
     public void listBasicViewColumns_SchemaViewColumns_Success() {
-        DBSchemaAccessor accessor = new DBSchemaAccessors(getOBOracleDataSource()).createOBOracle();
         Map<String, List<DBTableColumn>> columns = accessor.listBasicViewColumns(getOBOracleSchema());
         Assert.assertTrue(columns.containsKey("VIEW_TEST1"));
         Assert.assertTrue(columns.containsKey("VIEW_TEST2"));
@@ -162,7 +158,6 @@ public class OBOracleSchemaAccessorTest extends BaseTestEnv {
 
     @Test
     public void listBasicViewColumns_ViewColumns_Success() {
-        DBSchemaAccessor accessor = new DBSchemaAccessors(getOBOracleDataSource()).createOBOracle();
         List<DBTableColumn> columns = accessor.listBasicViewColumns(getOBOracleSchema(), "VIEW_TEST1");
         Assert.assertEquals(2, columns.size());
     }
@@ -170,7 +165,6 @@ public class OBOracleSchemaAccessorTest extends BaseTestEnv {
     @Test
     @Ignore("TODO: fix this test")
     public void listTableColumns_TestAllColumnDataTypes_Success() {
-        DBSchemaAccessor accessor = new DBSchemaAccessors(getOBOracleDataSource()).createOBOracle();
         List<DBTableColumn> columns =
                 accessor.listTableColumns(getOBOracleSchema(), "TEST_DATA_TYPE");
         Assert.assertEquals(columns.size(), verifyDataTypes.size());
@@ -184,7 +178,6 @@ public class OBOracleSchemaAccessorTest extends BaseTestEnv {
 
     @Test
     public void listTableColumns_TestColumnAttributesOtherThanDataType_Success() {
-        DBSchemaAccessor accessor = new DBSchemaAccessors(getOBOracleDataSource()).createOBOracle();
         List<DBTableColumn> columns =
                 accessor.listTableColumns(getOBOracleSchema(), "TEST_OTHER_THAN_DATA_TYPE");
         Assert.assertEquals(columns.size(), columnAttributes.size());
@@ -199,14 +192,12 @@ public class OBOracleSchemaAccessorTest extends BaseTestEnv {
 
     @Test
     public void listTableColumns_TestGetAllColumnInSchema_Success() {
-        DBSchemaAccessor accessor = new DBSchemaAccessors(getOBOracleDataSource()).createOBOracle();
         Map<String, List<DBTableColumn>> table2Columns = accessor.listTableColumns(getOBOracleSchema());
         Assert.assertTrue(table2Columns.size() > 0);
     }
 
     @Test
     public void listTableIndex_TestIndexType_Success() {
-        DBSchemaAccessor accessor = new DBSchemaAccessors(getOBOracleDataSource()).createOBOracle();
         List<DBTableIndex> indexList = accessor.listTableIndexes(getOBOracleSchema(), "TEST_INDEX_TYPE");
         Assert.assertEquals(2, indexList.size());
         Assert.assertEquals(DBIndexType.UNIQUE, indexList.get(0).getType());
@@ -217,7 +208,6 @@ public class OBOracleSchemaAccessorTest extends BaseTestEnv {
 
     @Test
     public void listTableIndex_TestIndexRange_Success() {
-        DBSchemaAccessor accessor = new DBSchemaAccessors(getOBOracleDataSource()).createOBOracle();
         List<DBTableIndex> indexList = accessor.listTableIndexes(getOBOracleSchema(), "TEST_INDEX_RANGE");
         Assert.assertEquals(2, indexList.size());
         Assert.assertEquals(true, indexList.get(0).getGlobal());
@@ -226,7 +216,6 @@ public class OBOracleSchemaAccessorTest extends BaseTestEnv {
 
     @Test
     public void listTableIndex_TestIndexAvailable_Success() {
-        DBSchemaAccessor accessor = new DBSchemaAccessors(getOBOracleDataSource()).createOBOracle();
         List<DBTableIndex> indexList = accessor.listTableIndexes(getOBOracleSchema(), "TEST_INDEX_RANGE");
         Assert.assertEquals(2, indexList.size());
         Assert.assertTrue(indexList.get(0).getAvailable());
@@ -235,7 +224,6 @@ public class OBOracleSchemaAccessorTest extends BaseTestEnv {
 
     @Test
     public void listTableConstraint_TestForeignKey_Success() {
-        DBSchemaAccessor accessor = new DBSchemaAccessors(getOBOracleDataSource()).createOBOracle();
         List<DBTableConstraint> constraintListList =
                 accessor.listTableConstraints(getOBOracleSchema(), "TEST_FK_CHILD");
         Assert.assertEquals(1, constraintListList.size());
@@ -247,7 +235,6 @@ public class OBOracleSchemaAccessorTest extends BaseTestEnv {
 
     @Test
     public void listTableConstraint_TestPrimaryKey_Success() {
-        DBSchemaAccessor accessor = new DBSchemaAccessors(getOBOracleDataSource()).createOBOracle();
         List<DBTableConstraint> constraintListList =
                 accessor.listTableConstraints(getOBOracleSchema(), "TEST_FK_PARENT");
         Assert.assertEquals(1, constraintListList.size());
@@ -259,7 +246,6 @@ public class OBOracleSchemaAccessorTest extends BaseTestEnv {
 
     @Test
     public void listTableConstraint_TestPrimaryKeyIndex_Success() {
-        DBSchemaAccessor accessor = new DBSchemaAccessors(getOBOracleDataSource()).createOBOracle();
         List<DBTableIndex> indexes =
                 accessor.listTableIndexes(getOBOracleSchema(), "TEST_PK_INDEX");
         Assert.assertEquals(1, indexes.size());
@@ -268,7 +254,6 @@ public class OBOracleSchemaAccessorTest extends BaseTestEnv {
 
     @Test
     public void getPartition_Hash_Success() {
-        DBSchemaAccessor accessor = new DBSchemaAccessors(getOBOracleDataSource()).createOBOracle();
         DBTablePartition partition =
                 accessor.getPartition(getOBOracleSchema(), "part_hash");
         Assert.assertEquals(5L, partition.getPartitionOption().getPartitionsNum().longValue());
@@ -277,7 +262,6 @@ public class OBOracleSchemaAccessorTest extends BaseTestEnv {
 
     @Test
     public void getTableOptions_Success() {
-        DBSchemaAccessor accessor = new DBSchemaAccessors(getOBOracleDataSource()).createOBOracle();
         DBTableOptions options =
                 accessor.getTableOptions(getOBOracleSchema(), "part_hash");
         Assert.assertEquals("this is a comment", options.getComment());
@@ -285,21 +269,18 @@ public class OBOracleSchemaAccessorTest extends BaseTestEnv {
 
     @Test
     public void listSystemViews_databaseNotSYS_empty() {
-        DBSchemaAccessor accessor = new DBSchemaAccessors(getOBOracleDataSource()).createOBOracle();
         List<String> viewNames = accessor.showSystemViews("notsys");
         Assert.assertTrue(viewNames.isEmpty());
     }
 
     @Test
     public void listSystemViews_databaseSYS_notEmpty() {
-        DBSchemaAccessor accessor = new DBSchemaAccessors(getOBOracleDataSource()).createOBOracle();
         List<String> viewNames = accessor.showSystemViews("SYS");
         Assert.assertTrue(!viewNames.isEmpty());
     }
 
     @Test
     public void showVariables_Success() {
-        DBSchemaAccessor accessor = new DBSchemaAccessors(getOBOracleDataSource()).createOBOracle();
         List<DBVariable> variables = accessor.showVariables();
         List<DBVariable> sessionVariables = accessor.showSessionVariables();
         List<DBVariable> globalVariables = accessor.showGlobalVariables();
@@ -310,42 +291,36 @@ public class OBOracleSchemaAccessorTest extends BaseTestEnv {
 
     @Test
     public void showCharset_Success() {
-        DBSchemaAccessor accessor = new DBSchemaAccessors(getOBOracleDataSource()).createOBOracle();
         List<String> charset = accessor.showCharset();
         Assert.assertTrue(charset != null && charset.size() > 0);
     }
 
     @Test
     public void showCollation_Success() {
-        DBSchemaAccessor accessor = new DBSchemaAccessors(getOBOracleDataSource()).createOBOracle();
         List<String> collation = accessor.showCollation();
         Assert.assertTrue(collation != null && collation.size() > 0);
     }
 
     @Test
     public void showViews_Success() {
-        DBSchemaAccessor accessor = new DBSchemaAccessors(getOBOracleDataSource()).createOBOracle();
         List<DBObjectIdentity> views = accessor.listViews(getOBOracleSchema());
         Assert.assertTrue(views != null && views.size() == 2);
     }
 
     @Test
     public void getView_Success() {
-        DBSchemaAccessor accessor = new DBSchemaAccessors(getOBOracleDataSource()).createOBOracle();
         DBView view = accessor.getView(getOBOracleSchema(), "VIEW_TEST1");
         Assert.assertTrue(view != null && view.getColumns().size() == 2);
     }
 
     @Test
     public void listFunctions_Success() {
-        DBSchemaAccessor accessor = new DBSchemaAccessors(getOBOracleDataSource()).createOBOracle();
         List<DBPLObjectIdentity> functions = accessor.listFunctions(getOBOracleSchema());
         Assert.assertTrue(functions != null && functions.size() == 3);
     }
 
     @Test
     public void listFunctions_invalidFunctionList() {
-        DBSchemaAccessor accessor = new DBSchemaAccessors(getOBOracleDataSource()).createOBOracle();
         List<DBPLObjectIdentity> functions = accessor.listFunctions(getOBOracleSchema());
         functions = functions.stream().filter(function -> {
             if (StringUtils.equals(function.getName(), "INVALIDE_FUNC")) {
@@ -362,7 +337,6 @@ public class OBOracleSchemaAccessorTest extends BaseTestEnv {
 
     @Test
     public void getFunction_Success() {
-        DBSchemaAccessor accessor = new DBSchemaAccessors(getOBOracleDataSource()).createOBOracle();
         DBFunction function = accessor.getFunction(getOBOracleSchema(), "FUNC_DETAIL_TEST");
         Assert.assertTrue(function != null
                 && function.getParams().size() == 1
@@ -373,14 +347,12 @@ public class OBOracleSchemaAccessorTest extends BaseTestEnv {
 
     @Test
     public void showProcedures_Success() {
-        DBSchemaAccessor accessor = new DBSchemaAccessors(getOBOracleDataSource()).createOBOracle();
         List<DBPLObjectIdentity> procedures = accessor.listProcedures(getOBOracleSchema());
         Assert.assertTrue(procedures != null && procedures.size() >= 3);
     }
 
     @Test
     public void showProcedures_invalidProcedureList() {
-        DBSchemaAccessor accessor = new DBSchemaAccessors(getOBOracleDataSource()).createOBOracle();
         List<DBPLObjectIdentity> procedures = accessor.listProcedures(getOBOracleSchema());
         procedures = procedures.stream().filter(procedure -> {
             if (StringUtils.equals(procedure.getName(), "INVALID_PROCEDURE_TEST")) {
@@ -397,7 +369,6 @@ public class OBOracleSchemaAccessorTest extends BaseTestEnv {
 
     @Test
     public void getProcedure_Success() {
-        DBSchemaAccessor accessor = new DBSchemaAccessors(getOBOracleDataSource()).createOBOracle();
         DBProcedure procedure = accessor.getProcedure(getOBOracleSchema(), "PROCEDURE_DETAIL_TEST");
         Assert.assertTrue(procedure != null
                 && procedure.getParams().size() == 2
@@ -406,14 +377,12 @@ public class OBOracleSchemaAccessorTest extends BaseTestEnv {
 
     @Test
     public void listPackages_Success() {
-        DBSchemaAccessor accessor = new DBSchemaAccessors(getOBOracleDataSource()).createOBOracle();
         List<DBPLObjectIdentity> packages = accessor.listPackages(getOBOracleSchema());
         Assert.assertTrue(packages != null && !packages.isEmpty());
     }
 
     @Test
     public void listPackages_invalidPackageList() {
-        DBSchemaAccessor accessor = new DBSchemaAccessors(getOBOracleDataSource()).createOBOracle();
         List<DBPLObjectIdentity> packages = accessor.listPackages(getOBOracleSchema());
         boolean flag = false;
         for (DBPLObjectIdentity dbPackage : packages) {
@@ -426,7 +395,6 @@ public class OBOracleSchemaAccessorTest extends BaseTestEnv {
 
     @Test
     public void getPackage_Success() {
-        DBSchemaAccessor accessor = new DBSchemaAccessors(getOBOracleDataSource()).createOBOracle();
         DBPackage dbPackage = accessor.getPackage(getOBOracleSchema(), "T_PACKAGE");
         Assert.assertTrue(dbPackage != null
                 && dbPackage.getPackageHead().getVariables().size() == 1
@@ -441,7 +409,6 @@ public class OBOracleSchemaAccessorTest extends BaseTestEnv {
 
     @Test
     public void listriggers_Success() {
-        DBSchemaAccessor accessor = new DBSchemaAccessors(getOBOracleDataSource()).createOBOracle();
         List<DBPLObjectIdentity> triggers = accessor.listTriggers(getOBOracleSchema());
         Assert.assertNotEquals(null, triggers);
         boolean flag = false;
@@ -455,7 +422,6 @@ public class OBOracleSchemaAccessorTest extends BaseTestEnv {
 
     @Test
     public void listTriggers_InvalidTriggerList() {
-        DBSchemaAccessor accessor = new DBSchemaAccessors(getOBOracleDataSource()).createOBOracle();
         List<DBPLObjectIdentity> triggers = accessor.listTriggers(getOBOracleSchema());
         boolean flag = false;
         for (DBPLObjectIdentity trigger : triggers) {
@@ -468,7 +434,6 @@ public class OBOracleSchemaAccessorTest extends BaseTestEnv {
 
     @Test
     public void getTrigger_Success() {
-        DBSchemaAccessor accessor = new DBSchemaAccessors(getOBOracleDataSource()).createOBOracle();
         DBTrigger trigger = accessor.getTrigger(getOBOracleSchema(), "TRIGGER_TEST");
         Assert.assertNotNull(trigger);
         Assert.assertEquals("TRIGGER_TEST", trigger.getTriggerName());
@@ -479,7 +444,6 @@ public class OBOracleSchemaAccessorTest extends BaseTestEnv {
         String createTypeDdl = String.format("CREATE TYPE \"%s\" AS OBJECT (name VARCHAR2(100), ssn NUMBER)", typeName);
         jdbcTemplate.execute(createTypeDdl);
 
-        DBSchemaAccessor accessor = new DBSchemaAccessors(getOBOracleDataSource()).createOBOracle();
         List<DBPLObjectIdentity> types = accessor.listTypes(getOBOracleSchema());
         Assert.assertNotNull(types);
         Assert.assertEquals(1, types.size());
@@ -493,7 +457,6 @@ public class OBOracleSchemaAccessorTest extends BaseTestEnv {
         String createTypeDdl = String.format("CREATE TYPE \"%s\" AS OBJECT (name VARCHAR2(100), ssn NUMBER)", typeName);
         jdbcTemplate.execute(createTypeDdl);
 
-        DBSchemaAccessor accessor = new DBSchemaAccessors(getOBOracleDataSource()).createOBOracle();
         DBType type = accessor.getType(getOBOracleSchema(), typeName);
         Assert.assertNotNull(type);
         Assert.assertEquals(typeName, type.getTypeName());
@@ -507,7 +470,6 @@ public class OBOracleSchemaAccessorTest extends BaseTestEnv {
         String createTypeDdl = String.format("CREATE TYPE \"%s\" AS VARRAY(5) OF VARCHAR2(25);", typeName);
         jdbcTemplate.execute(createTypeDdl);
 
-        DBSchemaAccessor accessor = new DBSchemaAccessors(getOBOracleDataSource()).createOBOracle();
         DBType type = accessor.getType(getOBOracleSchema(), typeName);
         Assert.assertNotNull(type);
         Assert.assertEquals(typeName, type.getTypeName());
@@ -530,7 +492,6 @@ public class OBOracleSchemaAccessorTest extends BaseTestEnv {
         String ddl = String.format("CREATE TYPE \"%s\" AS TABLE OF \"cust_address_typ2\";", typeName);
         jdbcTemplate.execute(ddl);
 
-        DBSchemaAccessor accessor = new DBSchemaAccessors(getOBOracleDataSource()).createOBOracle();
         DBType type = accessor.getType(getOBOracleSchema(), typeName);
         Assert.assertNotNull(type);
         Assert.assertEquals(typeName, type.getTypeName());
@@ -542,7 +503,6 @@ public class OBOracleSchemaAccessorTest extends BaseTestEnv {
 
     @Test
     public void listSynonyms_testPublicSynonymListForOracle() {
-        DBSchemaAccessor accessor = new DBSchemaAccessors(getOBOracleDataSource()).createOBOracle();
         List<DBObjectIdentity> synonyms = accessor.listSynonyms(getOBOracleSchema(), DBSynonymType.PUBLIC);
         Assert.assertNotEquals(0, synonyms.size());
         boolean flag = false;
@@ -556,7 +516,6 @@ public class OBOracleSchemaAccessorTest extends BaseTestEnv {
 
     @Test
     public void listSynonyms_testCommonSynonymListForOracle() {
-        DBSchemaAccessor accessor = new DBSchemaAccessors(getOBOracleDataSource()).createOBOracle();
         List<DBObjectIdentity> synonyms = accessor.listSynonyms(getOBOracleSchema(), DBSynonymType.COMMON);
         Assert.assertNotEquals(0, synonyms.size());
         boolean flag = false;
@@ -570,7 +529,6 @@ public class OBOracleSchemaAccessorTest extends BaseTestEnv {
 
     @Test
     public void getSynonym_testPublicSynonymInfoForOracle() {
-        DBSchemaAccessor accessor = new DBSchemaAccessors(getOBOracleDataSource()).createOBOracle();
         DBSynonym synonym = accessor.getSynonym(getOBOracleSchema(), "PUBLIC_SYNONYM_TEST", DBSynonymType.PUBLIC);
         Assert.assertNotNull(synonym);
         Assert.assertEquals(DBSynonymType.PUBLIC, synonym.getSynonymType());
@@ -579,7 +537,6 @@ public class OBOracleSchemaAccessorTest extends BaseTestEnv {
 
     @Test
     public void getSynonym_testCommonSynonymInfoForOracle() {
-        DBSchemaAccessor accessor = new DBSchemaAccessors(getOBOracleDataSource()).createOBOracle();
         DBSynonym synonym = accessor.getSynonym(getOBOracleSchema(), "COMMON_SYNONYM_TEST", DBSynonymType.COMMON);
         Assert.assertNotNull(synonym);
         Assert.assertEquals(DBSynonymType.COMMON, synonym.getSynonymType());
@@ -588,21 +545,18 @@ public class OBOracleSchemaAccessorTest extends BaseTestEnv {
 
     @Test
     public void getDatabase_Success() {
-        DBSchemaAccessor accessor = new DBSchemaAccessors(getOBOracleDataSource()).createOBOracle();
         DBDatabase database = accessor.getDatabase(getOBOracleSchema());
         Assert.assertNotNull(database);
     }
 
     @Test
     public void listSequences_Success() {
-        DBSchemaAccessor accessor = new DBSchemaAccessors(getOBOracleDataSource()).createOBOracle();
         List<DBObjectIdentity> sequences = accessor.listSequences(getOBOracleSchema());
         Assert.assertTrue(sequences != null && !sequences.isEmpty());
     }
 
     @Test
     public void getSequence_Success() {
-        DBSchemaAccessor accessor = new DBSchemaAccessors(getOBOracleDataSource()).createOBOracle();
         DBSequence sequence = accessor.getSequence(getOBOracleSchema(), "SEQ_TEST");
         Assert.assertTrue(sequence != null && sequence.getName().equalsIgnoreCase("SEQ_TEST"));
         Assert.assertEquals("CREATE SEQUENCE \"SEQ_TEST\" MINVALUE 1 MAXVALUE 10 INCREMENT BY 2 CACHE 5 ORDER CYCLE;",
@@ -611,7 +565,6 @@ public class OBOracleSchemaAccessorTest extends BaseTestEnv {
 
     @Test
     public void listTables_Success() {
-        DBSchemaAccessor accessor = new DBSchemaAccessors(getOBOracleDataSource()).createOBOracle();
         List<DBObjectIdentity> tables =
                 accessor.listTables(getOBOracleSchema(), null);
         Assert.assertTrue(tables.size() > 0);
@@ -620,7 +573,6 @@ public class OBOracleSchemaAccessorTest extends BaseTestEnv {
 
     @Test
     public void listTableColumns_test_default_null_Success() {
-        DBSchemaAccessor accessor = new DBSchemaAccessors(getOBOracleDataSource()).createOBOracle();
         List<DBTableColumn> columns =
                 accessor.listTableColumns(getOBOracleSchema(), "TEST_DEFAULT_NULL");
         Assert.assertTrue(columns.size() > 0);


### PR DESCRIPTION
#### What type of PR is this?
type-bug
module-Database object

#### What this PR does / why we need it:
1. Fix cannot get table charset in native mysql mode. OB mysql get table charset by `DBSchemaAccessorUtil#obtainOptionsByParse` which is not work for native mysql mode. 
we can get table by parse table ddl in both mysql and ob mysql mode. add `obtainOptionsByParser` method and use it to get table options.

2. optimize DBSchemaAccessor ut test by create `private static DBSchemaAccessor accessor`
3. fix `@Ignore("TODO: fix this test case")` ut test. I consulted kernel classmates and found that the `comment` field of the `information_schema.STATISTICS` table and the `comment` field of the `show index from` query have different sources and meanings. The `comment` field of `information_schema.STATISTICS` cannot be used to indicate the status of the index, so for `Map<String, List<DBTableIndex >> listTableIndexes(String schemaName); `method does not query whether the index is available. Actually only the `List<DBTableIndex> listTableIndexes(String schemaName, String tableName)` method needs to provide the available status of the index.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #582

#### Special notes for your reviewer:

<!--
This section is used to describe how this PR is implemented. 
If this is a PR that fixes a bug, this section describes how the bug was fixed.
If it's a new feature, this section briefly describes how to implement the new feature.
etc.
-->

#### Additional documentation e.g., usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```