### PR TITLE
fix(rollback-plan): NPE when user input sql content is empty

### DIFF
--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/flow/task/RollbackPlanRuntimeFlowableTask.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/flow/task/RollbackPlanRuntimeFlowableTask.java
@@ -132,9 +132,10 @@ public class RollbackPlanRuntimeFlowableTask extends BaseODCFlowTaskDelegate<Rol
                 StringBuilder rollbackPlans = new StringBuilder();
                 int totalChangeLineConunt = 0;
                 int totalMaxChangeLinesLimit = flowTaskProperties.getTotalMaxChangeLines();
-                while (!userInputSqls.isEmpty() || (uploadFileSqlIterator != null && uploadFileSqlIterator.hasNext())) {
+                while (CollectionUtils.isNotEmpty(userInputSqls)
+                        || (uploadFileSqlIterator != null && uploadFileSqlIterator.hasNext())) {
                     String sql;
-                    if (!userInputSqls.isEmpty()) {
+                    if (CollectionUtils.isNotEmpty(userInputSqls)) {
                         sql = userInputSqls.remove(0).getStr();
                     } else {
                         sql = uploadFileSqlIterator.next().getStr();


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines.
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request.
3. Ensure you have added or ran the appropriate tests for your PR.
5. If the PR is unfinished, you may add or remove a WIP or [WIP] prefix to your pull request title.
-->

#### What type of PR is this?
type-bug

#### What this PR does / why we need it:
NPE occurs when user input sql content is empty during generating rollback plan. This PR fix it by using `CollectionUtils.isNotEmpty(userInputSqls)` replace `!userInputSqls.isEmpty()`

#### Which issue(s) this PR fixes:
Fixes #1240 

#### Special notes for your reviewer:
Self-test passed
<!--
This section is used to describe how this PR is implemented. 
If this is a PR that fixes a bug, this section describes how the bug was fixed.
If it's a new feature, this section briefly describes how to implement the new feature.
etc.
-->

#### Additional documentation e.g., usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```