### PR TITLE
fix(web): response header content-type would be application/xml while using RestTemplate

### DIFF
--- a/server/odc-server/src/main/java/com/oceanbase/odc/server/config/MvcConfiguration.java
+++ b/server/odc-server/src/main/java/com/oceanbase/odc/server/config/MvcConfiguration.java
@@ -33,6 +33,7 @@ import org.springframework.format.datetime.standard.DateTimeFormatterRegistrar;
 import org.springframework.http.MediaType;
 import org.springframework.http.converter.HttpMessageConverter;
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.http.converter.xml.MappingJackson2XmlHttpMessageConverter;
 import org.springframework.web.context.request.RequestContextListener;
 import org.springframework.web.filter.RequestContextFilter;
 import org.springframework.web.filter.ShallowEtagHeaderFilter;
@@ -115,15 +116,28 @@ public class MvcConfiguration implements WebMvcConfigurer {
 
     @Override
     public void extendMessageConverters(List<HttpMessageConverter<?>> converters) {
-        for (HttpMessageConverter converter : converters) {
+        int xmlConverterIndex = -1;
+        int jacksonConverterIndex = -1;
+        for (int i = 0; i < converters.size(); i++) {
+            HttpMessageConverter<?> converter = converters.get(i);
+            if (converter instanceof MappingJackson2XmlHttpMessageConverter) {
+                xmlConverterIndex = i;
+            }
             if (converter instanceof MappingJackson2HttpMessageConverter) {
+                jacksonConverterIndex = i;
                 MappingJackson2HttpMessageConverter jacksonConverter = (MappingJackson2HttpMessageConverter) converter;
                 jacksonConverter.setObjectMapper(objectMapper);
                 log.info("update objectMapper for jackson http message converter");
-                return;
             }
         }
-        throw new RuntimeException("no jackson http message converter found!");
+        if (jacksonConverterIndex == -1) {
+            throw new RuntimeException("no jackson http message converter found!");
+        }
+        if (xmlConverterIndex != -1) {
+            HttpMessageConverter<?> jacksonConverter = converters.get(jacksonConverterIndex);
+            converters.set(jacksonConverterIndex, converters.get(xmlConverterIndex));
+            converters.set(xmlConverterIndex, jacksonConverter);
+        }
     }
 
 

--- a/server/odc-server/src/main/java/com/oceanbase/odc/server/config/MvcConfiguration.java
+++ b/server/odc-server/src/main/java/com/oceanbase/odc/server/config/MvcConfiguration.java
@@ -133,7 +133,9 @@ public class MvcConfiguration implements WebMvcConfigurer {
         if (jacksonConverterIndex == -1) {
             throw new RuntimeException("no jackson http message converter found!");
         }
-        if (xmlConverterIndex != -1) {
+        // swap xml converter and jackson converter if the xmlConverter exists and is before
+        // jacksonConverter
+        if (xmlConverterIndex != -1 && xmlConverterIndex < jacksonConverterIndex) {
             HttpMessageConverter<?> jacksonConverter = converters.get(jacksonConverterIndex);
             converters.set(jacksonConverterIndex, converters.get(xmlConverterIndex));
             converters.set(xmlConverterIndex, jacksonConverter);

--- a/server/odc-server/src/main/java/com/oceanbase/odc/server/config/MvcConfiguration.java
+++ b/server/odc-server/src/main/java/com/oceanbase/odc/server/config/MvcConfiguration.java
@@ -133,8 +133,11 @@ public class MvcConfiguration implements WebMvcConfigurer {
         if (jacksonConverterIndex == -1) {
             throw new RuntimeException("no jackson http message converter found!");
         }
-        // swap xml converter and jackson converter if the xmlConverter exists and is before
-        // jacksonConverter
+        /**
+         * swap xml converter and jackson converter if the xmlConverter exists and is before
+         * jacksonConverter
+         */
+
         if (xmlConverterIndex != -1 && xmlConverterIndex < jacksonConverterIndex) {
             HttpMessageConverter<?> jacksonConverter = converters.get(jacksonConverterIndex);
             converters.set(jacksonConverterIndex, converters.get(xmlConverterIndex));

--- a/server/odc-service/src/main/java/com/oceanbase/odc/config/RestTemplateConfig.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/config/RestTemplateConfig.java
@@ -17,17 +17,13 @@ package com.oceanbase.odc.config;
 
 import java.nio.charset.Charset;
 import java.time.Duration;
-import java.util.Iterator;
-import java.util.List;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.MediaType;
-import org.springframework.http.converter.HttpMessageConverter;
 import org.springframework.http.converter.StringHttpMessageConverter;
-import org.springframework.http.converter.xml.MappingJackson2XmlHttpMessageConverter;
 import org.springframework.web.client.RestTemplate;
 
 import com.alibaba.fastjson.support.spring.FastJsonHttpMessageConverter4;
@@ -50,21 +46,12 @@ public class RestTemplateConfig {
      */
     @Bean("internalProxyRestTemplate")
     public RestTemplate internalProxyRestTemplate() {
-
-        RestTemplate restTemplate = new RestTemplateBuilder()
+        return new RestTemplateBuilder()
                 .rootUri("http://localhost:" + serverPort)
                 .setConnectTimeout(Duration.ofSeconds(1))
                 .setReadTimeout(Duration.ofSeconds(60))
                 .errorHandler(new IgnoreResponseErrorHandler())
                 .build();
-        List<HttpMessageConverter<?>> converters = restTemplate.getMessageConverters();
-        for (Iterator<HttpMessageConverter<?>> iterator = converters.iterator(); iterator.hasNext();) {
-            HttpMessageConverter<?> converter = iterator.next();
-            if (converter instanceof MappingJackson2XmlHttpMessageConverter) {
-                iterator.remove();
-            }
-        }
-        return restTemplate;
     }
 
     @Bean("vpcRestTemplate")

--- a/server/odc-service/src/main/java/com/oceanbase/odc/config/RestTemplateConfig.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/config/RestTemplateConfig.java
@@ -17,13 +17,17 @@ package com.oceanbase.odc.config;
 
 import java.nio.charset.Charset;
 import java.time.Duration;
+import java.util.Iterator;
+import java.util.List;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.MediaType;
+import org.springframework.http.converter.HttpMessageConverter;
 import org.springframework.http.converter.StringHttpMessageConverter;
+import org.springframework.http.converter.xml.MappingJackson2XmlHttpMessageConverter;
 import org.springframework.web.client.RestTemplate;
 
 import com.alibaba.fastjson.support.spring.FastJsonHttpMessageConverter4;
@@ -46,12 +50,21 @@ public class RestTemplateConfig {
      */
     @Bean("internalProxyRestTemplate")
     public RestTemplate internalProxyRestTemplate() {
-        return new RestTemplateBuilder()
+
+        RestTemplate restTemplate = new RestTemplateBuilder()
                 .rootUri("http://localhost:" + serverPort)
                 .setConnectTimeout(Duration.ofSeconds(1))
                 .setReadTimeout(Duration.ofSeconds(60))
                 .errorHandler(new IgnoreResponseErrorHandler())
                 .build();
+        List<HttpMessageConverter<?>> converters = restTemplate.getMessageConverters();
+        for (Iterator<HttpMessageConverter<?>> iterator = converters.iterator(); iterator.hasNext();) {
+            HttpMessageConverter<?> converter = iterator.next();
+            if (converter instanceof MappingJackson2XmlHttpMessageConverter) {
+                iterator.remove();
+            }
+        }
+        return restTemplate;
     }
 
     @Bean("vpcRestTemplate")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines.
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request.
3. Ensure you have added or ran the appropriate tests for your PR.
5. If the PR is unfinished, you may add or remove a WIP or [WIP] prefix to your pull request title.
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
type-bug
type-feature
type-docs
etc.

Optionally add one or more of the following kinds if applicable:
module-resultset
module-sql execution
etc.
-->
type-bug
module-web

#### What this PR does / why we need it:
The [PR](https://github.com/oceanbase/odc/pull/338) involves a problem that the response header `content-type` would be `application/xml` while using RestTemplate. The root cause is that after importing the dependency `jackson-dataformat-xml`, Spring will automatically register a `MappingJackson2XmlHttpMessageConverter` whose order is higher than `MappingJackson2HttpMessageConverter`. If the request header Accept is like `'text/plain, */*'`, Spring will firstly use `MappingJackson2XmlHttpMessageConverter` to convert the response to an xml format which would cause the issue.

This PR swap the order of `MappingJackson2HttpMessageConverter` and `MappingJackson2XmlHttpMessageConverter` to make `MappingJackson2XmlHttpMessageConverter` work before `MappingJackson2XmlHttpMessageConverter`.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

<!--
This section is used to describe how this PR is implemented. 
If this is a PR that fixes a bug, this section describes how the bug was fixed.
If it's a new feature, this section briefly describes how to implement the new feature.
etc.
-->

#### Additional documentation e.g., usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```