### PR TITLE
fix(data-transfer): set page size to avoid ob-dumper splitting files

### DIFF
--- a/server/plugins/task-plugin-ob-mysql/src/main/java/com/oceanbase/odc/plugin/task/obmysql/datatransfer/factory/DumpParameterFactory.java
+++ b/server/plugins/task-plugin-ob-mysql/src/main/java/com/oceanbase/odc/plugin/task/obmysql/datatransfer/factory/DumpParameterFactory.java
@@ -88,6 +88,7 @@ public class DumpParameterFactory extends BaseParameterFactory<DumpParameter> {
             parameter.setSnapshot(false);
         }
         if (transferConfig.isTransferData()) {
+            parameter.setPageSize(Integer.MAX_VALUE);
             if (transferConfig.getBatchCommitNum() != null) {
                 parameter.setCommitSize(transferConfig.getBatchCommitNum());
             }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines.
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request.
3. Ensure you have added or ran the appropriate tests for your PR.
5. If the PR is unfinished, you may add or remove a WIP or [WIP] prefix to your pull request title.
-->

#### What type of PR is this?
type-bug
<!--
Add one of the following kinds:
type-bug
type-feature
type-docs
etc.

Optionally add one or more of the following kinds if applicable:
module-resultset
module-sql execution
etc.
-->

#### What this PR does / why we need it:
This PR is to set `DumpParameter.pageSize` into a big value. OB-DUMPER will split transfer task by this param as line counts. 
For example, if we export a table with 10,000 lines by specifing 1000 as  value of `pageSize`  , we will get 10 files after transferring. There files would be named like `xxx.0.0.csv`, `xxx.1.0.csv`, `xxx.2.0.csv`...

So we set this param to `Interger.MAX_VALUE` to avoid ob-dumper splitting fies.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #266 #900 

#### Special notes for your reviewer:
FYI, this PR can only avoid issues like above. If you export a table with several partitions, it will still be splitted into several files.. Each file represents one of its partitions.