### PR TITLE
feat(data-security): add data type unit into response

### DIFF
--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/datasecurity/SensitiveColumnService.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/datasecurity/SensitiveColumnService.java
@@ -70,6 +70,7 @@ import com.oceanbase.odc.service.datasecurity.model.SensitiveColumnStats;
 import com.oceanbase.odc.service.datasecurity.model.SensitiveRule;
 import com.oceanbase.odc.service.datasecurity.util.SensitiveColumnMapper;
 import com.oceanbase.odc.service.db.browser.DBSchemaAccessors;
+import com.oceanbase.odc.service.feature.VersionDiffConfigService;
 import com.oceanbase.odc.service.iam.HorizontalDataPermissionValidator;
 import com.oceanbase.odc.service.iam.UserService;
 import com.oceanbase.odc.service.iam.auth.AuthenticationFacade;
@@ -116,6 +117,9 @@ public class SensitiveColumnService {
     @Autowired
     private HorizontalDataPermissionValidator permissionValidator;
 
+    @Autowired
+    private VersionDiffConfigService versionDiffConfigService;
+
     private static final SensitiveColumnMapper mapper = SensitiveColumnMapper.INSTANCE;
 
     @Transactional(rollbackFor = Exception.class)
@@ -140,6 +144,7 @@ public class SensitiveColumnService {
                         accessor.listBasicTableColumns(database.getName()), exists));
                 databaseColumn.setView2Columns(getFilteringExistColumns(database.getId(),
                         accessor.listBasicViewColumns(database.getName()), exists));
+                databaseColumn.setDataTypeUnits(versionDiffConfigService.getDatatypeList(session));
                 if (!databaseColumn.getTable2Columns().isEmpty() || !databaseColumn.getView2Columns().isEmpty()) {
                     databaseColumns.add(databaseColumn);
                 }

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/datasecurity/model/DatabaseWithAllColumns.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/datasecurity/model/DatabaseWithAllColumns.java
@@ -19,6 +19,7 @@ package com.oceanbase.odc.service.datasecurity.model;
 import java.util.List;
 import java.util.Map;
 
+import com.oceanbase.odc.service.feature.model.DataTypeUnit;
 import com.oceanbase.tools.dbbrowser.model.DBTableColumn;
 
 import lombok.Data;
@@ -34,5 +35,9 @@ public class DatabaseWithAllColumns {
     private String databaseName;
     private Map<String, List<DBTableColumn>> table2Columns;
     private Map<String, List<DBTableColumn>> view2Columns;
+    /**
+     * Mapping from database type to show type, used for displaying column type icon
+     */
+    private List<DataTypeUnit> dataTypeUnits;
 
 }


### PR DESCRIPTION
#### What type of PR is this?
type-feature
module-data security

#### What this PR does / why we need it:
When manually add sensitive columns, we will show column type icon as followings:
<img width="704" alt="image" src="https://github.com/oceanbase/odc/assets/84772536/4e21b0c0-6631-4126-9092-784e7683a991">
Different databse type and version has different column type, so we need response data type unit to front-end.

#### Which issue(s) this PR fixes:
Fixes #46 