### PR TITLE
fix(datasource): make ODP_SHARDING_OB_MYSQL not be converted to OB_MYSQL in some special cases

### DIFF
--- a/server/odc-common/src/main/java/com/oceanbase/odc/common/json/NormalDialectTypeOutput.java
+++ b/server/odc-common/src/main/java/com/oceanbase/odc/common/json/NormalDialectTypeOutput.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2023 OceanBase.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.oceanbase.odc.common.json;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * will be removed in ODC 4.2.4
+ *
+ * @author jingtian
+ * @date 2023/12/22
+ * @since ODC_release_4.2.3
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.FIELD, ElementType.METHOD, ElementType.TYPE})
+@Documented
+public @interface NormalDialectTypeOutput {
+}

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/audit/model/AuditEvent.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/audit/model/AuditEvent.java
@@ -17,6 +17,7 @@ package com.oceanbase.odc.service.audit.model;
 
 import java.util.Date;
 
+import com.oceanbase.odc.common.json.NormalDialectTypeOutput;
 import com.oceanbase.odc.core.shared.constant.AuditEventAction;
 import com.oceanbase.odc.core.shared.constant.AuditEventResult;
 import com.oceanbase.odc.core.shared.constant.AuditEventType;
@@ -106,6 +107,7 @@ public class AuditEvent {
     /**
      * Connection dialect type for this event; Null if not in connection
      */
+    @NormalDialectTypeOutput
     private DialectType connectionDialectType;
 
     /**

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/flow/task/model/MockDataTaskResult.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/flow/task/model/MockDataTaskResult.java
@@ -19,6 +19,7 @@ import java.util.List;
 
 import org.apache.commons.collections4.CollectionUtils;
 
+import com.oceanbase.odc.common.json.NormalDialectTypeOutput;
 import com.oceanbase.odc.core.flow.model.FlowTaskResult;
 import com.oceanbase.odc.core.shared.constant.DialectType;
 import com.oceanbase.odc.service.connection.model.ConnectionConfig;
@@ -51,6 +52,7 @@ public class MockDataTaskResult implements FlowTaskResult {
     private Long currentRecord;
     private Long totalGen;
     private String sessionName;
+    @NormalDialectTypeOutput
     private DialectType dbMode;
     @Deprecated
     private String internalTaskId;

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/onlineschemachange/model/OnlineSchemaChangeScheduleTaskResult.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/onlineschemachange/model/OnlineSchemaChangeScheduleTaskResult.java
@@ -15,6 +15,7 @@
  */
 package com.oceanbase.odc.service.onlineschemachange.model;
 
+import com.oceanbase.odc.common.json.NormalDialectTypeOutput;
 import com.oceanbase.odc.core.shared.constant.DialectType;
 
 import lombok.AllArgsConstructor;
@@ -32,6 +33,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class OnlineSchemaChangeScheduleTaskResult {
+    @NormalDialectTypeOutput
     private DialectType dialectType;
 
     /**

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/regulation/ruleset/model/Rule.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/regulation/ruleset/model/Rule.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonProperty.Access;
 import com.oceanbase.odc.common.i18n.Internationalizable;
+import com.oceanbase.odc.common.json.NormalDialectTypeOutput;
 import com.oceanbase.odc.core.authority.model.SecurityResource;
 import com.oceanbase.odc.core.shared.OrganizationIsolated;
 import com.oceanbase.odc.core.shared.constant.DialectType;
@@ -62,6 +63,7 @@ public class Rule implements SecurityResource, OrganizationIsolated, Serializabl
      * if type = SQL_CONSOLE, then appliedDialectTypes is always null which means applied to all
      * dialectTypes<br>
      */
+    @NormalDialectTypeOutput
     private List<DialectType> appliedDialectTypes;
 
     /**

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/regulation/ruleset/model/RuleMetadata.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/regulation/ruleset/model/RuleMetadata.java
@@ -18,6 +18,7 @@ package com.oceanbase.odc.service.regulation.ruleset.model;
 import java.util.List;
 
 import com.oceanbase.odc.common.i18n.Internationalizable;
+import com.oceanbase.odc.common.json.NormalDialectTypeOutput;
 import com.oceanbase.odc.core.shared.constant.DialectType;
 
 import lombok.Data;
@@ -53,6 +54,7 @@ public class RuleMetadata {
      * if type = SQL_CONSOLE, then appliedDialectTypes is always null which means it could be applied to
      * all dialectTypes<br>
      */
+    @NormalDialectTypeOutput
     private List<DialectType> supportedDialectTypes;
 
 


### PR DESCRIPTION

#### What type of PR is this?
type-bug

#### What this PR does / why we need it:
Fix the bug introduced by this PR：https://github.com/oceanbase/odc/pull/1253
There are some special scenarios, such as the optional DialectType in security rules and the DialectType displayed in operation records. In these cases, ODP_SHARDING_OB_MYSQL should not be converted to OB_MYSQL.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1279

#### Special notes for your reviewer:

<!--
This section is used to describe how this PR is implemented. 
If this is a PR that fixes a bug, this section describes how the bug was fixed.
If it's a new feature, this section briefly describes how to implement the new feature.
etc.
-->

#### Additional documentation e.g., usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```