### PR TITLE
fix(result-set-export): get wrong filename for result-set export task on cloud

### DIFF
--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/resultset/DumperResultSetExportTaskManager.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/resultset/DumperResultSetExportTaskManager.java
@@ -27,7 +27,6 @@ import org.springframework.stereotype.Component;
 
 import com.oceanbase.odc.common.util.StringUtils;
 import com.oceanbase.odc.core.session.ConnectionSession;
-import com.oceanbase.odc.service.datatransfer.model.DataTransferFormat;
 import com.oceanbase.odc.service.objectstorage.cloud.CloudObjectStorageService;
 import com.oceanbase.odc.service.session.util.SqlRewriteUtil;
 
@@ -68,7 +67,7 @@ public class DumperResultSetExportTaskManager implements ResultSetExportTaskMana
     @Override
     public ResultSetExportTaskContext start(ConnectionSession session, ResultSetExportTaskParameter parameter,
             String userId, String taskId) {
-        if (parameter.getFileFormat() != DataTransferFormat.SQL || parameter.getTableName() == null) {
+        if (parameter.getTableName() == null) {
             parameter.setTableName(DEFAULT_FILE_PREFIX);
         }
         String fileName = StringUtils.isBlank(parameter.getFileName()) ? "result_set" : parameter.getFileName().trim();

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/resultset/DumperResultSetExportTaskManager.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/resultset/DumperResultSetExportTaskManager.java
@@ -27,6 +27,7 @@ import org.springframework.stereotype.Component;
 
 import com.oceanbase.odc.common.util.StringUtils;
 import com.oceanbase.odc.core.session.ConnectionSession;
+import com.oceanbase.odc.service.datatransfer.model.DataTransferFormat;
 import com.oceanbase.odc.service.objectstorage.cloud.CloudObjectStorageService;
 import com.oceanbase.odc.service.session.util.SqlRewriteUtil;
 
@@ -67,7 +68,7 @@ public class DumperResultSetExportTaskManager implements ResultSetExportTaskMana
     @Override
     public ResultSetExportTaskContext start(ConnectionSession session, ResultSetExportTaskParameter parameter,
             String userId, String taskId) {
-        if (parameter.getTableName() == null) {
+        if (parameter.getFileFormat() != DataTransferFormat.SQL || parameter.getTableName() == null) {
             parameter.setTableName(DEFAULT_FILE_PREFIX);
         }
         String fileName = StringUtils.isBlank(parameter.getFileName()) ? "result_set" : parameter.getFileName().trim();

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/resultset/ResultSetExportTask.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/resultset/ResultSetExportTask.java
@@ -426,7 +426,7 @@ public class ResultSetExportTask implements Callable<ResultSetExportResult> {
         try {
             if (cloudObjectStorageService.supported()) {
                 try {
-                    String objectName = cloudObjectStorageService.uploadTemp(origin.getName(), origin);
+                    String objectName = cloudObjectStorageService.uploadTemp(fileName, origin);
                     ((OssTaskReferManager) SpringContextUtil.getBean("ossTaskReferManager")).put(fileName, objectName);
                 } catch (Exception exception) {
                     throw new UnexpectedException(String


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines.
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request.
3. Ensure you have added or ran the appropriate tests for your PR.
5. If the PR is unfinished, you may add or remove a WIP or [WIP] prefix to your pull request title.
-->

#### What type of PR is this?
type-bug
<!--
Add one of the following kinds:
type-bug
type-feature
type-docs
etc.

Optionally add one or more of the following kinds if applicable:
module-resultset
module-sql execution
etc.
-->

#### What this PR does / why we need it:
There is a code bug which will lead to get wrong filename for result-set export task. So we use user-configured filename to upload result instead of origin filename.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
none