### PR TITLE
fix(PL): PL params of MySQL mode are not escaped

### DIFF
--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/db/util/OBMysqlCallFunctionCallBack.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/db/util/OBMysqlCallFunctionCallBack.java
@@ -65,7 +65,7 @@ public class OBMysqlCallFunctionCallBack implements ConnectionCallback<CallFunct
         String paramStr = params.stream().map(p -> {
             String value = p.getDefaultValue();
             if (StringUtils.isNotBlank(value)) {
-                return "'" + value + "'";
+                return StringUtils.quoteMysqlValue(value);
             } else if (Objects.isNull(value)) {
                 return "null";
             }

--- a/server/odc-service/src/test/resources/db/mysql_function_callback_test.sql
+++ b/server/odc-service/src/test/resources/db/mysql_function_callback_test.sql
@@ -20,3 +20,10 @@ begin
   return p0+p1;
 end;
 $$
+
+create function ${const:com.oceanbase.odc.service.db.util.OBMysqlCallFunctionCallBackTest.TEST_CASE_3} (
+  p0 varchar(20)) returns varchar(20)
+begin
+  return p0;
+end;
+$$


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines.
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request.
3. Ensure you have added or ran the appropriate tests for your PR.
5. If the PR is unfinished, you may add or remove a WIP or [WIP] prefix to your pull request title.
-->

#### What type of PR is this?
type-bug
<!--
Add one of the following kinds:
type-bug
type-feature
type-docs
etc.

Optionally add one or more of the following kinds if applicable:
module-resultset
module-sql execution
etc.
-->

#### What this PR does / why we need it:
When executing PL in MySQL mode, the input params are just wrapped but not escaped. This leads to syntax errors.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #174 