### PR TITLE
feat(sql-splitter): support SqlCommentProcessor to split sql by stream

### DIFF
--- a/server/odc-core/src/main/java/com/oceanbase/odc/core/sql/split/SqlCommentProcessor.java
+++ b/server/odc-core/src/main/java/com/oceanbase/odc/core/sql/split/SqlCommentProcessor.java
@@ -96,11 +96,11 @@ public class SqlCommentProcessor {
 
     public SqlCommentProcessor() {}
 
-    public static SqlLine getSqlLines(InputStream in, DialectType dialectType,
+    public static SqlStatementIterator iterator(InputStream in, DialectType dialectType,
             boolean preserveFormat,
             boolean preserveSingleComments,
             boolean preserveMultiComments) {
-        return new SqlLine(in, dialectType, preserveFormat, preserveSingleComments, preserveMultiComments);
+        return new SqlStatementIterator(in, dialectType, preserveFormat, preserveSingleComments, preserveMultiComments);
     }
 
     public static List<String> removeSqlComments(String originalSql,
@@ -612,7 +612,7 @@ public class SqlCommentProcessor {
         }
     }
 
-    public static class SqlLine implements Iterator<String>, AutoCloseable {
+    public static class SqlStatementIterator implements Iterator<String>, AutoCloseable {
         private final BufferedReader reader;
         private final StringBuffer buffer = new StringBuffer();
         private final LinkedList<String> holder = new LinkedList<>();
@@ -621,7 +621,7 @@ public class SqlCommentProcessor {
 
         private String current;
 
-        public SqlLine(InputStream input, DialectType dialectType,
+        public SqlStatementIterator(InputStream input, DialectType dialectType,
                 boolean preserveFormat,
                 boolean preserveSingleComments,
                 boolean preserveMultiComments) {

--- a/server/odc-core/src/main/java/com/oceanbase/odc/core/sql/split/SqlCommentProcessor.java
+++ b/server/odc-core/src/main/java/com/oceanbase/odc/core/sql/split/SqlCommentProcessor.java
@@ -15,9 +15,15 @@
  */
 package com.oceanbase.odc.core.sql.split;
 
+import java.io.BufferedReader;
+import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Iterator;
+import java.util.LinkedList;
 import java.util.List;
+import java.util.NoSuchElementException;
 import java.util.Objects;
 
 import com.oceanbase.odc.core.shared.constant.DialectType;
@@ -89,6 +95,10 @@ public class SqlCommentProcessor {
     }
 
     public SqlCommentProcessor() {}
+
+    public SqlIterator iterator(InputStream in) {
+        return new SqlIterator(in);
+    }
 
     public static List<String> removeSqlComments(String originalSql,
             String delimiter, DialectType dbMode, boolean preserveFormat) {
@@ -596,6 +606,73 @@ public class SqlCommentProcessor {
 
         public int getValue() {
             return value;
+        }
+    }
+
+    public class SqlIterator implements Iterator<String>, AutoCloseable {
+        private final BufferedReader reader;
+        private final StringBuffer buffer = new StringBuffer();
+        private final LinkedList<String> holder = new LinkedList<>();
+        private String current;
+
+        public SqlIterator(InputStream input) {
+            this.reader = new BufferedReader(new InputStreamReader(input));
+        }
+
+        @Override
+        public boolean hasNext() {
+            if (current == null) {
+                current = parseNext();
+            }
+            return current != null;
+        }
+
+        @Override
+        public String next() {
+            String next = current;
+            current = null;
+            if (next == null) {
+                next = parseNext();
+                if (next == null) {
+                    throw new NoSuchElementException("No more available sql.");
+                }
+            }
+            return next;
+        }
+
+        private String parseNext() {
+            try {
+                if (!holder.isEmpty()) {
+                    return holder.poll();
+                }
+                String line;
+                while (holder.isEmpty() && (line = reader.readLine()) != null) {
+                    if (Objects.nonNull(dialectType) && dialectType.isMysql()) {
+                        addLineMysql(holder, buffer, line);
+                    } else if (Objects.nonNull(dialectType) && dialectType.isOracle()) {
+                        addLineOracle(holder, buffer, line);
+                    }
+                }
+                if (!holder.isEmpty()) {
+                    return holder.poll();
+                }
+                if (buffer.toString().trim().length() == 0) {
+                    return null;
+                }
+                String sql = buffer.toString();
+                buffer.setLength(0);
+                return sql;
+            } catch (Exception e) {
+                throw new RuntimeException("Failed to parse input. reason: " + e.getMessage(), e);
+            }
+        }
+
+        @Override
+        public void close() throws Exception {
+            reader.close();
+            mlComment = false;
+            inString = '\0';
+            inNormalSql = false;
         }
     }
 

--- a/server/odc-core/src/test/java/com/oceanbase/odc/core/sql/split/SqlCommentProcessorTest.java
+++ b/server/odc-core/src/test/java/com/oceanbase/odc/core/sql/split/SqlCommentProcessorTest.java
@@ -28,6 +28,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import com.oceanbase.odc.core.shared.constant.DialectType;
+import com.oceanbase.odc.core.sql.split.SqlCommentProcessor.SqlLine;
 
 public class SqlCommentProcessorTest {
 
@@ -60,13 +61,12 @@ public class SqlCommentProcessorTest {
     @Test
     public void testIterator_MysqlMode() throws Exception {
         List<String> sqls;
-        SqlCommentProcessor processor = new SqlCommentProcessor(DialectType.OB_MYSQL, false, false, false);
         try (InputStream in =
                 this.getClass().getClassLoader().getResourceAsStream("sql/split/comment-processor-mysql-test.sql");
-                SqlCommentProcessor.SqlIterator iterator = processor.iterator(in)) {
+                SqlLine iterator = SqlCommentProcessor.getSqlLines(in, DialectType.OB_MYSQL, false, false, false)) {
             sqls = IteratorUtils.toList(iterator);
         }
-        sqls.forEach(System.out::println);
+        SqlCommentProcessor processor = new SqlCommentProcessor(DialectType.OB_MYSQL, false, false, false);
         List<String> rawList =
                 getVerifySqlFromFile("sql/split/comment-processor-mysql-verify.sql", processor.getDelimiter());
         Assert.assertEquals(rawList.size(), sqls.size());
@@ -78,12 +78,12 @@ public class SqlCommentProcessorTest {
     @Test
     public void testIterator_OracleMode() throws Exception {
         List<String> sqls;
-        SqlCommentProcessor processor = new SqlCommentProcessor(DialectType.OB_ORACLE, false, false, false);
         try (InputStream in =
                 this.getClass().getClassLoader().getResourceAsStream("sql/split/comment-processor-oracle-test.sql");
-                SqlCommentProcessor.SqlIterator iterator = processor.iterator(in)) {
+                SqlLine iterator = SqlCommentProcessor.getSqlLines(in, DialectType.OB_ORACLE, false, false, false)) {
             sqls = IteratorUtils.toList(iterator);
         }
+        SqlCommentProcessor processor = new SqlCommentProcessor(DialectType.OB_ORACLE, false, false, false);
         List<String> rawList =
                 getVerifySqlFromFile("sql/split/comment-processor-oracle-verify.sql", processor.getDelimiter());
         Assert.assertEquals(rawList.size(), sqls.size());

--- a/server/odc-core/src/test/java/com/oceanbase/odc/core/sql/split/SqlCommentProcessorTest.java
+++ b/server/odc-core/src/test/java/com/oceanbase/odc/core/sql/split/SqlCommentProcessorTest.java
@@ -62,13 +62,13 @@ public class SqlCommentProcessorTest {
         List<String> sqls;
         SqlCommentProcessor processor = new SqlCommentProcessor(DialectType.OB_MYSQL, false, false, false);
         try (InputStream in =
-            this.getClass().getClassLoader().getResourceAsStream("sql/split/comment-processor-mysql-test.sql");
-            SqlCommentProcessor.SqlIterator iterator = processor.iterator(in)) {
+                this.getClass().getClassLoader().getResourceAsStream("sql/split/comment-processor-mysql-test.sql");
+                SqlCommentProcessor.SqlIterator iterator = processor.iterator(in)) {
             sqls = IteratorUtils.toList(iterator);
         }
         sqls.forEach(System.out::println);
         List<String> rawList =
-            getVerifySqlFromFile("sql/split/comment-processor-mysql-verify.sql", processor.getDelimiter());
+                getVerifySqlFromFile("sql/split/comment-processor-mysql-verify.sql", processor.getDelimiter());
         Assert.assertEquals(rawList.size(), sqls.size());
         for (int i = 0; i < sqls.size(); i++) {
             Assert.assertEquals(rawList.get(i), String.format("%s%s%s", sqls.get(i), processor.getDelimiter(), "\n"));
@@ -80,12 +80,12 @@ public class SqlCommentProcessorTest {
         List<String> sqls;
         SqlCommentProcessor processor = new SqlCommentProcessor(DialectType.OB_ORACLE, false, false, false);
         try (InputStream in =
-            this.getClass().getClassLoader().getResourceAsStream("sql/split/comment-processor-oracle-test.sql");
-            SqlCommentProcessor.SqlIterator iterator = processor.iterator(in)) {
+                this.getClass().getClassLoader().getResourceAsStream("sql/split/comment-processor-oracle-test.sql");
+                SqlCommentProcessor.SqlIterator iterator = processor.iterator(in)) {
             sqls = IteratorUtils.toList(iterator);
         }
         List<String> rawList =
-            getVerifySqlFromFile("sql/split/comment-processor-oracle-verify.sql", processor.getDelimiter());
+                getVerifySqlFromFile("sql/split/comment-processor-oracle-verify.sql", processor.getDelimiter());
         Assert.assertEquals(rawList.size(), sqls.size());
         for (int i = 0; i < sqls.size(); i++) {
             Assert.assertEquals(rawList.get(i), String.format("%s%s%s", sqls.get(i), processor.getDelimiter(), "\n"));

--- a/server/odc-core/src/test/java/com/oceanbase/odc/core/sql/split/SqlCommentProcessorTest.java
+++ b/server/odc-core/src/test/java/com/oceanbase/odc/core/sql/split/SqlCommentProcessorTest.java
@@ -28,7 +28,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import com.oceanbase.odc.core.shared.constant.DialectType;
-import com.oceanbase.odc.core.sql.split.SqlCommentProcessor.SqlLine;
+import com.oceanbase.odc.core.sql.split.SqlCommentProcessor.SqlStatementIterator;
 
 public class SqlCommentProcessorTest {
 
@@ -63,7 +63,8 @@ public class SqlCommentProcessorTest {
         List<String> sqls;
         try (InputStream in =
                 this.getClass().getClassLoader().getResourceAsStream("sql/split/comment-processor-mysql-test.sql");
-                SqlLine iterator = SqlCommentProcessor.getSqlLines(in, DialectType.OB_MYSQL, false, false, false)) {
+                SqlStatementIterator iterator =
+                        SqlCommentProcessor.iterator(in, DialectType.OB_MYSQL, false, false, false)) {
             sqls = IteratorUtils.toList(iterator);
         }
         SqlCommentProcessor processor = new SqlCommentProcessor(DialectType.OB_MYSQL, false, false, false);
@@ -80,7 +81,8 @@ public class SqlCommentProcessorTest {
         List<String> sqls;
         try (InputStream in =
                 this.getClass().getClassLoader().getResourceAsStream("sql/split/comment-processor-oracle-test.sql");
-                SqlLine iterator = SqlCommentProcessor.getSqlLines(in, DialectType.OB_ORACLE, false, false, false)) {
+                SqlStatementIterator iterator =
+                        SqlCommentProcessor.iterator(in, DialectType.OB_ORACLE, false, false, false)) {
             sqls = IteratorUtils.toList(iterator);
         }
         SqlCommentProcessor processor = new SqlCommentProcessor(DialectType.OB_ORACLE, false, false, false);

--- a/server/odc-core/src/test/java/com/oceanbase/odc/core/sql/split/SqlCommentProcessorTest.java
+++ b/server/odc-core/src/test/java/com/oceanbase/odc/core/sql/split/SqlCommentProcessorTest.java
@@ -76,6 +76,23 @@ public class SqlCommentProcessorTest {
     }
 
     @Test
+    public void testIterator_OracleMode() throws Exception {
+        List<String> sqls;
+        SqlCommentProcessor processor = new SqlCommentProcessor(DialectType.OB_ORACLE, false, false, false);
+        try (InputStream in =
+            this.getClass().getClassLoader().getResourceAsStream("sql/split/comment-processor-oracle-test.sql");
+            SqlCommentProcessor.SqlIterator iterator = processor.iterator(in)) {
+            sqls = IteratorUtils.toList(iterator);
+        }
+        List<String> rawList =
+            getVerifySqlFromFile("sql/split/comment-processor-oracle-verify.sql", processor.getDelimiter());
+        Assert.assertEquals(rawList.size(), sqls.size());
+        for (int i = 0; i < sqls.size(); i++) {
+            Assert.assertEquals(rawList.get(i), String.format("%s%s%s", sqls.get(i), processor.getDelimiter(), "\n"));
+        }
+    }
+
+    @Test
     public void split_splitBySlashAndContainsMultiComment_splitSucceed() {
         List<String> sqls = new ArrayList<>();
         sqls.add("CREATE\n"

--- a/server/odc-core/src/test/java/com/oceanbase/odc/core/sql/split/SqlCommentProcessorTest.java
+++ b/server/odc-core/src/test/java/com/oceanbase/odc/core/sql/split/SqlCommentProcessorTest.java
@@ -23,6 +23,7 @@ import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.apache.commons.collections4.IteratorUtils;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -50,6 +51,24 @@ public class SqlCommentProcessorTest {
         List<String> sqls = getSqlWithoutComment(processor, line);
         List<String> rawList =
                 getVerifySqlFromFile("sql/split/comment-processor-oracle-verify.sql", processor.getDelimiter());
+        Assert.assertEquals(rawList.size(), sqls.size());
+        for (int i = 0; i < sqls.size(); i++) {
+            Assert.assertEquals(rawList.get(i), String.format("%s%s%s", sqls.get(i), processor.getDelimiter(), "\n"));
+        }
+    }
+
+    @Test
+    public void testIterator_MysqlMode() throws Exception {
+        List<String> sqls;
+        SqlCommentProcessor processor = new SqlCommentProcessor(DialectType.OB_MYSQL, false, false, false);
+        try (InputStream in =
+            this.getClass().getClassLoader().getResourceAsStream("sql/split/comment-processor-mysql-test.sql");
+            SqlCommentProcessor.SqlIterator iterator = processor.iterator(in)) {
+            sqls = IteratorUtils.toList(iterator);
+        }
+        sqls.forEach(System.out::println);
+        List<String> rawList =
+            getVerifySqlFromFile("sql/split/comment-processor-mysql-verify.sql", processor.getDelimiter());
         Assert.assertEquals(rawList.size(), sqls.size());
         for (int i = 0; i < sqls.size(); i++) {
             Assert.assertEquals(rawList.get(i), String.format("%s%s%s", sqls.get(i), processor.getDelimiter(), "\n"));


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines.
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request.
3. Ensure you have added or ran the appropriate tests for your PR.
5. If the PR is unfinished, you may add or remove a WIP or [WIP] prefix to your pull request title.
-->

#### What type of PR is this?
type-feature
<!--
Add one of the following kinds:
type-bug
type-feature
type-docs
etc.

Optionally add one or more of the following kinds if applicable:
module-resultset
module-sql execution
etc.
-->

#### What this PR does / why we need it:
The `SqlCommentProcessor` needs to read SQL text into memory at once and then split it. When the SQL file is large, OOM exceptions may occur. 
This PR supports reading and splitting SQL through a `InputStream`.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
none, just an optimization

#### Special notes for your reviewer:
The UT has passed.
<!--
This section is used to describe how this PR is implemented. 
If this is a PR that fixes a bug, this section describes how the bug was fixed.
If it's a new feature, this section briefly describes how to implement the new feature.
etc.
-->

#### Additional documentation e.g., usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```