### PR TITLE
fix(partition-plan): create partition plan task failed in obmysql 1479

### DIFF
--- a/libs/db-browser/src/main/java/com/oceanbase/tools/dbbrowser/schema/mysql/OBMySQLNoGreaterThan1479SchemaAccessor.java
+++ b/libs/db-browser/src/main/java/com/oceanbase/tools/dbbrowser/schema/mysql/OBMySQLNoGreaterThan1479SchemaAccessor.java
@@ -156,7 +156,6 @@ public class OBMySQLNoGreaterThan1479SchemaAccessor extends BaseOBMySQLLessThan2
                     subPartitionOption.setExpression(subPartExpression);
                 } else {
                     subPartitionOption.setColumnNames(Arrays.asList(subPartExpression.split(",")));
-
                 }
             } else {
                 partition.setWarning("Only support HASH/KEY subpartition currently, please check comparing ddl");

--- a/libs/db-browser/src/main/java/com/oceanbase/tools/dbbrowser/schema/mysql/OBMySQLNoGreaterThan1479SchemaAccessor.java
+++ b/libs/db-browser/src/main/java/com/oceanbase/tools/dbbrowser/schema/mysql/OBMySQLNoGreaterThan1479SchemaAccessor.java
@@ -135,10 +135,7 @@ public class OBMySQLNoGreaterThan1479SchemaAccessor extends BaseOBMySQLLessThan2
             partitionDefinition.setOrdinalPosition(rs.getInt("part_id"));
             partitionDefinition.setType(DBTablePartitionType.fromValue(rs.getString("partition_method")));
             String description = null;
-            if (partitionDefinition.getType() == DBTablePartitionType.LIST
-                    || partitionDefinition.getType() == DBTablePartitionType.LIST_COLUMNS) {
-                description = rs.getString("list_val");
-            } else if (partitionDefinition.getType() == DBTablePartitionType.RANGE
+            if (partitionDefinition.getType() == DBTablePartitionType.RANGE
                     || partitionDefinition.getType() == DBTablePartitionType.RANGE_COLUMNS) {
                 description = rs.getString("high_bound_val");
             }

--- a/libs/db-browser/src/main/resources/schema/sql/obmysql/obmysql_1_4_79.yaml
+++ b/libs/db-browser/src/main/resources/schema/sql/obmysql/obmysql_1_4_79.yaml
@@ -124,8 +124,7 @@ sqls:
       '1' as is_sub_part_template,
       p.part_id,
       p.part_name,
-      p.high_bound_val,
-      p.list_val
+      p.high_bound_val
     from
       oceanbase.__all_tenant n,
       oceanbase.__all_database d,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines.
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request.
3. Ensure you have added or ran the appropriate tests for your PR.
5. If the PR is unfinished, you may add or remove a WIP or [WIP] prefix to your pull request title.
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
type-bug
type-feature
type-docs
etc.

Optionally add one or more of the following kinds if applicable:
module-resultset
module-sql execution
etc.
-->
type-bug

#### What this PR does / why we need it:
The partition plan uses SchemaAccessor to obtain range partition info. But in obmysql 1479, the query SQL is wrong because `oceanbase.__all_part` doesn't have `list_val` column(higher version does).
This PR corrects the partition info query SQL by deleting the non-existing column. It only affects the partition plan given that it uses Parser to obtain partition info in other scenery. And partition plan doesn't care about the list partition info so deleting this column will be fine.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #969 

#### Special notes for your reviewer:

<!--
This section is used to describe how this PR is implemented. 
If this is a PR that fixes a bug, this section describes how the bug was fixed.
If it's a new feature, this section briefly describes how to implement the new feature.
etc.
-->

#### Additional documentation e.g., usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```