### PR TITLE
fix(jdbc): full link trace leads to OOM exception

### DIFF
--- a/server/plugins/connect-plugin-ob-mysql/src/main/java/com/oceanbase/odc/plugin/connect/obmysql/OBMySQLConnectionExtension.java
+++ b/server/plugins/connect-plugin-ob-mysql/src/main/java/com/oceanbase/odc/plugin/connect/obmysql/OBMySQLConnectionExtension.java
@@ -117,9 +117,8 @@ public class OBMySQLConnectionExtension implements ConnectionExtensionPoint {
     }
 
     protected Map<String, String> appendDefaultJdbcUrlParameters(Map<String, String> jdbcUrlParams) {
-        if (!jdbcUrlParams.containsKey("enableFullLinkTrace")) {
-            jdbcUrlParams.put("enableFullLinkTrace", "true");
-        }
+        // there is a bug of oceanbase-client 2.4.7.1, setting this to true may cause OOM exception
+        jdbcUrlParams.put("enableFullLinkTrace", "false");
         return jdbcUrlParams;
     }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines.
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request.
3. Ensure you have added or ran the appropriate tests for your PR.
5. If the PR is unfinished, you may add or remove a WIP or [WIP] prefix to your pull request title.
-->

#### What type of PR is this?
type-bug
<!--
Add one of the following kinds:
type-bug
type-feature
type-docs
etc.

Optionally add one or more of the following kinds if applicable:
module-resultset
module-sql execution
etc.
-->

#### What this PR does / why we need it:

There is a bug of oceanbase-client 2.4.7.1. If we set `enableFullLinktrace` to true , there may be cause OOM exception.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1105 