### PR TITLE
fix(sql-execute): move internal rowid to after last select item when rewriting sql

### DIFF
--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/session/util/SqlRewriteUtil.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/session/util/SqlRewriteUtil.java
@@ -45,7 +45,7 @@ import lombok.extern.slf4j.Slf4j;
 public class SqlRewriteUtil {
 
     private static final String SELECT_ODC_INTERNAL_ROWID_STMT =
-            " ROWID AS \"" + OdcConstants.ODC_INTERNAL_ROWID + "\", ";
+            ", ROWID AS \"" + OdcConstants.ODC_INTERNAL_ROWID + "\" ";
 
     public static String addInternalRowIdColumn(String sql, @NonNull AbstractSyntaxTree ast) {
         if (StringUtils.isBlank(sql)) {
@@ -82,6 +82,8 @@ public class SqlRewriteUtil {
         }
         StringBuilder newSql = new StringBuilder(sql);
         List<Projection> selectItems = selectBody.getSelectItems();
+        int lastSelectItemStop = selectItems.get(selectItems.size() - 1).getStop();
+        newSql.insert(lastSelectItemStop + 1, SELECT_ODC_INTERNAL_ROWID_STMT);
         Projection star = new Projection();
         if (selectItems.contains(star)) {
             if (!(from instanceof NameReference)) {
@@ -98,8 +100,6 @@ public class SqlRewriteUtil {
             int starIndex = selectItems.indexOf(star);
             newSql.insert(selectItems.get(starIndex).getStart(), tableName + ".");
         }
-        int firstSelectItemStart = selectItems.get(0).getStart();
-        newSql.insert(firstSelectItemStart, SELECT_ODC_INTERNAL_ROWID_STMT);
         return newSql.toString();
     }
 

--- a/server/odc-service/src/test/java/com/oceanbase/odc/service/session/SqlRewriteUtilTest.java
+++ b/server/odc-service/src/test/java/com/oceanbase/odc/service/session/SqlRewriteUtilTest.java
@@ -27,13 +27,15 @@ public class SqlRewriteUtilTest {
     @Test
     public void addInternalROWIDColumn_WithAlias_AddRowId() {
         String sql = addInternalRowIdColumn("select t.ROWID, t.* from TEST t");
-        Assert.assertEquals("select  ROWID AS \"__ODC_INTERNAL_ROWID__\", t.ROWID, t.* from TEST t", sql);
+        Assert.assertEquals("select t.ROWID, t.*, ROWID AS \"__ODC_INTERNAL_ROWID__\"  from TEST t", sql);
     }
 
     @Test
     public void addInternalROWIDColumn_WithStarInSelect_AddRowId() {
         String sql = addInternalRowIdColumn("select * from TEST;");
-        Assert.assertEquals("select  ROWID AS \"__ODC_INTERNAL_ROWID__\", TEST.* from TEST;", sql);
+        Assert.assertEquals(
+                "select TEST.*, ROWID AS \"__ODC_INTERNAL_ROWID__\"  from TEST;",
+                sql);
     }
 
     @Test
@@ -61,13 +63,13 @@ public class SqlRewriteUtilTest {
     @Test
     public void addInternalROWIDColumn_WithStarInSelectForUpdate_AddRowId() {
         String sql = addInternalRowIdColumn("select * from TEST for update;");
-        Assert.assertEquals("select  ROWID AS \"__ODC_INTERNAL_ROWID__\", TEST.* from TEST for update;", sql);
+        Assert.assertEquals("select TEST.*, ROWID AS \"__ODC_INTERNAL_ROWID__\"  from TEST for update;", sql);
     }
 
     @Test
     public void addInternalROWIDColumn_WithUpperCaseFrom_AddRowIdSuccess() {
         String sql = addInternalRowIdColumn("select * FROM TEST for update;");
-        Assert.assertEquals("select  ROWID AS \"__ODC_INTERNAL_ROWID__\", TEST.* FROM TEST for update;", sql);
+        Assert.assertEquals("select TEST.*, ROWID AS \"__ODC_INTERNAL_ROWID__\"  FROM TEST for update;", sql);
     }
 
     @Test(expected = IllegalStateException.class)
@@ -78,27 +80,27 @@ public class SqlRewriteUtilTest {
     @Test
     public void addInternalROWIDColumn_WithDollarSign_AddRowIdSuccess() {
         String sql = addInternalRowIdColumn("select * FROM GV$SQL_AUDIT;");
-        Assert.assertEquals("select  ROWID AS \"__ODC_INTERNAL_ROWID__\", GV$SQL_AUDIT.* FROM GV$SQL_AUDIT;", sql);
+        Assert.assertEquals("select GV$SQL_AUDIT.*, ROWID AS \"__ODC_INTERNAL_ROWID__\"  FROM GV$SQL_AUDIT;", sql);
     }
 
     @Test
     public void addInternalROWIDColumn_WithBackSlash_AddRowIdSuccess() {
         String sql = addInternalRowIdColumn("select * FROM \"GV\\SQL_AUDIT\";");
-        Assert.assertEquals("select  ROWID AS \"__ODC_INTERNAL_ROWID__\", \"GV\\SQL_AUDIT\".* FROM \"GV\\SQL_AUDIT\";",
+        Assert.assertEquals("select \"GV\\SQL_AUDIT\".*, ROWID AS \"__ODC_INTERNAL_ROWID__\"  FROM \"GV\\SQL_AUDIT\";",
                 sql);
     }
 
     @Test
     public void addInternalROWIDColumn_WithStarInWhereClause_AddRowIdSuccess() {
         String sql = addInternalRowIdColumn("select sid FROM GV$SQL_AUDIT WHERE sid='*';");
-        Assert.assertEquals("select  ROWID AS \"__ODC_INTERNAL_ROWID__\", sid FROM GV$SQL_AUDIT WHERE sid='*';", sql);
+        Assert.assertEquals("select sid, ROWID AS \"__ODC_INTERNAL_ROWID__\"  FROM GV$SQL_AUDIT WHERE sid='*';", sql);
     }
 
     @Test
     public void addInternalROWIDColumn_StarWithinSelect_AddRowIdSuccess() {
         String sql = addInternalRowIdColumn("select* FROM GV$SQL_AUDIT WHERE sid='*';");
         Assert.assertEquals(
-                "select ROWID AS \"__ODC_INTERNAL_ROWID__\", GV$SQL_AUDIT.* FROM GV$SQL_AUDIT WHERE sid='*';", sql);
+                "selectGV$SQL_AUDIT.*, ROWID AS \"__ODC_INTERNAL_ROWID__\"  FROM GV$SQL_AUDIT WHERE sid='*';", sql);
     }
 
     @Test
@@ -110,13 +112,13 @@ public class SqlRewriteUtilTest {
     @Test
     public void addInternalROWIDColumn_WithAlias_AddRowIdSuccess() {
         String sql = addInternalRowIdColumn("select * from GV$SQL_AUDIT g");
-        Assert.assertEquals("select  ROWID AS \"__ODC_INTERNAL_ROWID__\", g.* from GV$SQL_AUDIT g", sql);
+        Assert.assertEquals("select g.*, ROWID AS \"__ODC_INTERNAL_ROWID__\"  from GV$SQL_AUDIT g", sql);
     }
 
     @Test
     public void addInternalROWIDColumn_WithSchema_AddRowIdSuccess() {
         String sql = addInternalRowIdColumn("select * from SYS.GV$SQL_AUDIT");
-        Assert.assertEquals("select  ROWID AS \"__ODC_INTERNAL_ROWID__\", SYS.GV$SQL_AUDIT.* from SYS.GV$SQL_AUDIT",
+        Assert.assertEquals("select SYS.GV$SQL_AUDIT.*, ROWID AS \"__ODC_INTERNAL_ROWID__\"  from SYS.GV$SQL_AUDIT",
                 sql);
     }
 
@@ -129,7 +131,7 @@ public class SqlRewriteUtilTest {
     @Test
     public void addInternalROWIDColumn_WithHint_AddRowIdSuccess() {
         String sql = addInternalRowIdColumn("select /*+ monitor */ id from test");
-        Assert.assertEquals("select /*+ monitor */  ROWID AS \"__ODC_INTERNAL_ROWID__\", id from test", sql);
+        Assert.assertEquals("select /*+ monitor */ id, ROWID AS \"__ODC_INTERNAL_ROWID__\"  from test", sql);
     }
 
     @Test


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines.
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request.
3. Ensure you have added or ran the appropriate tests for your PR.
5. If the PR is unfinished, you may add or remove a WIP or [WIP] prefix to your pull request title.
-->

#### What type of PR is this?
type-bug
<!--
Add one of the following kinds:
type-bug
type-feature
type-docs
etc.

Optionally add one or more of the following kinds if applicable:
module-resultset
module-sql execution
etc.
-->

#### What this PR does / why we need it:
When executing a sql like `select a, b from xxx order by 2`, the result will be sorted by the `b` column .
But in ODC, it would be rewrite into `select ROWID AS "__ODC_INTERNAL_ROWID__" , a, b from xxx order by 2`, which will get a result sorted by the `a` column.

In this PR, we move rowid part to after last select item position. So the sql above would be rewrite as `select a, b, ROWID AS "__ODC_INTERNAL_ROWID__"   from xxx order by 2`. The result will be corrected.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #742 