### PR TITLE
fix(permission): user can create datasource without any project and role

### DIFF
--- a/server/integration-test/src/test/java/com/oceanbase/odc/service/iam/UserPermissionServiceTest.java
+++ b/server/integration-test/src/test/java/com/oceanbase/odc/service/iam/UserPermissionServiceTest.java
@@ -15,144 +15,37 @@
  */
 package com.oceanbase.odc.service.iam;
 
-import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.Mockito.when;
-
-import java.util.Collections;
 import java.util.List;
 
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
 
 import com.oceanbase.odc.AuthorityTestEnv;
 import com.oceanbase.odc.core.shared.constant.Cipher;
-import com.oceanbase.odc.core.shared.constant.ConnectionVisibleScope;
-import com.oceanbase.odc.core.shared.constant.PermissionType;
-import com.oceanbase.odc.core.shared.constant.ResourceType;
 import com.oceanbase.odc.core.shared.constant.UserType;
-import com.oceanbase.odc.core.shared.exception.NotFoundException;
-import com.oceanbase.odc.metadb.iam.PermissionEntity;
 import com.oceanbase.odc.metadb.iam.UserEntity;
 import com.oceanbase.odc.metadb.iam.UserPermissionEntity;
 import com.oceanbase.odc.service.connection.ConnectionService;
-import com.oceanbase.odc.service.connection.model.ConnectionConfig;
-import com.oceanbase.odc.service.iam.auth.AuthenticationFacade;
-import com.oceanbase.odc.service.iam.model.BatchUpdateUserPermissionsReq;
-import com.oceanbase.odc.service.iam.model.BatchUpdateUserPermissionsReq.UserAction;
-import com.oceanbase.odc.service.iam.model.User;
-import com.oceanbase.odc.service.iam.model.UserPermissionResp;
 
 public class UserPermissionServiceTest extends AuthorityTestEnv {
+
     @Autowired
     private UserPermissionService userPermissionService;
     @MockBean
-    private AuthenticationFacade authenticationFacade;
-    @MockBean
     private ConnectionService connectionService;
-
-    @Rule
-    public ExpectedException thrown = ExpectedException.none();
-    private static final Long OTHER_ORGANIZATION_ID = 1001L;
 
     @Before
     public void setUp() {
-        // clear related tables
         deleteAll();
-        // create a test user and role, and grant suitable permissions
-        UserEntity currentUserEntity = grantAllPermissions(ResourceType.ODC_CONNECTION);
-        User user = new User(currentUserEntity);
-        when(authenticationFacade.currentUser()).thenReturn(user);
-        when(authenticationFacade.currentUserId()).thenReturn(user.getId());
-        when(authenticationFacade.currentOrganizationId()).thenReturn(user.getOrganizationId());
     }
 
     @After
     public void clear() {
         deleteAll();
-    }
-
-    @Test
-    public void test_listUserPermissions() {
-        UserEntity user1 = createUser("user1", ORGANIZATION_ID);
-        UserEntity user2 = createUser("user2", ORGANIZATION_ID);
-        PermissionEntity permission1 = createPermission("ODC_CONNECTION:1", "apply");
-        PermissionEntity permission2 = createPermission("ODC_CONNECTION:1", "connect");
-        createUserPermission(user1.getId(), permission1.getId());
-        createUserPermission(user2.getId(), permission2.getId());
-        List<UserPermissionResp> respNotEmpty = userPermissionService.list("ODC_CONNECTION:1");
-        Assert.assertEquals(2, respNotEmpty.size());
-        List<UserPermissionResp> respEmpty = userPermissionService.list("ODC_CONNECTION:2");
-        Assert.assertEquals(0, respEmpty.size());
-    }
-
-    @Test
-    public void test_batchUpdateForConnection_Success() {
-        ConnectionConfig config = new ConnectionConfig();
-        config.setOrganizationId(ORGANIZATION_ID);
-        when(connectionService.getWithoutPermissionCheck(anyLong())).thenReturn(config);
-        UserEntity user1 = createUser("user1", ORGANIZATION_ID);
-        UserEntity user2 = createUser("user2", ORGANIZATION_ID);
-        UserEntity user3 = createUser("user3", ORGANIZATION_ID);
-        PermissionEntity permission1 = createPermission("ODC_CONNECTION:1", "apply");
-        PermissionEntity permission2 = createPermission("ODC_CONNECTION:1", "connect");
-        createUserPermission(user1.getId(), permission1.getId());
-        createUserPermission(user2.getId(), permission2.getId());
-        List<UserPermissionResp> originalResp = userPermissionService.list("ODC_CONNECTION:1");
-        Assert.assertEquals(2, originalResp.size());
-
-        BatchUpdateUserPermissionsReq req = new BatchUpdateUserPermissionsReq();
-        req.setResourceIdentifier("ODC_CONNECTION:1");
-        req.setUserActions(Collections.singletonList(createUserActions(user3.getId(), "apply")));
-        List<UserPermissionResp> updateResp = userPermissionService.batchUpdateForConnection(req);
-        Assert.assertEquals(1, updateResp.size());
-        List<UserPermissionResp> currentResp = userPermissionService.list("ODC_CONNECTION:1");
-        Assert.assertEquals(1, currentResp.size());
-        Assert.assertEquals("apply", currentResp.get(0).getAction());
-    }
-
-    @Test
-    public void test_batchUpdateForConnection_HorizontalAuthoring_Connection() {
-        ConnectionConfig config = new ConnectionConfig();
-        config.setId(1L);
-        config.setOrganizationId(OTHER_ORGANIZATION_ID);
-        config.setVisibleScope(ConnectionVisibleScope.ORGANIZATION);
-        when(connectionService.getWithoutPermissionCheck(anyLong())).thenReturn(config);
-        UserEntity user1 = createUser("user1", ORGANIZATION_ID);
-        UserEntity user2 = createUser("user2", ORGANIZATION_ID);
-        PermissionEntity permission1 = createPermission("ODC_CONNECTION:1", "apply");
-        createUserPermission(user1.getId(), permission1.getId());
-        List<UserPermissionResp> originalResp = userPermissionService.list("ODC_CONNECTION:1");
-        Assert.assertEquals(1, originalResp.size());
-
-        BatchUpdateUserPermissionsReq req = new BatchUpdateUserPermissionsReq();
-        req.setResourceIdentifier("ODC_CONNECTION:1");
-        req.setUserActions(Collections.singletonList(createUserActions(user2.getId(), "apply")));
-        thrown.expect(NotFoundException.class);
-        thrown.expectMessage(String.format("%s not found by %s=%s", ResourceType.ODC_CONNECTION, "id", 1));
-        List<UserPermissionResp> updateResp = userPermissionService.batchUpdateForConnection(req);
-    }
-
-    @Test
-    public void test_batchUpdateForConnection_HorizontalAuthoring_User() {
-        UserEntity user1 = createUser("user1", ORGANIZATION_ID);
-        UserEntity user2 = createUser("user2", OTHER_ORGANIZATION_ID);
-        PermissionEntity permission1 = createPermission("ODC_CONNECTION:1", "apply");
-        createUserPermission(user1.getId(), permission1.getId());
-        List<UserPermissionResp> originalResp = userPermissionService.list("ODC_CONNECTION:1");
-        Assert.assertEquals(1, originalResp.size());
-
-        BatchUpdateUserPermissionsReq req = new BatchUpdateUserPermissionsReq();
-        req.setResourceIdentifier("ODC_CONNECTION:1");
-        req.setUserActions(Collections.singletonList(createUserActions(user2.getId(), "apply")));
-        thrown.expect(NotFoundException.class);
-        thrown.expectMessage(String.format("%s not found by %s=%s", ResourceType.ODC_USER, "id", user2.getId()));
-        List<UserPermissionResp> updateResp = userPermissionService.batchUpdateForConnection(req);
     }
 
     @Test
@@ -163,23 +56,6 @@ public class UserPermissionServiceTest extends AuthorityTestEnv {
         Assert.assertEquals(1, userPermission.size());
     }
 
-    @Test
-    public void test_deleteExistsUserPermissions() {
-        UserEntity user1 = createUser("user1", ORGANIZATION_ID);
-        PermissionEntity permission1 = createPermission("ODC_CONNECTION:1", "apply");
-        PermissionEntity permission2 = createPermission("ODC_CONNECTION:2", "connect");
-        createUserPermission(user1.getId(), permission1.getId());
-        createUserPermission(user1.getId(), permission2.getId());
-        List<UserPermissionResp> resp1 = userPermissionService.list("ODC_CONNECTION:1");
-        Assert.assertEquals(1, resp1.size());
-        List<UserPermissionResp> resp2 = userPermissionService.list("ODC_CONNECTION:2");
-        Assert.assertEquals(1, resp2.size());
-        userPermissionService.deleteExistsUserPermissions(new User(user1), Collections.singletonList(permission1));
-        List<UserPermissionResp> resp3 = userPermissionService.list("ODC_CONNECTION:1");
-        Assert.assertEquals(0, resp3.size());
-        List<UserPermissionResp> resp4 = userPermissionService.list("ODC_CONNECTION:2");
-        Assert.assertEquals(1, resp4.size());
-    }
 
     private UserEntity createUser(String name, Long organizationId) {
         UserEntity userEntity = new UserEntity();
@@ -196,30 +72,4 @@ public class UserPermissionServiceTest extends AuthorityTestEnv {
         return userRepository.saveAndFlush(userEntity);
     }
 
-    private PermissionEntity createPermission(String resourceIdentifier, String action) {
-        PermissionEntity permissionEntity = new PermissionEntity();
-        permissionEntity.setAction(action);
-        permissionEntity.setCreatorId(ADMIN_USER_ID);
-        permissionEntity.setOrganizationId(ORGANIZATION_ID);
-        permissionEntity.setResourceIdentifier(resourceIdentifier);
-        permissionEntity.setType(PermissionType.PUBLIC_RESOURCE);
-        permissionEntity.setBuiltIn(false);
-        return permissionRepository.saveAndFlush(permissionEntity);
-    }
-
-    private UserPermissionEntity createUserPermission(Long userId, Long permissionId) {
-        UserPermissionEntity userPermissionEntity = new UserPermissionEntity();
-        userPermissionEntity.setUserId(userId);
-        userPermissionEntity.setPermissionId(permissionId);
-        userPermissionEntity.setCreatorId(ADMIN_USER_ID);
-        userPermissionEntity.setOrganizationId(ORGANIZATION_ID);
-        return userPermissionRepository.saveAndFlush(userPermissionEntity);
-    }
-
-    private UserAction createUserActions(Long userId, String action) {
-        UserAction userAction = new UserAction();
-        userAction.setUserId(userId);
-        userAction.setAction(action);
-        return userAction;
-    }
 }

--- a/server/odc-server/src/main/java/com/oceanbase/odc/server/web/controller/v2/IamController.java
+++ b/server/odc-server/src/main/java/com/oceanbase/odc/server/web/controller/v2/IamController.java
@@ -54,7 +54,6 @@ import com.oceanbase.odc.service.iam.RoleService;
 import com.oceanbase.odc.service.iam.UserBatchImportPreviewer;
 import com.oceanbase.odc.service.iam.UserPermissionService;
 import com.oceanbase.odc.service.iam.UserService;
-import com.oceanbase.odc.service.iam.model.BatchUpdateUserPermissionsReq;
 import com.oceanbase.odc.service.iam.model.ChangePasswordReq;
 import com.oceanbase.odc.service.iam.model.CreateRoleReq;
 import com.oceanbase.odc.service.iam.model.CreateUserReq;
@@ -65,7 +64,6 @@ import com.oceanbase.odc.service.iam.model.Role;
 import com.oceanbase.odc.service.iam.model.UpdateRoleReq;
 import com.oceanbase.odc.service.iam.model.UpdateUserReq;
 import com.oceanbase.odc.service.iam.model.User;
-import com.oceanbase.odc.service.iam.model.UserPermissionResp;
 import com.oceanbase.odc.service.iam.model.UserPreviewBatchImportResp;
 
 import io.swagger.annotations.ApiOperation;
@@ -378,32 +376,6 @@ public class IamController {
     public SuccessResponse<Role> setRoleEnabled(@PathVariable Long id,
             @RequestBody SetEnabledReq req) {
         return Responses.success(roleService.setEnabled(id, req.getEnabled()));
-    }
-
-    /**
-     * List all user permissions related to the resource
-     *
-     * @param resourceIdentifier ODC_CONNECTION:id
-     * @return
-     */
-    @ApiOperation(value = "listUserPermissions", notes = "查询用户权限列表")
-    @RequestMapping(value = "/userPermissions", method = RequestMethod.GET)
-    public SuccessResponse<List<UserPermissionResp>> listUserPermissions(@RequestParam() String resourceIdentifier) {
-        return Responses.success(userPermissionService.list(resourceIdentifier));
-    }
-
-    /**
-     * Update all user permissions related to the resource
-     *
-     * @param req
-     * @return
-     */
-    @Deprecated
-    @ApiOperation(value = "updateUserPermissions", notes = "更新用户权限列表")
-    @RequestMapping(value = "/userPermissions/batchUpdateForConnection", method = RequestMethod.POST)
-    public SuccessResponse<List<UserPermissionResp>> batchUpdateUserPermissionsForConnection(
-            @RequestBody BatchUpdateUserPermissionsReq req) {
-        return Responses.success(userPermissionService.batchUpdateForConnection(req));
     }
 
     private <T> T parseJson(String json, String parameterName, Class<T> classType) {

--- a/server/odc-server/src/main/java/com/oceanbase/odc/server/web/controller/v2/IamController.java
+++ b/server/odc-server/src/main/java/com/oceanbase/odc/server/web/controller/v2/IamController.java
@@ -398,6 +398,7 @@ public class IamController {
      * @param req
      * @return
      */
+    @Deprecated
     @ApiOperation(value = "updateUserPermissions", notes = "更新用户权限列表")
     @RequestMapping(value = "/userPermissions/batchUpdateForConnection", method = RequestMethod.POST)
     public SuccessResponse<List<UserPermissionResp>> batchUpdateUserPermissionsForConnection(

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/collaboration/project/ProjectService.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/collaboration/project/ProjectService.java
@@ -167,27 +167,16 @@ public class ProjectService {
     @Transactional(rollbackFor = Exception.class)
     public Project create(@NotNull @Valid Project project) {
         preCheck(project);
-
-        /**
-         * save project entity
-         */
         project.setOrganizationId(currentOrganizationId());
         project.setCreator(currentInnerUser());
         project.setLastModifier(currentInnerUser());
         project.setArchived(false);
         project.setBuiltin(false);
         ProjectEntity saved = repository.save(modelToEntity(project));
-
-        /**
-         * save project members as resource roles
-         */
         List<UserResourceRole> userResourceRoles = resourceRoleService.saveAll(
                 project.getMembers().stream()
                         .map(member -> member2UserResourceRole(member, saved.getId()))
                         .collect(Collectors.toList()));
-
-        grantPermissions(userResourceRoles, currentOrganizationId());
-
         return entityToModel(saved, userResourceRoles);
     }
 
@@ -296,7 +285,6 @@ public class ProjectService {
                 members.stream()
                         .map(member -> member2UserResourceRole(member, project.getId()))
                         .collect(Collectors.toList()));
-        grantPermissions(userResourceRoles, currentOrganizationId());
         return entityToModel(project, userResourceRoles);
     }
 
@@ -314,8 +302,6 @@ public class ProjectService {
                 members.stream()
                         .map(member -> member2UserResourceRole(member, projectId))
                         .collect(Collectors.toList()));
-        grantPermissions(userResourceRoles, organizationId);
-
         return entityToModel(project, userResourceRoles);
     }
 
@@ -364,18 +350,14 @@ public class ProjectService {
         if (CollectionUtils.isEmpty(members)) {
             return true;
         }
-        List<UserResourceRole> updated = resourceRoleService.saveAll(
+        resourceRoleService.saveAll(
                 members.stream().map(member -> {
                     member.setId(userId);
                     return member2UserResourceRole(member, project.getId());
                 }).collect(Collectors.toList()));
-
         checkMemberRoles(detail(projectId).getMembers());
-
-        grantPermissions(updated, currentOrganizationId());
         return true;
     }
-
 
     @SkipAuthorize("internal usage")
     public Map<Long, List<Project>> mapByIdIn(Set<Long> ids) {
@@ -426,20 +408,6 @@ public class ProjectService {
     public Set<Long> getMemberProjectIds(Long userId) {
         return resourceRoleService.listByUserId(userId).stream().map(UserResourceRole::getResourceId)
                 .collect(Collectors.toSet());
-    }
-
-    private void grantPermissions(List<UserResourceRole> userResourceRoles, Long organizationId) {
-        if (CollectionUtils.isEmpty(userResourceRoles)) {
-            return;
-        }
-        /**
-         * grant create datasource permission to DBAs and Owners
-         */
-        userResourceRoles.stream()
-                .filter(userResourceRole -> userResourceRole.getResourceRole() == ResourceRoleName.OWNER
-                        || userResourceRole.getResourceRole() == ResourceRoleName.DBA)
-                .forEach(userResourceRole -> userPermissionService.bindUserAndCreateDataSourcePermission(
-                        userResourceRole.getUserId(), organizationId));
     }
 
     private Project entityToModel(ProjectEntity entity, List<UserResourceRole> userResourceRoles) {

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/iam/UserPermissionService.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/iam/UserPermissionService.java
@@ -150,6 +150,7 @@ public class UserPermissionService {
                 .collect(Collectors.toList());
     }
 
+    @Deprecated
     @Transactional(rollbackFor = Exception.class)
     @SkipAuthorize("inside method permission check")
     public List<UserPermissionResp> batchUpdateForConnection(@NonNull BatchUpdateUserPermissionsReq req) {
@@ -304,27 +305,6 @@ public class UserPermissionService {
             userPermissionRepository.saveAndFlush(userPermission);
         });
     }
-
-    @SkipAuthorize("internal usage")
-    @Transactional(rollbackFor = Exception.class)
-    public void bindUserAndCreateDataSourcePermission(@NonNull Long userId, @NonNull Long organizationId) {
-        PermissionEntity permission = new PermissionEntity();
-        permission.setAction("create");
-        permission.setType(PermissionType.PUBLIC_RESOURCE);
-        permission.setResourceIdentifier("ODC_CONNECTION:*");
-        permission.setOrganizationId(organizationId);
-        permission.setCreatorId(userId);
-        permission.setBuiltIn(false);
-        PermissionEntity saved = permissionRepository.saveAndFlush(permission);
-
-        UserPermissionEntity userPermission = new UserPermissionEntity();
-        userPermission.setUserId(userId);
-        userPermission.setPermissionId(saved.getId());
-        userPermission.setCreatorId(userId);
-        userPermission.setOrganizationId(organizationId);
-        userPermissionRepository.saveAndFlush(userPermission);
-    }
-
 
     private void inspectConnectionPermissions(@NonNull Long connectionId, @NonNull String action) {
         List<Permission> permissions = new ArrayList<>();

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/iam/UserPermissionService.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/iam/UserPermissionService.java
@@ -15,15 +15,9 @@
  */
 package com.oceanbase.odc.service.iam;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 import javax.validation.constraints.NotEmpty;
 
@@ -33,15 +27,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.validation.annotation.Validated;
 
-import com.oceanbase.odc.core.authority.SecurityManager;
-import com.oceanbase.odc.core.authority.model.DefaultSecurityResource;
-import com.oceanbase.odc.core.authority.permission.ConnectionPermission;
-import com.oceanbase.odc.core.authority.permission.Permission;
 import com.oceanbase.odc.core.authority.util.SkipAuthorize;
-import com.oceanbase.odc.core.shared.PreConditions;
 import com.oceanbase.odc.core.shared.constant.PermissionType;
 import com.oceanbase.odc.core.shared.constant.ResourceType;
-import com.oceanbase.odc.core.shared.exception.AccessDeniedException;
 import com.oceanbase.odc.core.shared.exception.NotFoundException;
 import com.oceanbase.odc.metadb.iam.PermissionEntity;
 import com.oceanbase.odc.metadb.iam.PermissionRepository;
@@ -51,14 +39,6 @@ import com.oceanbase.odc.metadb.iam.UserPermissionRepository;
 import com.oceanbase.odc.metadb.iam.UserRepository;
 import com.oceanbase.odc.service.connection.ConnectionService;
 import com.oceanbase.odc.service.connection.model.ConnectionConfig;
-import com.oceanbase.odc.service.iam.auth.AuthenticationFacade;
-import com.oceanbase.odc.service.iam.auth.AuthorizationFacade;
-import com.oceanbase.odc.service.iam.model.BatchUpdateUserPermissionsReq;
-import com.oceanbase.odc.service.iam.model.BatchUpdateUserPermissionsReq.UserAction;
-import com.oceanbase.odc.service.iam.model.User;
-import com.oceanbase.odc.service.iam.model.UserPermissionResp;
-import com.oceanbase.odc.service.iam.util.ResourceContextUtil;
-import com.oceanbase.odc.service.resourcegroup.model.ResourceContext;
 import com.oceanbase.tools.loaddump.utils.StringUtils;
 
 import lombok.NonNull;
@@ -73,14 +53,6 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @Validated
 public class UserPermissionService {
-    @Autowired
-    private SecurityManager securityManager;
-
-    @Autowired
-    private AuthorizationFacade authorizationFacade;
-
-    @Autowired
-    private AuthenticationFacade authenticationFacade;
 
     @Autowired
     private UserPermissionRepository userPermissionRepository;
@@ -93,124 +65,6 @@ public class UserPermissionService {
 
     @Autowired
     private ConnectionService connectionService;
-
-    @Autowired
-    private HorizontalDataPermissionValidator permissionValidator;
-
-    @SkipAuthorize("inside method permission check")
-    public List<UserPermissionResp> list(@NonNull String resourceIdentifier) {
-        List<UserPermissionResp> returnValue = new ArrayList<>();
-        ResourceContext resourceContext = ResourceContextUtil.parseFromResourceIdentifier(resourceIdentifier);
-        if (Objects.isNull(resourceContext.getId())
-                || !Objects.equals(resourceContext.getField(), ResourceType.ODC_CONNECTION.name())) {
-            log.warn("Failed to query user permissions, resourceIdentifier={}", resourceIdentifier);
-            return returnValue;
-        }
-        inspectConnectionPermissions(resourceContext.getId(), "read");
-        List<UserPermissionEntity> userPermissionEntities =
-                userPermissionRepository.findByOrganizationIdAndResourceIdentifier(
-                        authenticationFacade.currentOrganizationId(), resourceIdentifier);
-        if (CollectionUtils.isEmpty(userPermissionEntities)) {
-            return returnValue;
-        }
-        List<Long> permissionIds = userPermissionEntities.stream().map(UserPermissionEntity::getPermissionId).distinct()
-                .collect(Collectors.toList());
-        List<Long> userIds = userPermissionEntities.stream().map(UserPermissionEntity::getUserId).distinct()
-                .collect(Collectors.toList());
-        Map<Long, PermissionEntity> permissionId2Entity = permissionRepository.findByIdIn(permissionIds).stream()
-                .collect(Collectors.toMap(PermissionEntity::getId, entity -> entity));
-        Map<Long, UserEntity> userId2Entity = userRepository.findByIdIn(userIds).stream()
-                .collect(Collectors.toMap(UserEntity::getId, entity -> entity));
-
-        // delete duplicated userPermissionEntity
-        Set<Long> userPermissionIds = new HashSet<>();
-        Map<Long, List<UserPermissionEntity>> userId2UserPermissions =
-                userPermissionEntities.stream().collect(Collectors.groupingBy(UserPermissionEntity::getUserId));
-        for (Long userId : userId2UserPermissions.keySet()) {
-            List<UserPermissionEntity> userPermissions = userId2UserPermissions.get(userId);
-            UserPermissionEntity entity = userPermissions.get(0);
-            for (int i = 1; i < userPermissions.size(); i++) {
-                ConnectionPermission existsPrivilege = new ConnectionPermission(resourceContext.getId().toString(),
-                        permissionId2Entity.get(entity.getPermissionId()).getAction());
-                ConnectionPermission currentPrivilege = new ConnectionPermission(resourceContext.getId().toString(),
-                        permissionId2Entity.get(userPermissions.get(i).getPermissionId()).getAction());
-                if (currentPrivilege.implies(existsPrivilege)) {
-                    entity = userPermissions.get(i);
-                }
-            }
-            userPermissionIds.add(entity.getId());
-        }
-        userPermissionEntities = userPermissionEntities.stream()
-                .filter(entity -> userPermissionIds.contains(entity.getId())).collect(Collectors.toList());
-
-        return userPermissionEntities.stream()
-                .map(entity -> new UserPermissionResp(entity,
-                        userId2Entity.getOrDefault(entity.getUserId(), new UserEntity()),
-                        permissionId2Entity.getOrDefault(entity.getPermissionId(), new PermissionEntity())))
-                .collect(Collectors.toList());
-    }
-
-    @Deprecated
-    @Transactional(rollbackFor = Exception.class)
-    @SkipAuthorize("inside method permission check")
-    public List<UserPermissionResp> batchUpdateForConnection(@NonNull BatchUpdateUserPermissionsReq req) {
-        List<UserPermissionResp> userPermissionRespList = new ArrayList<>();
-        if (Objects.isNull(req.getResourceIdentifier())) {
-            return userPermissionRespList;
-        }
-        ResourceContext resourceContext = ResourceContextUtil.parseFromResourceIdentifier(req.getResourceIdentifier());
-        if (Objects.isNull(resourceContext.getId())
-                || !Objects.equals(resourceContext.getField(), ResourceType.ODC_CONNECTION.name())) {
-            return userPermissionRespList;
-        }
-        inspectConnectionPermissions(resourceContext.getId(), "update");
-
-        // intercept horizontal authorizing
-        List<Long> userIds = req.getUserActions().stream().map(UserAction::getUserId).collect(Collectors.toList());
-        List<User> users = userRepository.findByIdIn(userIds).stream().map(User::new).collect(Collectors.toList());
-        permissionValidator.checkCurrentOrganization(users);
-        ConnectionConfig connection = connectionService.getWithoutPermissionCheck(resourceContext.getId());
-        permissionValidator.checkCurrentOrganization(connection);
-
-        // delete exists user permission relations and permissions records
-        List<UserPermissionEntity> userPermissionEntities =
-                userPermissionRepository.findByOrganizationIdAndResourceIdentifier(
-                        authenticationFacade.currentOrganizationId(), req.getResourceIdentifier());
-        List<Long> userPermissionIds =
-                userPermissionEntities.stream().map(UserPermissionEntity::getId).collect(Collectors.toList());
-        List<Long> permissionIds =
-                userPermissionEntities.stream().map(UserPermissionEntity::getPermissionId).collect(Collectors.toList());
-        userPermissionRepository.deleteByIds(userPermissionIds);
-        permissionRepository.deleteByIds(permissionIds);
-
-        Map<Long, UserEntity> userId2Entity = userRepository.findByIdIn(userIds).stream()
-                .collect(Collectors.toMap(UserEntity::getId, entity -> entity));
-
-        // insert new user permissions and permissions records
-        for (UserAction userAction : req.getUserActions()) {
-            PreConditions.notNull(userAction.getUserId(), "userActions.userId");
-            PreConditions.notEmpty(userAction.getAction(), "userActions.action");
-            PermissionEntity permissionEntity = new PermissionEntity();
-            permissionEntity.setAction(userAction.getAction());
-            permissionEntity.setResourceIdentifier(req.getResourceIdentifier());
-            permissionEntity.setType(PermissionType.PUBLIC_RESOURCE);
-            permissionEntity.setCreatorId(authenticationFacade.currentUserId());
-            permissionEntity.setOrganizationId(authenticationFacade.currentOrganizationId());
-            permissionEntity.setBuiltIn(false);
-            permissionRepository.save(permissionEntity);
-
-            UserPermissionEntity userPermissionEntity = new UserPermissionEntity();
-            userPermissionEntity.setUserId(userAction.getUserId());
-            userPermissionEntity.setPermissionId(permissionEntity.getId());
-            userPermissionEntity.setCreatorId(authenticationFacade.currentUserId());
-            userPermissionEntity.setOrganizationId(authenticationFacade.currentOrganizationId());
-            userPermissionRepository.save(userPermissionEntity);
-
-            userPermissionRespList.add(new UserPermissionResp(userPermissionEntity,
-                    userId2Entity.getOrDefault(userAction.getUserId(), new UserEntity()), permissionEntity));
-        }
-        return userPermissionRespList;
-    }
 
     @SkipAuthorize("odc internal usage")
     @Transactional(rollbackFor = Exception.class)
@@ -265,24 +119,6 @@ public class UserPermissionService {
         userPermissionRepository.saveAndFlush(userPermission);
     }
 
-    @SkipAuthorize("odc internal usage")
-    @Transactional(rollbackFor = Exception.class)
-    public void deleteExistsUserPermissions(User user, List<PermissionEntity> permissionEntities) {
-        List<String> resourceIdentifiers =
-                permissionEntities.stream().map(PermissionEntity::resourceIdentifier).collect(Collectors.toList());
-        List<UserPermissionEntity> existsUserPermissions =
-                userPermissionRepository.findByUserIdAndResourceIdentifiers(user.getId(), resourceIdentifiers);
-        if (CollectionUtils.isEmpty(existsUserPermissions)) {
-            return;
-        }
-        int affectNum1 = permissionRepository.deleteByIds(
-                existsUserPermissions.stream().map(UserPermissionEntity::getPermissionId).collect(Collectors.toList()));
-        log.info("Delete exists permissionEntities, affectNum={}", affectNum1);
-        int affectNum2 = userPermissionRepository.deleteByIds(
-                existsUserPermissions.stream().map(UserPermissionEntity::getId).collect(Collectors.toList()));
-        log.info("Delete exists userPermissionEntities, user={}, affectNum={}", user, affectNum2);
-    }
-
     @SkipAuthorize("internal usage")
     @Transactional(rollbackFor = Exception.class)
     public void bindUserAndDataSourcePermission(@NonNull Long userId, @NonNull Long organizationId,
@@ -306,16 +142,5 @@ public class UserPermissionService {
         });
     }
 
-    private void inspectConnectionPermissions(@NonNull Long connectionId, @NonNull String action) {
-        List<Permission> permissions = new ArrayList<>();
-        permissions.add(securityManager.getPermissionByActions(
-                new DefaultSecurityResource(connectionId.toString(), ResourceType.ODC_CONNECTION.name()),
-                Collections.singleton(action)));
-        boolean checkResult = authorizationFacade.isImpliesPermissions(authenticationFacade.currentUser(), permissions);
-        if (!checkResult) {
-            throw new AccessDeniedException(
-                    "The current user dose not have " + action + " permission for ODC_CONNECTION:" + connectionId);
-        }
-    }
 
 }

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/permissionapply/project/ApplyProjectPreprocessor.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/permissionapply/project/ApplyProjectPreprocessor.java
@@ -61,7 +61,7 @@ public class ApplyProjectPreprocessor implements Preprocessor {
         ApplyProjectParameter parameter = (ApplyProjectParameter) req.getParameters();
         Verify.notNull(parameter.getProject(), "project");
         Verify.notEmpty(parameter.getResourceRoles(), "resourceRole");
-        Verify.notBlank(parameter.getApplyReason(), "applyReason");
+        Verify.notNull(parameter.getApplyReason(), "applyReason");
         ProjectEntity projectEntity = checkProjectExistAndValid(parameter.getProject().getId());
         List<ResourceRoleEntity> resourceRoleEntities = checkResourceRoleExist(
                 parameter.getResourceRoles().stream().map(ApplyResourceRole::getId).collect(Collectors.toList()));


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines.
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request.
3. Ensure you have added or ran the appropriate tests for your PR.
5. If the PR is unfinished, you may add or remove a WIP or [WIP] prefix to your pull request title.
-->

#### What type of PR is this?
type-bug
module-user permission

#### What this PR does / why we need it:
In ODC 4.2.3, if a user join a project with OWNER or DBA role, then ODC  will grant `create` permission of `CONNECTION:*`  to this user. But when the user leave the project, these permission is not reclaimed. So user can create datasource without any project and role. 
In this PR, I fix it by delete the internal grant permission operation.

#### Which issue(s) this PR fixes:
Fixes #1013 #683 

#### Special notes for your reviewer:
Self-test passed

#### Additional documentation e.g., usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```