### PR TITLE
fix(data-transfer): remove permission check when testing connection

### DIFF
--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/connection/ConnectionTestService.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/connection/ConnectionTestService.java
@@ -63,7 +63,7 @@ public class ConnectionTestService {
             req.setTenantName("sys");
         }
         if (Objects.nonNull(connectionId)) {
-            ConnectionConfig connection = connectionService.getForConnect(connectionId);
+            ConnectionConfig connection = connectionService.getForConnectionSkipPermissionCheck(connectionId);
             if (Objects.isNull(req.getType())) {
                 req.setType(connection.getType());
             }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines.
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request.
3. Ensure you have added or ran the appropriate tests for your PR.
5. If the PR is unfinished, you may add or remove a WIP or [WIP] prefix to your pull request title.
-->

#### What type of PR is this?
type-bug
<!--
Add one of the following kinds:
type-bug
type-feature
type-docs
etc.

Optionally add one or more of the following kinds if applicable:
module-resultset
module-sql execution
etc.
-->

#### What this PR does / why we need it:
When create a datatransfer task, we could input sys account in task configuration. However, if we use a user without editing data source permissions to perform this operation, an access denied exception will be reported.

In fact , testing connection will not  involve any security issues, so I removed this permission check.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1030 
