### PR TITLE
fix(parse-sid): optimize parse sid failed error message

### DIFF
--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/common/util/ResourceIDParser.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/common/util/ResourceIDParser.java
@@ -19,8 +19,12 @@ import java.util.Arrays;
 import java.util.List;
 
 import com.oceanbase.odc.core.shared.PreConditions;
+import com.oceanbase.odc.core.shared.exception.BadRequestException;
 import com.oceanbase.odc.service.common.model.ResourceIdentifier;
 
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
 public class ResourceIDParser {
     // order for this key list should not be modified
     // new key support: new key should insert into head of this list
@@ -43,7 +47,12 @@ public class ResourceIDParser {
         Integer endIndex = rId.length();
         // sid:1:d:test
         for (String key : keyList) {
-            endIndex = extract(rId, resourceIdentifier, endIndex, key);
+            try {
+                endIndex = extract(rId, resourceIdentifier, endIndex, key);
+            } catch (Exception e) {
+                log.warn("Parse resource identifier failed, rId: {}, key: {}", rId, key, e);
+                throw new BadRequestException("Parse resource identifier failed");
+            }
         }
         return resourceIdentifier;
     }


### PR DESCRIPTION


#### What type of PR is this?

<!--
Add one of the following kinds:
type-bug
type-feature
type-docs
etc.

Optionally add one or more of the following kinds if applicable:
module-resultset
module-sql execution
etc.
-->
type-bug

#### What this PR does / why we need it:
`ResourceIdentifier i = ResourceIDParser.parse(sid);` is used in list columns interface, when the database name and table name are the same as `ResourceIdentifier` the sid will be like "d:c:t:c" or "d:v:t:v", in this case there will throw exception in `ResourceIDParser#extract` method.
Considering that this method of parsing SID is used in many interfaces, both the front and back ends must be modified to truly fix it, and the situation of stepping on this bug is quite extreme. Here we only optimize the error message.




#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #598

#### Special notes for your reviewer:

<!--
This section is used to describe how this PR is implemented. 
If this is a PR that fixes a bug, this section describes how the bug was fixed.
If it's a new feature, this section briefly describes how to implement the new feature.
etc.
-->

#### Additional documentation e.g., usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```