### PR TITLE
fix(sql-execute): fix the issue where the number type is displayed using scientific notation when the value is 0.0000000

### DIFF
--- a/server/odc-core/src/main/java/com/oceanbase/odc/core/sql/execute/mapper/DefaultJdbcRowMapper.java
+++ b/server/odc-core/src/main/java/com/oceanbase/odc/core/sql/execute/mapper/DefaultJdbcRowMapper.java
@@ -46,6 +46,7 @@ public class DefaultJdbcRowMapper extends BaseDialectBasedRowMapper {
             mapperList.add(new MySQLDatetimeMapper());
             mapperList.add(new MySQLYearMapper());
             mapperList.add(new MySQLTimestampMapper());
+            mapperList.add(new MySQLNumberMapper());
         } else if (dialectType == DialectType.OB_ORACLE) {
             mapperList.add(new OracleNlsFormatDateMapper(
                     ConnectionSessionUtil.getNlsDateFormat(session)));

--- a/server/odc-core/src/main/java/com/oceanbase/odc/core/sql/execute/mapper/MySQLNumberMapper.java
+++ b/server/odc-core/src/main/java/com/oceanbase/odc/core/sql/execute/mapper/MySQLNumberMapper.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2023 OceanBase.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.oceanbase.odc.core.sql.execute.mapper;
+
+import java.sql.SQLException;
+
+import org.apache.commons.lang3.StringUtils;
+
+import com.oceanbase.tools.dbbrowser.model.datatype.DataType;
+
+import lombok.NonNull;
+
+/**
+ * {@link MySQLNumberMapper}
+ *
+ * @author yh263208
+ * @date 2023-11-10 14:55
+ * @since ODC_release_4.2.2bp
+ */
+public class MySQLNumberMapper implements JdbcColumnMapper {
+
+    @Override
+    public Object mapCell(@NonNull CellData data) throws SQLException {
+        byte[] content = data.getBytes();
+        if (content == null) {
+            return null;
+        }
+        return new String(content);
+    }
+
+    @Override
+    public boolean supports(@NonNull DataType dataType) {
+        return StringUtils.containsAnyIgnoreCase(dataType.getDataTypeName(), "DECIMAL", "NUMBER", "FIXED");
+    }
+
+}

--- a/server/odc-core/src/test/java/com/oceanbase/odc/core/sql/execute/mapper/MySQLNumberMapperTest.java
+++ b/server/odc-core/src/test/java/com/oceanbase/odc/core/sql/execute/mapper/MySQLNumberMapperTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2023 OceanBase.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.oceanbase.odc.core.sql.execute.mapper;
+
+import java.io.IOException;
+import java.sql.SQLException;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.oceanbase.odc.core.sql.execute.tool.BitCellData;
+import com.oceanbase.tools.dbbrowser.model.datatype.CommonDataTypeFactory;
+import com.oceanbase.tools.dbbrowser.model.datatype.DataType;
+import com.oceanbase.tools.dbbrowser.model.datatype.DataTypeFactory;
+
+/**
+ * Test cases for {@link MySQLNumberMapper}
+ *
+ * @author yh263208
+ * @date 2023-11-10 15:28
+ * @since ODC_release_4.22bp
+ */
+public class MySQLNumberMapperTest {
+
+    @Test
+    public void mapCell_nonNullNumber_returnRightValue() throws IOException, SQLException {
+        DataTypeFactory factory = new CommonDataTypeFactory("decimal unsigned");
+        DataType dataType = factory.generate();
+        MySQLNumberMapper mapper = new MySQLNumberMapper();
+        String expect = "0.0000000";
+        Assert.assertEquals(expect, mapper.mapCell(new BitCellData(expect.getBytes(), dataType)));
+    }
+
+    @Test
+    public void mapCell_nullNumber_returnNull() throws IOException, SQLException {
+        DataTypeFactory factory = new CommonDataTypeFactory("decimal unsigned");
+        DataType dataType = factory.generate();
+        MySQLNumberMapper mapper = new MySQLNumberMapper();
+        Assert.assertNull(mapper.mapCell(new BitCellData(null, dataType)));
+    }
+
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines.
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request.
3. Ensure you have added or ran the appropriate tests for your PR.
5. If the PR is unfinished, you may add or remove a WIP or [WIP] prefix to your pull request title.
-->

#### What type of PR is this?

type-bug
<!--
Add one of the following kinds:
type-bug
type-feature
type-docs
etc.

Optionally add one or more of the following kinds if applicable:
module-resultset
module-sql execution
etc.
-->

#### What this PR does / why we need it:

the number content will be displayed by using scientific notation when the value is 0.0000000 which confused the user. this pr fix this problem.

I have tested for three number datatype: `number`, `decimal` and `fixed` and I have also tested these datatypes with zerofill settings. Both two scenarios are normal.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #762 

#### Special notes for your reviewer:

<!--
This section is used to describe how this PR is implemented. 
If this is a PR that fixes a bug, this section describes how the bug was fixed.
If it's a new feature, this section briefly describes how to implement the new feature.
etc.
-->

#### Additional documentation e.g., usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```