### PR TITLE
fix(sql-execution): avoid adding rowid when dblink exists

### DIFF
--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/session/util/SqlRewriteUtil.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/session/util/SqlRewriteUtil.java
@@ -76,16 +76,21 @@ public class SqlRewriteUtil {
         FromReference from = froms.get(0);
         Pivot pivot = null;
         UnPivot unPivot = null;
+        boolean containsdblink = false;
         if (from instanceof NameReference) {
             NameReference nameFrom = (NameReference) from;
             pivot = nameFrom.getPivot();
             unPivot = nameFrom.getUnPivot();
+            /**
+             * 如果 {@link containsdblink} 为 true 意味着表名是 {@code xxx@xxx} 样式的，这代表着 dblink，含有 dblink 的情况下不能改写。
+             */
+            containsdblink = StringUtils.startsWith(nameFrom.getUserVariable(), "@");
         } else if (from instanceof ExpressionReference) {
             ExpressionReference exprFrom = (ExpressionReference) from;
             pivot = exprFrom.getPivot();
             unPivot = exprFrom.getUnPivot();
         }
-        if (pivot != null || unPivot != null) {
+        if (pivot != null || unPivot != null || containsdblink) {
             return originalSql;
         }
         StringBuilder newSql = new StringBuilder(sql);

--- a/server/odc-service/src/test/java/com/oceanbase/odc/service/session/SqlRewriteUtilTest.java
+++ b/server/odc-service/src/test/java/com/oceanbase/odc/service/session/SqlRewriteUtilTest.java
@@ -136,4 +136,11 @@ public class SqlRewriteUtilTest {
         Assert.assertEquals("select distinct val from test t1", sql);
     }
 
+    @Test
+    public void addInternalROWIDColumn_WithDBlink_AddRowIdFailed() {
+        String expect = "select * from aaa@bbb;";
+        String sql = SqlRewriteUtil.addInternalROWIDColumn(expect);
+        Assert.assertEquals(expect, sql);
+    }
+
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines.
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request.
3. Ensure you have added or ran the appropriate tests for your PR.
5. If the PR is unfinished, you may add or remove a WIP or [WIP] prefix to your pull request title.
-->

#### What type of PR is this?

type-bug
<!--
Add one of the following kinds:
type-bug
type-feature
type-docs
etc.

Optionally add one or more of the following kinds if applicable:
module-resultset
module-sql execution
etc.
-->

#### What this PR does / why we need it:

avoid adding rowid when dblink exists

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #214 

#### Special notes for your reviewer:

<!--
This section is used to describe how this PR is implemented. 
If this is a PR that fixes a bug, this section describes how the bug was fixed.
If it's a new feature, this section briefly describes how to implement the new feature.
etc.
-->

#### Additional documentation e.g., usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```