### PR TITLE
fix(data-transfer): only inject sys tenant config when it's configured in datasource

### DIFF
--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/datatransfer/DataTransferService.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/datatransfer/DataTransferService.java
@@ -361,22 +361,21 @@ public class DataTransferService {
     }
 
     private void injectSysConfig(ConnectionConfig connectionConfig, DataTransferConfig transferConfig) {
-        String sysUserInConfig = transferConfig.getSysUser();
-        if (StringUtils.isBlank(sysUserInConfig)) {
+        String sysUserInMeta = connectionConfig.getSysTenantUsername();
+        if (StringUtils.isBlank(sysUserInMeta)) {
             log.info("No Sys user setting");
             return;
         }
-        String sysPasswordInConfig = transferConfig.getSysPassword();
-        connectionConfig.setSysTenantUsername(sysUserInConfig);
-        connectionConfig.setSysTenantPassword(sysPasswordInConfig);
+        connectionConfig.setUsername(sysUserInMeta);
+        connectionConfig.setPassword(connectionConfig.getSysTenantPassword());
         if (testSysTenantAccount(connectionConfig)) {
             log.info("Sys user has been approved, connectionId={}", connectionConfig.getId());
-            transferConfig.getConnectionInfo().setSysTenantUsername(sysUserInConfig);
-            transferConfig.getConnectionInfo().setSysTenantPassword(sysPasswordInConfig);
+            transferConfig.getConnectionInfo().setSysTenantUsername(sysUserInMeta);
+            transferConfig.getConnectionInfo().setSysTenantPassword(connectionConfig.getSysTenantPassword());
             return;
         }
         log.info("Access denied, Sys tenant account and password error, connectionId={}, sysUserInConfig={}",
-                connectionConfig.getId(), sysUserInConfig);
+                connectionConfig.getId(), sysUserInMeta);
         transferConfig.getConnectionInfo().setSysTenantUsername(null);
         transferConfig.getConnectionInfo().setSysTenantPassword(null);
     }

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/datatransfer/task/DataTransferTaskContext.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/datatransfer/task/DataTransferTaskContext.java
@@ -34,7 +34,7 @@ public class DataTransferTaskContext implements Future<DataTransferTaskResult> {
 
     public DataTransferTaskResult getStatus() {
         if (task.getJob() == null) {
-            return null;
+            return new DataTransferTaskResult();
         }
         return new DataTransferTaskResult(task.getJob().getDataObjectsStatus(),
                 task.getJob().getSchemaObjectsStatus());

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/flow/task/DataTransferRuntimeFlowableTask.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/flow/task/DataTransferRuntimeFlowableTask.java
@@ -89,7 +89,7 @@ public class DataTransferRuntimeFlowableTask extends BaseODCFlowTaskDelegate<Voi
             odcInternalFileService.getExternalImportFiles(taskEntity, submitter, config.getImportFileName());
         }
         context = dataTransferService.create(taskId + "", config);
-        taskService.start(taskId);
+        taskService.start(taskId, context.getStatus());
         return null;
     }
 

--- a/server/plugins/task-plugin-ob-mysql/src/main/java/com/oceanbase/odc/plugin/task/obmysql/datatransfer/factory/BaseParameterFactory.java
+++ b/server/plugins/task-plugin-ob-mysql/src/main/java/com/oceanbase/odc/plugin/task/obmysql/datatransfer/factory/BaseParameterFactory.java
@@ -200,6 +200,12 @@ public abstract class BaseParameterFactory<T extends BaseParameter> {
                 throw new IllegalArgumentException("Can not accept a blank object name");
             }
             Set<String> nameSet = whiteListMap.computeIfAbsent(dbObject.getDbObjectType(), k -> new HashSet<>());
+            if (StringUtils.isNotEmpty(transferConfig.getQuerySql())) {
+                // do not quote table name for result-set-export task, because ob-loader-dumper will quote it in
+                // insertion repeatedly
+                nameSet.add(objectName);
+                continue;
+            }
             if (transferConfig.getConnectionInfo().getConnectType().getDialectType().isOracle()) {
                 nameSet.add(StringUtils.quoteOracleIdentifier(objectName));
             } else {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines.
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request.
3. Ensure you have added or ran the appropriate tests for your PR.
5. If the PR is unfinished, you may add or remove a WIP or [WIP] prefix to your pull request title.
-->

#### What type of PR is this?
type-bug
<!--
Add one of the following kinds:
type-bug
type-feature
type-docs
etc.

Optionally add one or more of the following kinds if applicable:
module-resultset
module-sql execution
etc.
-->

#### What this PR does / why we need it:

There are some issues,  such as #1030 and #1158 , are caused by the sys tenant configs. 
On the one hand, due to the fact that after OceanBase4.x, ob-loader-dump no longer relies on the account and password of sys tenants. On the other hand, this configuration has security issues. 
Therefore, we prohibit users from filling in the sys tenant account password when initiating transfer tasks.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1030 and #1158
