### PR TITLE
fix(name): change resource name length limit from 64 to 128

### DIFF
--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/automation/model/CreateRuleReq.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/automation/model/CreateRuleReq.java
@@ -25,7 +25,7 @@ import lombok.Data;
 
 @Data
 public class CreateRuleReq {
-    @Size(min = 1, max = 64, message = "Automation rule name is out of range [1,64]")
+    @Size(min = 1, max = 128, message = "Automation rule name is out of range [1,128]")
     @Name(message = "Automation rule name cannot start or end with whitespaces")
     private String name;
     private Long eventId;

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/datasecurity/model/MaskingAlgorithm.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/datasecurity/model/MaskingAlgorithm.java
@@ -41,7 +41,7 @@ import lombok.Data;
 
 /**
  * @author gaoda.xy
- * @date 2023/5/9 10:56
+ * @date 2023/5/10 10:56
  */
 @Data
 public class MaskingAlgorithm implements SecurityResource, OrganizationIsolated {

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/datasecurity/model/MaskingAlgorithm.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/datasecurity/model/MaskingAlgorithm.java
@@ -49,7 +49,7 @@ public class MaskingAlgorithm implements SecurityResource, OrganizationIsolated 
     @JsonProperty(access = Access.READ_ONLY)
     private Long id;
 
-    @Size(min = 1, max = 64, message = "Masking algorithm name is out of range [1,64]")
+    @Size(min = 1, max = 128, message = "Masking algorithm name is out of range [1,128]")
     @Name(message = "Masking algorithm name cannot start or end with whitespaces")
     @Internationalizable
     private String name;

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/datasecurity/model/SensitiveRule.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/datasecurity/model/SensitiveRule.java
@@ -43,7 +43,7 @@ public class SensitiveRule implements SecurityResource, OrganizationIsolated {
     @JsonProperty(access = Access.READ_ONLY)
     private Long id;
 
-    @Size(min = 1, max = 64, message = "Sensitive rule name is out of range [1,64]")
+    @Size(min = 1, max = 128, message = "Sensitive rule name is out of range [1,128]")
     @Name(message = "Sensitive rule name cannot start or end with whitespaces")
     private String name;
 

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/iam/model/CreateRoleReq.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/iam/model/CreateRoleReq.java
@@ -34,7 +34,7 @@ import lombok.Data;
 
 @Data
 public class CreateRoleReq {
-    @Size(min = 1, max = 64, message = "Role name is out of range [1,64]")
+    @Size(min = 1, max = 128, message = "Role name is out of range [1,128]")
     @Name(message = "Role name cannot start or end with whitespaces")
     private String name;
     private boolean enabled;

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/iam/model/CreateUserReq.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/iam/model/CreateUserReq.java
@@ -35,10 +35,10 @@ import lombok.Setter;
 @Getter
 @Setter
 public class CreateUserReq {
-    @Size(min = 1, max = 64, message = "User name is out of range [1,64]")
+    @Size(min = 1, max = 128, message = "User name is out of range [1,128]")
     @Name(message = "User name cannot start or end with whitespaces")
     private String name;
-    @Size(min = 1, max = 64, message = "User account name is out of range [1,64]")
+    @Size(min = 1, max = 128, message = "User account name is out of range [1,128]")
     @Name(message = "User account name cannot start or end with whitespaces")
     private String accountName;
     @SensitiveInput

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/integration/model/IntegrationConfig.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/integration/model/IntegrationConfig.java
@@ -46,7 +46,7 @@ public class IntegrationConfig implements SecurityResource, OrganizationIsolated
     @NotNull
     private IntegrationType type;
 
-    @Size(min = 1, max = 64, message = "Integration name is out of range [1,64]")
+    @Size(min = 1, max = 128, message = "Integration name is out of range [1,128]")
     @Name(message = "Integration name cannot start or end with whitespaces")
     private String name;
 

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/resourcegroup/model/ModifyResourceGroupReq.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/resourcegroup/model/ModifyResourceGroupReq.java
@@ -43,7 +43,7 @@ public class ModifyResourceGroupReq {
     /**
      * Name for a resource group
      */
-    @Size(min = 1, max = 64, message = "Resource group name is out of range [1,64]")
+    @Size(min = 1, max = 128, message = "Resource group name is out of range [1,128]")
     @Name(message = "Resource group name cannot start or end with whitespaces")
     private String name;
     /**


### PR DESCRIPTION
#### What type of PR is this?
type-bug

#### What this PR does / why we need it:
In cloud mode, the user name may longer than 64 chars. This PR change resource name length limit from 64 to 128.
