### PR TITLE
fix(schema-plugin):  cannot get table detail in odp sharding mysql mode when lower_case_table_names = 1 or 2

### DIFF
--- a/server/plugins/schema-plugin-odp-sharding-ob-mysql/src/main/java/com/oceanbase/odc/plugin/schema/odpsharding/obmysql/ODPShardingOBMySQLTableExtension.java
+++ b/server/plugins/schema-plugin-odp-sharding-ob-mysql/src/main/java/com/oceanbase/odc/plugin/schema/odpsharding/obmysql/ODPShardingOBMySQLTableExtension.java
@@ -23,10 +23,13 @@ import com.oceanbase.odc.common.util.JdbcOperationsUtil;
 import com.oceanbase.odc.plugin.schema.obmysql.OBMySQLTableExtension;
 import com.oceanbase.tools.dbbrowser.editor.DBTablePartitionEditor;
 import com.oceanbase.tools.dbbrowser.editor.mysql.MySQLDBTablePartitionEditor;
+import com.oceanbase.tools.dbbrowser.model.DBTable;
 import com.oceanbase.tools.dbbrowser.schema.DBSchemaAccessor;
 import com.oceanbase.tools.dbbrowser.schema.mysql.ODPOBMySQLSchemaAccessor;
 import com.oceanbase.tools.dbbrowser.stats.DBStatsAccessor;
 import com.oceanbase.tools.dbbrowser.stats.mysql.ODPOBMySQLStatsAccessor;
+
+import lombok.NonNull;
 
 /**
  * @author jingtian
@@ -35,6 +38,17 @@ import com.oceanbase.tools.dbbrowser.stats.mysql.ODPOBMySQLStatsAccessor;
  */
 @Extension
 public class ODPShardingOBMySQLTableExtension extends OBMySQLTableExtension {
+    @Override
+    public DBTable getDetail(@NonNull Connection connection, @NonNull String schemaName, @NonNull String tableName) {
+        DBTable table = super.getDetail(connection, schemaName, tableName);
+        /**
+         * In ODP sharding mysql mode, when variable lower_case_table_names = 1 or 2, the table name will be
+         * stored in uppercase letters. There is no automatic lowercase conversion of table names here.
+         */
+        table.setName(tableName);
+        return table;
+    }
+
     @Override
     protected DBSchemaAccessor getSchemaAccessor(Connection connection) {
         return new ODPOBMySQLSchemaAccessor(JdbcOperationsUtil.getJdbcOperations(connection));


### PR DESCRIPTION


#### What type of PR is this?
type-bug
module-Database object

#### What this PR does / why we need it:
fix cannot get table detail in odp sharding mysql when lower_case_table_names = 1 or 2.
In ODP sharding mysql mode, when variable lower_case_table_names = 1 or 2, the table name will be stored in uppercase letters. There is no need to automatic lowercase conversion of table name when database is Case Sensitive.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #793

#### Special notes for your reviewer:

<!--
This section is used to describe how this PR is implemented. 
If this is a PR that fixes a bug, this section describes how the bug was fixed.
If it's a new feature, this section briefly describes how to implement the new feature.
etc.
-->

#### Additional documentation e.g., usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```