### PR TITLE
fix(datasource):  convert the type of ob-mysql-sharding data source to ob-mysql

### DIFF
--- a/server/odc-service/src/main/java/com/oceanbase/odc/config/BeanConfiguration.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/config/BeanConfiguration.java
@@ -74,9 +74,8 @@ public class BeanConfiguration {
     public ObjectMapper objectMapper(SensitivePropertyHandler sensitivePropertyHandler) {
         CustomOutputSerializer customOutputSerializer = new CustomOutputSerializer()
                 .addSerializer(Internationalizable.class, new I18nOutputSerializer());
-        DialectTypeOutputSerializer dialectTypeOutputSerializer = new DialectTypeOutputSerializer();
         SimpleModule dialectTypeModule =
-                new SimpleModule().addSerializer(DialectType.class, dialectTypeOutputSerializer);
+                new SimpleModule().addSerializer(DialectType.class, new DialectTypeOutputSerializer());
         return JacksonFactory.unsafeJsonMapper()
                 .registerModule(JacksonModules.sensitiveInputHandling(sensitivePropertyHandler::decrypt))
                 .registerModule(JacksonModules.customOutputHandling(customOutputSerializer))
@@ -184,8 +183,10 @@ public class BeanConfiguration {
 
     /**
      * In order to adapt to the fact that there is no ODP_SHARDING_OB_MYSQL in DialectType of the
-     * front-end, ODP_SHARDING_OB_MYSQL is converted to OB_MYSQL during serialization.
+     * front-end, ODP_SHARDING_OB_MYSQL is converted to OB_MYSQL during serialization. Will be removed
+     * in the future
      */
+    @Deprecated
     private static class DialectTypeOutputSerializer extends JsonSerializer<DialectType> {
 
         @Override
@@ -197,6 +198,8 @@ public class BeanConfiguration {
                 } else {
                     jsonGenerator.writeString(dialectType.name());
                 }
+            } else {
+                jsonGenerator.writeNull();
             }
         }
     }

--- a/server/odc-service/src/main/java/com/oceanbase/odc/config/BeanConfiguration.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/config/BeanConfiguration.java
@@ -15,7 +15,9 @@
  */
 package com.oceanbase.odc.config;
 
+import java.io.IOException;
 import java.util.List;
+import java.util.Objects;
 
 import javax.annotation.PostConstruct;
 import javax.validation.constraints.NotBlank;
@@ -31,12 +33,17 @@ import org.springframework.security.web.firewall.HttpFirewall;
 import org.springframework.session.web.http.CookieSerializer;
 import org.springframework.session.web.http.DefaultCookieSerializer;
 
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.oceanbase.odc.common.i18n.I18nOutputSerializer;
 import com.oceanbase.odc.common.i18n.Internationalizable;
 import com.oceanbase.odc.common.json.JacksonFactory;
 import com.oceanbase.odc.common.json.JacksonModules;
 import com.oceanbase.odc.common.json.JacksonModules.CustomOutputSerializer;
+import com.oceanbase.odc.core.shared.constant.DialectType;
 import com.oceanbase.odc.core.shared.exception.UnsupportedException;
 import com.oceanbase.odc.service.connection.CloudMetadataClient;
 import com.oceanbase.odc.service.connection.model.OBDatabaseUser;
@@ -67,9 +74,13 @@ public class BeanConfiguration {
     public ObjectMapper objectMapper(SensitivePropertyHandler sensitivePropertyHandler) {
         CustomOutputSerializer customOutputSerializer = new CustomOutputSerializer()
                 .addSerializer(Internationalizable.class, new I18nOutputSerializer());
+        DialectTypeOutputSerializer dialectTypeOutputSerializer = new DialectTypeOutputSerializer();
+        SimpleModule dialectTypeModule =
+                new SimpleModule().addSerializer(DialectType.class, dialectTypeOutputSerializer);
         return JacksonFactory.unsafeJsonMapper()
                 .registerModule(JacksonModules.sensitiveInputHandling(sensitivePropertyHandler::decrypt))
-                .registerModule(JacksonModules.customOutputHandling(customOutputSerializer));
+                .registerModule(JacksonModules.customOutputHandling(customOutputSerializer))
+                .registerModule(dialectTypeModule);
     }
 
     /**
@@ -168,6 +179,25 @@ public class BeanConfiguration {
         @Override
         public OBDatabaseUser getSysTenantUser(String instanceId) {
             throw new UnsupportedException("CloudMetadata not supported");
+        }
+    }
+
+    /**
+     * In order to adapt to the fact that there is no ODP_SHARDING_OB_MYSQL in DialectType of the
+     * front-end, ODP_SHARDING_OB_MYSQL is converted to OB_MYSQL during serialization.
+     */
+    private static class DialectTypeOutputSerializer extends JsonSerializer<DialectType> {
+
+        @Override
+        public void serialize(DialectType dialectType, JsonGenerator jsonGenerator,
+                SerializerProvider serializerProvider) throws IOException {
+            if (Objects.nonNull(dialectType)) {
+                if (dialectType.equals(DialectType.ODP_SHARDING_OB_MYSQL)) {
+                    jsonGenerator.writeString(DialectType.OB_MYSQL.name());
+                } else {
+                    jsonGenerator.writeString(dialectType.name());
+                }
+            }
         }
     }
 


### PR DESCRIPTION
#### What type of PR is this?
type-bug
module-datasource

#### What this PR does / why we need it:
The back-end `DialectType` has added `ODP_SHARDING_OB_MYSQL`, which may cause the front-end page to crash. This hidden bug has not been triggered so far.
In order to avoid this bug, `ODP_SHARDING_OB_MYSQL` is converted to `OB_MYSQL` during serialization.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1252

#### Special notes for your reviewer:

<!--
This section is used to describe how this PR is implemented. 
If this is a PR that fixes a bug, this section describes how the bug was fixed.
If it's a new feature, this section briefly describes how to implement the new feature.
etc.
-->

#### Additional documentation e.g., usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```