### PR TITLE
fix(sql-execute): no trace id when sql executing failed

### DIFF
--- a/server/odc-core/src/main/java/com/oceanbase/odc/core/sql/execute/model/JdbcGeneralResult.java
+++ b/server/odc-core/src/main/java/com/oceanbase/odc/core/sql/execute/model/JdbcGeneralResult.java
@@ -42,6 +42,7 @@ public class JdbcGeneralResult {
     private JdbcQueryResult queryResult;
     @Setter
     private int affectRows;
+    @Getter
     private final Exception thrown;
     @Getter
     @Setter

--- a/server/odc-core/src/main/java/com/oceanbase/odc/core/sql/util/FullLinkTraceUtil.java
+++ b/server/odc-core/src/main/java/com/oceanbase/odc/core/sql/util/FullLinkTraceUtil.java
@@ -48,7 +48,12 @@ public class FullLinkTraceUtil {
                 throw new UnexpectedException("No trace info, maybe value of ob_enable_show_trace is 0.");
             }
             String showTraceJson = resultSet.getString(1);
-            SqlExecTime execDetail = parseSpanList(JsonUtils.fromJsonList(showTraceJson, TraceSpan.class));
+            SqlExecTime execDetail;
+            try {
+                execDetail = parseSpanList(JsonUtils.fromJsonList(showTraceJson, TraceSpan.class));
+            } catch (Exception e) {
+                throw new UnexpectedException("Parse trace failed, original text: " + showTraceJson, e);
+            }
 
             execDetail.setLastPacketSendTimestamp(lastPacketSendTimestamp);
             execDetail.setLastPacketResponseTimestamp(lastPacketResponseTimestamp);

--- a/server/odc-core/src/main/java/com/oceanbase/odc/core/sql/util/FullLinkTraceUtil.java
+++ b/server/odc-core/src/main/java/com/oceanbase/odc/core/sql/util/FullLinkTraceUtil.java
@@ -48,12 +48,7 @@ public class FullLinkTraceUtil {
                 throw new UnexpectedException("No trace info, maybe value of ob_enable_show_trace is 0.");
             }
             String showTraceJson = resultSet.getString(1);
-            SqlExecTime execDetail;
-            try {
-                execDetail = parseSpanList(JsonUtils.fromJsonList(showTraceJson, TraceSpan.class));
-            } catch (Exception e) {
-                throw new UnexpectedException("Parse trace failed, original text: " + showTraceJson, e);
-            }
+            SqlExecTime execDetail = parseSpanList(JsonUtils.fromJsonList(showTraceJson, TraceSpan.class));
 
             execDetail.setLastPacketSendTimestamp(lastPacketSendTimestamp);
             execDetail.setLastPacketResponseTimestamp(lastPacketResponseTimestamp);

--- a/server/odc-core/src/test/java/com/oceanbase/odc/core/sql/util/FullLinkTraceUtilTest.java
+++ b/server/odc-core/src/test/java/com/oceanbase/odc/core/sql/util/FullLinkTraceUtilTest.java
@@ -34,7 +34,7 @@ import com.oceanbase.odc.core.sql.execute.model.SqlExecTime;
 public class FullLinkTraceUtilTest {
     @Test
     public void test_GetFullLinkTrace() throws Exception {
-        SqlExecTime execDetail = FullLinkTraceUtil.getFullLinkTraceDetail(mockStmt());
+        SqlExecTime execDetail = FullLinkTraceUtil.getFullLinkTraceDetail(mockStmt(), 60);
         Assert.assertNotNull(execDetail.getTraceSpan());
     }
 

--- a/server/odc-server/src/main/resources/data.sql
+++ b/server/odc-server/src/main/resources/data.sql
@@ -517,6 +517,8 @@ INSERT INTO config_system_configuration(`key`, `value`, `description`) VALUES('o
    '-1', '当前 database 最大 MemStore 空间占用，单位字节，默认值 -1， <=0 表示不限制') ON DUPLICATE KEY UPDATE `id`=`id`;
 INSERT INTO config_system_configuration(`key`, `value`, `description`) VALUES('odc.session.full-link-trace.enabled',
    'true', '是否开启全链路诊断的功能，默认为开启') ON DUPLICATE KEY UPDATE `id`=`id`;
+INSERT INTO config_system_configuration(`key`, `value`, `description`) VALUES('odc.session.full-link-trace-timeout-seconds',
+   '60', '查询全链路追踪的超时时间，单位为秒，默认 60 秒') ON DUPLICATE KEY UPDATE `id`=`id`;
 
 INSERT INTO config_system_configuration(`key`, `value`, `description`) VALUES('odc.security.file.upload.safe-suffix-list',
    '*', '允许上传的文件名扩展名，默认 *，表示允许所有文件扩展名') ON DUPLICATE KEY UPDATE `id`=`id`;

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/session/ConnectConsoleService.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/session/ConnectConsoleService.java
@@ -252,6 +252,7 @@ public class ConnectConsoleService {
                 new OdcStatementCallBack(sqlTuples, connectionSession, request.getAutoCommit(), queryLimit);
         statementCallBack.setDbmsoutputMaxRows(sessionProperties.getDbmsOutputMaxRows());
         statementCallBack.setUseFullLinkTrace(sessionProperties.isEnableFullLinkTrace());
+        statementCallBack.setFullLinkTraceTimeout(sessionProperties.getFullLinkTraceTimeoutSeconds());
         statementCallBack.setMaxCachedSize(sessionProperties.getResultSetMaxCachedSize());
         statementCallBack.setMaxCachedLines(sessionProperties.getResultSetMaxCachedLines());
 

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/session/OdcStatementCallBack.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/session/OdcStatementCallBack.java
@@ -114,6 +114,8 @@ public class OdcStatementCallBack implements StatementCallback<List<JdbcGeneralR
     @Setter
     private boolean useFullLinkTrace = false;
     @Setter
+    private int fullLinkTraceTimeout = 60;
+    @Setter
     private int maxCachedLines = 10000;
     @Setter
     private BiPredicate<Integer, ResultSetMetaData> cachePredicate = new CacheColumnPredicate();
@@ -173,7 +175,7 @@ public class OdcStatementCallBack implements StatementCallback<List<JdbcGeneralR
                     log.warn("Init driver statistic collect failed, reason={}", e.getMessage());
                 }
                 List<JdbcGeneralResult> executeResults;
-                if (returnVal.stream().anyMatch(r -> r.getStatus() == SqlExecuteStatus.FAILED) || !stopWhenError) {
+                if (returnVal.stream().noneMatch(r -> r.getStatus() == SqlExecuteStatus.FAILED) || !stopWhenError) {
                     try {
                         executeResults = doExecuteSql(statement, sqlTuple);
                     } catch (Exception exception) {
@@ -394,7 +396,7 @@ public class OdcStatementCallBack implements StatementCallback<List<JdbcGeneralR
             SqlExecTime executeDetails;
             if (useFullLinkTrace && VersionUtils.isGreaterThanOrEqualsTo(version, "4.1") &&
                     connectionSession.getDialectType().isOceanbase()) {
-                executeDetails = FullLinkTraceUtil.getFullLinkTraceDetail(statement);
+                executeDetails = FullLinkTraceUtil.getFullLinkTraceDetail(statement, fullLinkTraceTimeout);
             } else {
                 executeDetails = ConnectionPluginUtil.getTraceExtension(connectionSession.getDialectType())
                         .getExecuteDetail(statement, version);

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/session/SessionProperties.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/session/SessionProperties.java
@@ -128,4 +128,10 @@ public class SessionProperties {
     @Value("${odc.session.full-link-trace.enabled:true}")
     private boolean enableFullLinkTrace = true;
 
+    /**
+     * Timeout for querying full link trace
+     */
+    @Value("${odc.session.full-link-trace-timeout-seconds:60}")
+    private int fullLinkTraceTimeoutSeconds;
+
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines.
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request.
3. Ensure you have added or ran the appropriate tests for your PR.
5. If the PR is unfinished, you may add or remove a WIP or [WIP] prefix to your pull request title.
-->

#### What type of PR is this?
type-bug
<!--
Add one of the following kinds:
type-bug
type-feature
type-docs
etc.

Optionally add one or more of the following kinds if applicable:
module-resultset
module-sql execution
etc.
-->

#### What this PR does / why we need it:
When sql executing failed, ODC would not query trace id for it. In this PR, there will always be trace id, no matter it's succeeded or failed.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #697 
