### PR TITLE
fix(web-framework): invalid csrf token result into Invalid session error message

### DIFF
--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/iam/auth/CustomInvalidSessionStrategy.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/iam/auth/CustomInvalidSessionStrategy.java
@@ -54,7 +54,7 @@ public class CustomInvalidSessionStrategy implements InvalidSessionStrategy {
             throws IOException, ServletException {
         log.info("Session invalid for uri={}", httpServletRequest.getRequestURI());
         if (httpServletRequest.getRequestURI().startsWith(DATA_URI_PREFIX)) {
-            BadRequestException exception = new BadRequestException("Invalid Session");
+            BadRequestException exception = new BadRequestException("Invalid Http Session");
             WebResponseUtils.writeBackLoginExpiredJson(httpServletRequest, httpServletResponse, exception,
                     this.localeResolver);
         } else {

--- a/server/starters/web-starter/src/main/java/com/oceanbase/odc/config/PlaySiteSecurityConfiguration.java
+++ b/server/starters/web-starter/src/main/java/com/oceanbase/odc/config/PlaySiteSecurityConfiguration.java
@@ -38,7 +38,6 @@ import com.oceanbase.odc.service.iam.LoginHistoryService;
 import com.oceanbase.odc.service.iam.auth.CustomAuthenticationEntryPoint;
 import com.oceanbase.odc.service.iam.auth.CustomAuthenticationFailureHandler;
 import com.oceanbase.odc.service.iam.auth.CustomAuthenticationSuccessHandler;
-import com.oceanbase.odc.service.iam.auth.CustomInvalidSessionStrategy;
 import com.oceanbase.odc.service.iam.auth.CustomLogoutSuccessHandler;
 import com.oceanbase.odc.service.iam.auth.play.PlaysiteOpenAPIClient;
 import com.oceanbase.odc.service.iam.auth.play.PlaysiteOpenAPIConstants;
@@ -137,8 +136,7 @@ public class PlaySiteSecurityConfiguration extends WebSecurityConfigurerAdapter 
                 // Never: Spring Security will never create an HttpSession, but will use the existing one
                 .sessionCreationPolicy(SessionCreationPolicy.IF_REQUIRED)
                 .sessionFixation()
-                .migrateSession()
-                .invalidSessionStrategy(new CustomInvalidSessionStrategy(LOGIN_PAGE,localeResolver));
+                .migrateSession();
         // @formatter:on        
         csrfConfigureHelper.configure(http);
 

--- a/server/starters/web-starter/src/main/java/com/oceanbase/odc/config/WebSecurityConfiguration.java
+++ b/server/starters/web-starter/src/main/java/com/oceanbase/odc/config/WebSecurityConfiguration.java
@@ -38,7 +38,6 @@ import com.oceanbase.odc.service.captcha.CaptchaAuthenticationProcessingFilter;
 import com.oceanbase.odc.service.iam.auth.CustomAuthenticationEntryPoint;
 import com.oceanbase.odc.service.iam.auth.CustomAuthenticationFailureHandler;
 import com.oceanbase.odc.service.iam.auth.CustomAuthenticationSuccessHandler;
-import com.oceanbase.odc.service.iam.auth.CustomInvalidSessionStrategy;
 import com.oceanbase.odc.service.iam.auth.CustomLogoutSuccessHandler;
 import com.oceanbase.odc.service.iam.auth.UsernamePasswordConfigureHelper;
 import com.oceanbase.odc.service.iam.auth.bastion.BastionAuthenticationProcessingFilter;
@@ -143,10 +142,10 @@ public class WebSecurityConfiguration extends WebSecurityConfigurerAdapter {
                 // SessionCreationPolicy.ALWAYS --> SessionCreationPolicy.IF_REQUIRED，防止登出后再次访问页面生成session造成无法跳转至登录页
                 .sessionCreationPolicy(SessionCreationPolicy.IF_REQUIRED)
                 .sessionFixation()
-                .migrateSession()
-                .invalidSessionStrategy(new CustomInvalidSessionStrategy(commonSecurityProperties.getLoginPage(),localeResolver));
+                .migrateSession();
         // @formatter:on
         csrfConfigureHelper.configure(http);
+
         http.addFilterBefore(
                 new TestLoginAuthenticationFilter(),
                 OAuth2LoginAuthenticationFilter.class);


### PR DESCRIPTION
…ror message

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines.
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request.
3. Ensure you have added or ran the appropriate tests for your PR.
5. If the PR is unfinished, you may add or remove a WIP or [WIP] prefix to your pull request title.
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
type-bug
type-feature
type-docs
etc.

Optionally add one or more of the following kinds if applicable:
module-resultset
module-sql execution
etc.
-->
type-bug

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #591

#### Special notes for your reviewer:

<!--
This section is used to describe how this PR is implemented. 
If this is a PR that fixes a bug, this section describes how the bug was fixed.
If it's a new feature, this section briefly describes how to implement the new feature.
etc.
-->

the CsrfFilter in spring secuity will refer InvalidSessionStrategy before self defined AccessDeniedHandler.

while CSRF protection enabled, skip set InvalidSessionStrategy.

here is the test result

*scenario MissingCsrfToken*
curl -iL -XPOST \
 "http://localhost:8989/api/v2/database/databases/1000215currentOrganizationId=1&ignoreError=true&taskType=ONLINE_SCHEMA_CHANGE"
HTTP/1.1 400
Set-Cookie: XSRF-TOKEN=813a1677-0508-4dc4-96b8-c4b221ce8fea; Domain=localhost; Path=/
X-Content-Type-Options: nosniff
X-XSS-Protection: 1; mode=block
Cache-Control: no-cache, no-store, max-age=0, must-revalidate
Pragma: no-cache
Expires: 0
X-Frame-Options: DENY
Content-Type: application/json;charset=UTF-8
Content-Length: 265
Date: Tue, 19 Dec 2023 11:55:01 GMT
Connection: close

{"code":"MissingCsrfToken","data":false,"durationMillis":0,"errCode":"MissingCsrfToken","errMsg":"缺少 CSRF token","httpStatus":null,"importantMsg":false,"message":"缺少 CSRF token","requestId":null,"server":"B-38DMMD6R-2106.local","timestamp":0.0,"traceId":""}%

*scenario valid CsrfToken but Invalid Session*
curl -iL -XPOST \
 "http://localhost:8989/api/v2/database/databases/1000215currentOrganizationId=1&ignoreError=true&taskType=ONLINE_SCHEMA_CHANGE"
HTTP/1.1 401
Set-Cookie: XSRF-TOKEN=002b2e54-363b-4977-a249-7967a7672614; Domain=localhost; Path=/
X-Content-Type-Options: nosniff
X-XSS-Protection: 1; mode=block
Cache-Control: no-cache, no-store, max-age=0, must-revalidate
Pragma: no-cache
Expires: 0
X-Frame-Options: DENY
Content-Type: application/json;charset=UTF-8
Content-Length: 439
Date: Tue, 19 Dec 2023 11:57:43 GMT

{"code":"LoginExpired","durationMillis":null,"error":{"code":"LoginExpired","details":[{"code":"InsufficientAuthenticationException","message":"Full authentication is required to access this resource","target":null}],"message":"会话已过期，请重新登录"},"httpStatus":"UNAUTHORIZED","message":"会话已过期，请重新登录","requestId":null,"server":"B-38DMMD6R-2106.local","successful":false,"timestamp":null,"traceId":null}%

#### Additional documentation e.g., usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```