### PR TITLE
fix(obclient): do not create os user when it already exists

### DIFF
--- a/server/odc-server/src/main/java/com/oceanbase/odc/server/web/websocket/WebSocketServer.java
+++ b/server/odc-server/src/main/java/com/oceanbase/odc/server/web/websocket/WebSocketServer.java
@@ -294,7 +294,8 @@ public class WebSocketServer {
 
     private synchronized void addOsUser(String userId) throws IOException, InterruptedException {
         String osUserName = getOsUserName(userId);
-        Process userExists = new ProcessBuilder().command("grep", "-c", "^" + osUserName + ":", "/etc/passwd").start();
+        Process userExists = new ProcessBuilder()
+                .command("grep", "-c", "^" + osUserName + ":", "/etc/passwd").start();
         try (BufferedReader reader = new BufferedReader(new InputStreamReader(userExists.getInputStream()))) {
             String line = reader.readLine();
             if (StringUtils.equals(line, "1")) {

--- a/server/odc-server/src/main/java/com/oceanbase/odc/server/web/websocket/WebSocketServer.java
+++ b/server/odc-server/src/main/java/com/oceanbase/odc/server/web/websocket/WebSocketServer.java
@@ -15,8 +15,10 @@
  */
 package com.oceanbase.odc.server.web.websocket;
 
+import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
@@ -290,19 +292,30 @@ public class WebSocketServer {
         return obclientCmd;
     }
 
-    private void addOsUser(String userId) throws IOException, InterruptedException {
-        Process process = new ProcessBuilder().command("bash", "-c", "useradd ".concat(getOsUserName(userId))).start();
-        if (process.waitFor(10, TimeUnit.SECONDS)) {
-            // exitValue() == 0 means add user successfully, exitValue() == 9 means user already exists, we
-            // would return silently
-            if (process.exitValue() == 0 || process.exitValue() == 9) {
-                log.info("create os user successfully, name={}", getOsUserName(userId));
+    private synchronized void addOsUser(String userId) throws IOException, InterruptedException {
+        String osUserName = getOsUserName(userId);
+        Process userExists = new ProcessBuilder().command("grep", "-c", "^" + osUserName + ":", "/etc/passwd").start();
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(userExists.getInputStream()))) {
+            String line = reader.readLine();
+            if (StringUtils.equals(line, "1")) {
+                log.info("user {} already exists", osUserName);
                 return;
             }
         }
-        String output = IOUtils.toString(process.getInputStream(), StandardCharsets.UTF_8);
-        log.warn("create os user failed, exitValue={}, output={}", process.exitValue(), output);
-        throw new RuntimeException("create os user failed, exitVal=" + process.exitValue() + ", output=" + output);
+        Process userAdd = new ProcessBuilder()
+                .redirectErrorStream(true).command("bash", "-c", "useradd ".concat(osUserName)).start();
+        if (userAdd.waitFor(10, TimeUnit.SECONDS)) {
+            // exitValue() == 0 means add user successfully, exitValue() == 9 means user already exists, we
+            // would return silently
+            if (userAdd.exitValue() == 0 || userAdd.exitValue() == 9) {
+                log.info("create os user successfully, name={}", osUserName);
+                return;
+            }
+        }
+
+        String output = IOUtils.toString(userAdd.getInputStream(), StandardCharsets.UTF_8);
+        log.warn("create os user failed, exitValue={}, output={}", userAdd.exitValue(), output);
+        throw new RuntimeException("create os user failed, exitVal=" + userAdd.exitValue() + ", output=" + output);
     }
 
     private String getDbUser(ConnectionConfig connectionConfig) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines.
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request.
3. Ensure you have added or ran the appropriate tests for your PR.
5. If the PR is unfinished, you may add or remove a WIP or [WIP] prefix to your pull request title.
-->

#### What type of PR is this?
type-bug
<!--
Add one of the following kinds:
type-bug
type-feature
type-docs
etc.

Optionally add one or more of the following kinds if applicable:
module-resultset
module-sql execution
etc.
-->

#### What this PR does / why we need it:

When ODC opening a obclient window, it would call useradd command to create a os user .This is for security issues and for resource isolation.
However , this user would not be deleted. So the logs of the operating system will have some records of user creation failures.

So we will query whether this user already exists by grep file `/etc/passwd`. All users have read access to this file. If it exists, we won't create repeatedly.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #972 
