### PR TITLE
fix(datasource): the data source list refreshes very slowly and cannot obtain the connect status while there are a huge amount of data sources

### DIFF
--- a/server/integration-test/src/test/java/com/oceanbase/odc/service/connection/ConnectionConfigServiceTest.java
+++ b/server/integration-test/src/test/java/com/oceanbase/odc/service/connection/ConnectionConfigServiceTest.java
@@ -123,6 +123,8 @@ public class ConnectionConfigServiceTest extends MockedAuthorityTestEnv {
         when(encryptionFacade.userEncryptor(eq(CREATOR_ID), eq(SALT))).thenReturn(mockEncryptor);
         when(encryptionFacade.organizationEncryptor(eq(ORGANIZATION_ID), eq(SALT))).thenReturn(mockEncryptor);
         Mockito.when(environmentService.detailSkipPermissionCheck(Mockito.anyLong())).thenReturn(getEnvironment());
+        Mockito.when(environmentService.list(Mockito.anyLong()))
+                .thenReturn(Collections.singletonList(getEnvironment()));
         doNothing().when(userPermissionService).bindUserAndDataSourcePermission(eq(CREATOR_ID), eq(ORGANIZATION_ID),
                 any(Long.class), eq(Arrays.asList("read", "update", "delete")));
 
@@ -140,7 +142,6 @@ public class ConnectionConfigServiceTest extends MockedAuthorityTestEnv {
         DefaultLoginSecurityManager.removeSecurityContext();
         DefaultLoginSecurityManager.removeContext();
     }
-
 
     @Test
     public void exists_HasConnection_MatchTrue() {

--- a/server/odc-server/src/main/java/com/oceanbase/odc/server/web/controller/v2/DataSourceController.java
+++ b/server/odc-server/src/main/java/com/oceanbase/odc/server/web/controller/v2/DataSourceController.java
@@ -177,9 +177,9 @@ public class DataSourceController {
     }
 
     @ApiOperation(value = "statusDataSources", notes = "Obtain datasource status")
-    @RequestMapping(value = "/datasources/status", method = RequestMethod.GET)
-    public SuccessResponse<Map<Long, CheckState>> status(@RequestParam(name = "id") Set<Long> datasourceIds) {
-        return Responses.success(connectionService.getStatus(datasourceIds));
+    @RequestMapping(value = "/datasources/status", method = RequestMethod.POST)
+    public SuccessResponse<Map<Long, CheckState>> status(@RequestBody Set<Long> ids) {
+        return Responses.success(connectionService.getStatus(ids));
     }
 
     @ApiOperation(value = "statsDataSource", notes = "datasource stats information")

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/collaboration/environment/EnvironmentService.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/collaboration/environment/EnvironmentService.java
@@ -18,7 +18,6 @@ package com.oceanbase.odc.service.collaboration.environment;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -35,7 +34,6 @@ import com.oceanbase.odc.core.shared.constant.ResourceType;
 import com.oceanbase.odc.core.shared.exception.NotFoundException;
 import com.oceanbase.odc.metadb.collaboration.EnvironmentEntity;
 import com.oceanbase.odc.metadb.collaboration.EnvironmentRepository;
-import com.oceanbase.odc.metadb.iam.UserEntity;
 import com.oceanbase.odc.service.collaboration.environment.model.Environment;
 import com.oceanbase.odc.service.iam.HorizontalDataPermissionValidator;
 import com.oceanbase.odc.service.iam.UserService;
@@ -143,17 +141,6 @@ public class EnvironmentService {
     }
 
     private Environment entityToModel(@NonNull EnvironmentEntity entity) {
-        Environment environment = environmentMapper.entityToModel(entity);
-        UserEntity creator = userService.nullSafeGet(entity.getCreatorId());
-        UserEntity lastModifier = userService.nullSafeGet(entity.getLastModifierId());
-        if (Objects.nonNull(environment.getCreator())) {
-            environment.getCreator().setName(creator.getName());
-            environment.getCreator().setAccountName(creator.getAccountName());
-        }
-        if (Objects.nonNull(environment.getLastModifier())) {
-            environment.getLastModifier().setName(lastModifier.getName());
-            environment.getLastModifier().setAccountName(lastModifier.getAccountName());
-        }
-        return environment;
+        return environmentMapper.entityToModel(entity);
     }
 }

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/connection/ConnectionService.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/connection/ConnectionService.java
@@ -731,12 +731,12 @@ public class ConnectionService {
     private List<ConnectionConfig> entitiesToModels(@NonNull List<ConnectionEntity> entities,
             @NonNull Long organizationId, @NonNull Boolean withEnvironment) {
         if (CollectionUtils.isEmpty(entities)) {
-            return Collections.EMPTY_LIST;
+            return Collections.emptyList();
         }
         Map<Long, Environment> id2Environment;
         if (withEnvironment) {
             id2Environment = environmentService.list(organizationId).stream()
-                    .collect(Collectors.toMap(environment -> environment.getId(), environment -> environment));
+                    .collect(Collectors.toMap(Environment::getId, environment -> environment));
         } else {
             id2Environment = new HashMap<>();
         }
@@ -756,8 +756,8 @@ public class ConnectionService {
     }
 
     private ConnectionConfig entityToModel(@NonNull ConnectionEntity entity, @NonNull Boolean withEnvironment) {
-        return entitiesToModels(Arrays.asList(entity), entity.getOrganizationId(), withEnvironment).stream()
-                .findFirst()
+        return entitiesToModels(Collections.singletonList(entity), entity.getOrganizationId(), withEnvironment)
+                .stream().findFirst()
                 .orElseThrow(() -> new NotFoundException(ResourceType.ODC_CONNECTION, "id", entity.getId()));
     }
 

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/connection/ConnectionService.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/connection/ConnectionService.java
@@ -72,6 +72,7 @@ import com.oceanbase.odc.core.shared.constant.PermissionType;
 import com.oceanbase.odc.core.shared.constant.ResourceType;
 import com.oceanbase.odc.core.shared.exception.BadRequestException;
 import com.oceanbase.odc.core.shared.exception.NotFoundException;
+import com.oceanbase.odc.core.shared.exception.UnexpectedException;
 import com.oceanbase.odc.metadb.collaboration.EnvironmentRepository;
 import com.oceanbase.odc.metadb.connection.ConnectionAttributeEntity;
 import com.oceanbase.odc.metadb.connection.ConnectionAttributeRepository;
@@ -745,7 +746,7 @@ public class ConnectionService {
             if (withEnvironment) {
                 Environment environment = id2Environment.getOrDefault(connection.getEnvironmentId(), null);
                 if (Objects.isNull(environment)) {
-                    return connection;
+                    throw new UnexpectedException("environment not found, id=" + connection.getEnvironmentId());
                 }
                 connection.setEnvironmentStyle(environment.getStyle());
                 connection.setEnvironmentName(environment.getName());

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/connection/ConnectionService.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/connection/ConnectionService.java
@@ -42,6 +42,7 @@ import org.springframework.context.annotation.Lazy;
 import org.springframework.context.i18n.LocaleContextHolder;
 import org.springframework.data.domain.Example;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.domain.Specification;
@@ -301,9 +302,8 @@ public class ConnectionService {
         if (CollectionUtils.isEmpty(ids)) {
             return Collections.emptyList();
         }
-        List<ConnectionConfig> connections = this.repository
-                .findAll(ConnectionSpecs.idIn(ids)).stream().map(connection -> entityToModel(connection, false))
-                .collect(Collectors.toList());
+        List<ConnectionConfig> connections = entitiesToModels(this.repository
+                .findAll(ConnectionSpecs.idIn(ids)), currentOrganizationId(), false);
         if (CollectionUtils.isEmpty(connections)) {
             return Collections.emptyList();
         }
@@ -345,14 +345,12 @@ public class ConnectionService {
 
     @SkipAuthorize("odc internal usage")
     public List<ConnectionConfig> listByOrganizationId(@NonNull Long organizationId) {
-        return repository.findByOrganizationId(organizationId).stream().map(ds -> entityToModel(ds, true))
-                .collect(Collectors.toList());
+        return entitiesToModels(repository.findByOrganizationId(organizationId), organizationId, true);
     }
 
     @SkipAuthorize("odc internal usage")
     public List<ConnectionConfig> listByOrganizationIdWithoutEnvironment(@NonNull Long organizationId) {
-        return repository.findByOrganizationId(organizationId).stream().map(ds -> entityToModel(ds, false))
-                .collect(Collectors.toList());
+        return entitiesToModels(repository.findByOrganizationId(organizationId), organizationId, false);
     }
 
     @Transactional(rollbackFor = Exception.class)
@@ -388,9 +386,9 @@ public class ConnectionService {
         Specification<ConnectionEntity> spec = Specification
                 .where(ConnectionSpecs.organizationIdEqual(currentOrganizationId()))
                 .and(ConnectionSpecs.idIn(connIds));
-        Map<Long, ConnectionConfig> connMap = repository.findAll(spec).stream()
-                .map(connection -> entityToModel(connection, false))
-                .collect(Collectors.toMap(ConnectionConfig::getId, c -> c));
+        Map<Long, ConnectionConfig> connMap =
+                entitiesToModels(repository.findAll(spec), currentOrganizationId(), false).stream()
+                        .collect(Collectors.toMap(ConnectionConfig::getId, c -> c));
         Map<SecurityResource, Set<String>> res2Actions = authorizationFacade.getRelatedResourcesAndActions(user)
                 .entrySet().stream().collect(Collectors.toMap(e -> {
                     SecurityResource s = e.getKey();
@@ -436,19 +434,13 @@ public class ConnectionService {
                     .collect(Collectors.joining(","));
             throw new NotFoundException(ResourceType.ODC_CONNECTION, "id", absentIds);
         }
-        return entities.stream().map(connectionEntity -> entityToModel(connectionEntity, false))
-                .collect(Collectors.toList());
+        return entitiesToModels(entities, currentOrganizationId(), false);
     }
 
     @Transactional(rollbackFor = Exception.class)
     @SkipAuthorize("odc internal usage")
     public Set<Long> findIdsByHost(String host) {
         return repository.findIdsByHost(host);
-    }
-
-    @SkipAuthorize("internal usage")
-    public List<ConnectionConfig> listAllConnections() {
-        return repository.findAll().stream().map(mapper::entityToModel).collect(Collectors.toList());
     }
 
     @SkipAuthorize("internal usage")
@@ -579,11 +571,6 @@ public class ConnectionService {
         return repository.findByIdIn(ids).stream().map(mapper::entityToModel).collect(Collectors.toList());
     }
 
-    @SkipAuthorize("odc internal usage")
-    public boolean existsById(@NotNull Long id) {
-        return repository.existsById(id);
-    }
-
     @SkipAuthorize("internal usage")
     public ConnectionConfig getForConnectionSkipPermissionCheck(@NotNull Long id) {
         ConnectionConfig connection = internalGetSkipUserCheck(id, false);
@@ -650,7 +637,9 @@ public class ConnectionService {
         spec = spec.and(ConnectionSpecs.sort(pageable.getSort()));
         Pageable page = pageable.equals(Pageable.unpaged()) ? pageable
                 : PageRequest.of(pageable.getPageNumber(), pageable.getPageSize());
-        return this.repository.findAll(spec, page).map(connection -> entityToModel(connection, true));
+        Page<ConnectionEntity> entities = this.repository.findAll(spec, page);
+        List<ConnectionConfig> models = entitiesToModels(entities.getContent(), currentOrganizationId(), true);
+        return new PageImpl<>(models, page, entities.getTotalElements());
     }
 
     private String[] getHostPort(String hostPort) {
@@ -738,6 +727,39 @@ public class ConnectionService {
 
     private ConnectionEntity getEntity(@NonNull Long id) {
         return repository.findById(id).orElseThrow(() -> new NotFoundException(ResourceType.ODC_CONNECTION, "id", id));
+    }
+
+    private List<ConnectionConfig> entitiesToModels(@NonNull List<ConnectionEntity> entities,
+            @NonNull Long organizationId, @NonNull Boolean withEnvironment) {
+        if (CollectionUtils.isEmpty(entities)) {
+            return Collections.EMPTY_LIST;
+        }
+        Map<Long, Environment> id2Environment;
+        if (withEnvironment) {
+            id2Environment = environmentService.list(organizationId).stream()
+                    .collect(Collectors.toMap(environment -> environment.getId(), environment -> environment));
+        } else {
+            id2Environment = new HashMap<>();
+        }
+        return entities.stream().map(entity -> {
+            ConnectionConfig connection = mapper.entityToModel(entity);
+            connection.setStatus(CheckState.of(ConnectionStatus.TESTING));
+            if (withEnvironment) {
+                Environment environment = id2Environment.getOrDefault(connection.getEnvironmentId(), null);
+                if (Objects.isNull(environment)) {
+                    return connection;
+                }
+                connection.setEnvironmentStyle(environment.getStyle());
+                String environmentName = environment.getName();
+                if (environmentName.startsWith("${") && environmentName.endsWith("}")) {
+                    connection.setEnvironmentName(I18n.translate(environmentName.substring(2,
+                            environmentName.length() - 1), null, LocaleContextHolder.getLocale()));
+                } else {
+                    connection.setEnvironmentName(environmentName);
+                }
+            }
+            return connection;
+        }).collect(Collectors.toList());
     }
 
     private ConnectionConfig entityToModel(@NonNull ConnectionEntity entity, @NonNull Boolean withEnvironment) {

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/connection/ConnectionService.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/connection/ConnectionService.java
@@ -39,7 +39,6 @@ import org.apache.commons.lang.ObjectUtils;
 import org.apache.commons.lang.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Lazy;
-import org.springframework.context.i18n.LocaleContextHolder;
 import org.springframework.data.domain.Example;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
@@ -54,7 +53,6 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.DefaultTransactionDefinition;
 import org.springframework.validation.annotation.Validated;
 
-import com.oceanbase.odc.common.i18n.I18n;
 import com.oceanbase.odc.common.json.JsonUtils;
 import com.oceanbase.odc.core.authority.SecurityManager;
 import com.oceanbase.odc.core.authority.model.DefaultSecurityResource;
@@ -750,13 +748,7 @@ public class ConnectionService {
                     return connection;
                 }
                 connection.setEnvironmentStyle(environment.getStyle());
-                String environmentName = environment.getName();
-                if (environmentName.startsWith("${") && environmentName.endsWith("}")) {
-                    connection.setEnvironmentName(I18n.translate(environmentName.substring(2,
-                            environmentName.length() - 1), null, LocaleContextHolder.getLocale()));
-                } else {
-                    connection.setEnvironmentName(environmentName);
-                }
+                connection.setEnvironmentName(environment.getName());
             }
             return connection;
         }).collect(Collectors.toList());
@@ -768,13 +760,7 @@ public class ConnectionService {
         if (withEnvironment) {
             Environment environment = environmentService.detailSkipPermissionCheck(entity.getEnvironmentId());
             connection.setEnvironmentStyle(environment.getStyle());
-            String environmentName = environment.getName();
-            if (environmentName.startsWith("${") && environmentName.endsWith("}")) {
-                connection.setEnvironmentName(I18n.translate(environmentName.substring(2,
-                        environmentName.length() - 1), null, LocaleContextHolder.getLocale()));
-            } else {
-                connection.setEnvironmentName(environmentName);
-            }
+            connection.setEnvironmentName(environment.getName());
         }
         return connection;
     }

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/connection/ConnectionService.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/connection/ConnectionService.java
@@ -756,14 +756,9 @@ public class ConnectionService {
     }
 
     private ConnectionConfig entityToModel(@NonNull ConnectionEntity entity, @NonNull Boolean withEnvironment) {
-        ConnectionConfig connection = mapper.entityToModel(entity);
-        connection.setStatus(CheckState.of(ConnectionStatus.TESTING));
-        if (withEnvironment) {
-            Environment environment = environmentService.detailSkipPermissionCheck(entity.getEnvironmentId());
-            connection.setEnvironmentStyle(environment.getStyle());
-            connection.setEnvironmentName(environment.getName());
-        }
-        return connection;
+        return entitiesToModels(Arrays.asList(entity), entity.getOrganizationId(), withEnvironment).stream()
+                .findFirst()
+                .orElseThrow(() -> new NotFoundException(ResourceType.ODC_CONNECTION, "id", entity.getId()));
     }
 
     private ConnectionEntity modelToEntity(@NonNull ConnectionConfig model) {

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/connection/database/DatabaseService.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/connection/database/DatabaseService.java
@@ -36,7 +36,6 @@ import javax.validation.constraints.NotNull;
 
 import org.apache.commons.lang.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.i18n.LocaleContextHolder;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.domain.Specification;
@@ -47,7 +46,6 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.CollectionUtils;
 import org.springframework.validation.annotation.Validated;
 
-import com.oceanbase.odc.common.i18n.I18n;
 import com.oceanbase.odc.core.authority.util.Authenticated;
 import com.oceanbase.odc.core.authority.util.PreAuthenticate;
 import com.oceanbase.odc.core.authority.util.SkipAuthorize;
@@ -235,21 +233,18 @@ public class DatabaseService {
         }
         Page<Database> databases = list(params, Pageable.unpaged());
         if (CollectionUtils.isEmpty(databases.getContent())) {
-            return Collections.EMPTY_LIST;
+            return Collections.emptyList();
         }
         return databases.stream().filter(database -> Objects.nonNull(database.getDataSource()))
                 .map(database -> {
                     ConnectionConfig connection = database.getDataSource();
                     Environment environment = database.getEnvironment();
-                    if (environment.getName().startsWith("${") && environment.getName().endsWith("}")) {
-                        connection
-                                .setEnvironmentName(I18n.translate(
-                                        environment.getName().substring(2, environment.getName().length() - 1), null,
-                                        LocaleContextHolder.getLocale()));
+                    if (Objects.isNull(environment)) {
+                        log.warn("database environment is null, databaseId={}", database.getId());
                     } else {
+                        connection.setEnvironmentStyle(environment.getStyle());
                         connection.setEnvironmentName(environment.getName());
                     }
-                    connection.setEnvironmentStyle(database.getEnvironment().getStyle());
                     return connection;
                 })
                 .collect(Collectors.collectingAndThen(

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/connection/model/ConnectionConfig.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/connection/model/ConnectionConfig.java
@@ -33,6 +33,7 @@ import org.apache.commons.collections4.CollectionUtils;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonProperty.Access;
+import com.oceanbase.odc.common.i18n.Internationalizable;
 import com.oceanbase.odc.common.json.SensitiveInput;
 import com.oceanbase.odc.common.util.StringUtils;
 import com.oceanbase.odc.common.validate.Name;
@@ -298,6 +299,7 @@ public class ConnectionConfig
     private Long environmentId;
 
     @JsonProperty(access = Access.READ_ONLY)
+    @Internationalizable
     private String environmentName;
 
     @JsonProperty(access = Access.READ_ONLY)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines.
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request.
3. Ensure you have added or ran the appropriate tests for your PR.
5. If the PR is unfinished, you may add or remove a WIP or [WIP] prefix to your pull request title.
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
type-bug
type-feature
type-docs
etc.

Optionally add one or more of the following kinds if applicable:
module-resultset
module-sql execution
etc.
-->
type-bug
module-datasource

#### What this PR does / why we need it:
While there is a huge amount of data sources (like 3k), the data source list on the left side in the SQL console refreshes very slowly, and the data source connect status would always be loading without response. 

The related API:
- `/api/v2/collaboration/projects/databases/stats`
- `/api/v2/datasource/datasources/status`

The reason for the slow stats API is that when we convert entities to DTOs, our time cost is O(n) because we will query the environment entity for each data source. To solve this issue, we just query the environments only one time, to load the results into the map, and find the specific environment entity by id. In this way, the time cost is reduced to O(1).

The reason for not being able to load the data source status is that the browser limits the URL length and when we have like 3k data sources to test status, our GET request size exceeds the limit. The way to solve this problem is to use the POST method instead and pack parameters in the request body rather than in the URL parameters.


After the optimization, in the scenario of 3k data sources, the stats API RT reduced from 15000 - 16000 ms to 250 - 300 ms.
What's more, the connection status API works now, but it costs 20s under 3k data sources which is not acceptable. The front end should have some strategy to avoid packing all the data sources into one request. @HSunboy 


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #484
Fixes #483 

#### Special notes for your reviewer:

<!--
This section is used to describe how this PR is implemented. 
If this is a PR that fixes a bug, this section describes how the bug was fixed.
If it's a new feature, this section briefly describes how to implement the new feature.
etc.
-->

#### Additional documentation e.g., usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```