### PR TITLE
fix(database-change): failed to view a scheduled database change task with rollback plan in personal space

### DIFF
--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/flow/FlowInstanceService.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/flow/FlowInstanceService.java
@@ -624,20 +624,25 @@ public class FlowInstanceService {
         ExecutionStrategyConfig strategyConfig = ExecutionStrategyConfig.from(flowInstanceReq,
                 ExecutionStrategyConfig.INVALID_EXPIRE_INTERVAL_SECOND);
         try {
-            FlowTaskInstance taskInstance =
-                    flowFactory.generateFlowTaskInstance(flowInstance.getId(), true, true, taskType,
-                            strategyConfig);
-            taskInstance.setTargetTaskId(taskEntity.getId());
-            taskInstance.update();
             TaskParameters parameters = flowInstanceReq.getParameters();
             FlowInstanceConfigurer taskConfigurer;
             if (taskType == TaskType.ASYNC
                     && Boolean.TRUE.equals(((DatabaseChangeParameters) parameters).getGenerateRollbackPlan())) {
+                FlowTaskInstance taskInstance =
+                        flowFactory.generateFlowTaskInstance(flowInstance.getId(), false, true, taskType,
+                                strategyConfig);
+                taskInstance.setTargetTaskId(taskEntity.getId());
+                taskInstance.update();
                 FlowTaskInstance rollbackPlanInstance =
-                        flowFactory.generateFlowTaskInstance(flowInstance.getId(), false, false,
+                        flowFactory.generateFlowTaskInstance(flowInstance.getId(), true, false,
                                 TaskType.GENERATE_ROLLBACK, ExecutionStrategyConfig.autoStrategy());
                 taskConfigurer = flowInstance.newFlowInstance().next(rollbackPlanInstance).next(taskInstance);
             } else {
+                FlowTaskInstance taskInstance =
+                        flowFactory.generateFlowTaskInstance(flowInstance.getId(), true, true, taskType,
+                                strategyConfig);
+                taskInstance.setTargetTaskId(taskEntity.getId());
+                taskInstance.update();
                 taskConfigurer = flowInstance.newFlowInstance().next(taskInstance);
             }
             taskConfigurer.endFlowInstance();


### PR DESCRIPTION


#### What type of PR is this?
type-bug
module-database-change


#### What this PR does / why we need it:
after creating a scheduled database change task in personal space, the task details cannot be viewed after checking the option to generate a rollback plan.
The cause is `FlowInstanceService#buildWithoutApprovalNode` method incorrectly constructs `FlowInstance` when `rollbackPlanInstance` is added before the `service task`.

#### Which issue(s) this PR fixes:

Fixes #414

#### Special notes for your reviewer:

<!--
This section is used to describe how this PR is implemented. 
If this is a PR that fixes a bug, this section describes how the bug was fixed.
If it's a new feature, this section briefly describes how to implement the new feature.
etc.
-->

#### Additional documentation e.g., usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```