### PR TITLE
fix(data-security): create sensitive columns failed due to scanning duplicated columns

### DIFF
--- a/server/integration-test/src/test/java/com/oceanbase/odc/service/datasecurity/SensitiveColumnScanningTaskManagerTest.java
+++ b/server/integration-test/src/test/java/com/oceanbase/odc/service/datasecurity/SensitiveColumnScanningTaskManagerTest.java
@@ -85,7 +85,6 @@ public class SensitiveColumnScanningTaskManagerTest extends ServiceTestEnv {
     public static void setUp() {
         mysqlSession = TestConnectionUtil.getTestConnectionSession(ConnectType.OB_MYSQL);
         mysqlSession.getSyncJdbcExecutor(ConnectionSessionConstants.BACKEND_DS_KEY).update(sql.getMysql().getCreate());
-
         mysqlConnectionConfig = TestConnectionUtil.getTestConnectionConfig(ConnectType.OB_MYSQL);
 
         oracleSession = TestConnectionUtil.getTestConnectionSession(ConnectType.OB_ORACLE);
@@ -121,7 +120,7 @@ public class SensitiveColumnScanningTaskManagerTest extends ServiceTestEnv {
         SensitiveColumnScanningTaskInfo taskInfo = manager.start(databases, rules, oracleConnectionConfig, null);
         await().atMost(20, SECONDS)
                 .until(() -> manager.get(taskInfo.getTaskId()).getStatus() == ScanningTaskStatus.SUCCESS);
-        Assert.assertEquals(3, manager.get(taskInfo.getTaskId()).getSensitiveColumns().size());
+        Assert.assertEquals(2, manager.get(taskInfo.getTaskId()).getSensitiveColumns().size());
     }
 
     @Test
@@ -141,7 +140,7 @@ public class SensitiveColumnScanningTaskManagerTest extends ServiceTestEnv {
         SensitiveColumnScanningTaskInfo taskInfo = manager.start(databases, rules, oracleConnectionConfig, null);
         await().atMost(20, SECONDS)
                 .until(() -> manager.get(taskInfo.getTaskId()).getStatus() == ScanningTaskStatus.SUCCESS);
-        Assert.assertEquals(27, manager.get(taskInfo.getTaskId()).getSensitiveColumns().size());
+        Assert.assertEquals(20, manager.get(taskInfo.getTaskId()).getSensitiveColumns().size());
     }
 
     @Test

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/datasecurity/SensitiveColumnScanningTask.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/datasecurity/SensitiveColumnScanningTask.java
@@ -88,6 +88,8 @@ public class SensitiveColumnScanningTask implements Callable<Void> {
                     column.setSensitiveRuleId(recognizer.sensitiveRuleId());
                     column.setLevel(recognizer.sensitiveLevel());
                     sensitiveColumns.add(column);
+                    existsSensitiveColumns
+                            .add(new SensitiveColumnMeta(database.getId(), objectName, dbTableColumn.getName()));
                 }
             }
             taskInfo.addSensitiveColumns(sensitiveColumns);


### PR DESCRIPTION
#### What type of PR is this?
type-bug
module-data security

#### What this PR does / why we need it:
ODC recognize and store sensitive columns by `databaseId`, `tableName` and `columnName`.  And, the `varchar` in meta DB is case-insensitive. So if there are two columns with case-sensitive same `tableName` + `columnName`, then we cannot add both of them as sensitive column. In ODC 4.2.3, ODC will recognize both two columns when scan and this PR fix it.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1005 

#### Special notes for your reviewer:
Self-test passed.

#### Additional documentation e.g., usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```