### PR TITLE
fix(datasource): built-in database still belong to previous project when datasource unbind project

### DIFF
--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/connection/ConnectionService.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/connection/ConnectionService.java
@@ -102,7 +102,6 @@ import com.oceanbase.odc.service.common.response.PaginatedData;
 import com.oceanbase.odc.service.connection.ConnectionStatusManager.CheckState;
 import com.oceanbase.odc.service.connection.database.DatabaseService;
 import com.oceanbase.odc.service.connection.database.DatabaseSyncManager;
-import com.oceanbase.odc.service.connection.database.model.DatabaseSyncProperties;
 import com.oceanbase.odc.service.connection.model.ConnectProperties;
 import com.oceanbase.odc.service.connection.model.ConnectionConfig;
 import com.oceanbase.odc.service.connection.model.QueryConnectionParams;
@@ -211,9 +210,6 @@ public class ConnectionService {
 
     @Autowired
     private JdbcLockRegistry jdbcLockRegistry;
-
-    @Autowired
-    private DatabaseSyncProperties databaseSyncProperties;
 
     private final ConnectionMapper mapper = ConnectionMapper.INSTANCE;
 
@@ -580,7 +576,7 @@ public class ConnectionService {
             log.info("Connection updated, connection={}", updated);
             if (saved.getProjectId() != null && updated.getProjectId() == null) {
                 // Remove databases from project when unbind project from connection
-                updateDatabaseProjectId(savedEntity, null, databaseSyncProperties.isBlockInternalDatabase());
+                updateDatabaseProjectId(savedEntity, null, false);
             }
             transactionManager.commit(transactionStatus);
         } catch (Exception e) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines.
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request.
3. Ensure you have added or ran the appropriate tests for your PR.
5. If the PR is unfinished, you may add or remove a WIP or [WIP] prefix to your pull request title.
-->

#### What type of PR is this?
type-bug

#### What this PR does / why we need it:
I create a data source and bind a project. Then I manually add the built-in database oceanbase to the project. Now I unbind the datasource to the project, but the oceanbase database is still bound to the previous project.
This PR fix it.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1058 

#### Special notes for your reviewer:
Self-test passed

#### Additional documentation e.g., usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```