### PR TITLE
fix(result-set-export): failed to rewrite sql for mysql

### DIFF
--- a/server/odc-core/src/main/java/com/oceanbase/odc/core/shared/constant/OdcConstants.java
+++ b/server/odc-core/src/main/java/com/oceanbase/odc/core/shared/constant/OdcConstants.java
@@ -62,6 +62,7 @@ public class OdcConstants {
     public static final String DB_VARIABLE_TYPE_ENUM = "enum";
     public static final String UNKNOWN = "UNKNOWN";
     public static final String ODC_INTERNAL_ROWID = "__ODC_INTERNAL_ROWID__";
+    public static final String ODC_INTERNAL_RESULT_SET = "__ODC_INTERNAL_RESULT_SET__";
     public static final String ROWID = "ROWID";
     public static final String PRIMARY_KEY_NAME = "PRIMARY";
 

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/resultset/ResultSetExportFlowableTask.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/resultset/ResultSetExportFlowableTask.java
@@ -97,7 +97,7 @@ public class ResultSetExportFlowableTask extends BaseODCFlowTaskDelegate<ResultS
     @Override
     protected void onTimeout(Long taskId, TaskService taskService) {
         log.warn("Result set export task timeout, taskId={}", taskId);
-        taskService.fail(taskId, context.progress(), "");
+        taskService.fail(taskId, context == null ? 0.0 : context.progress(), "");
     }
 
     @Override
@@ -118,12 +118,17 @@ public class ResultSetExportFlowableTask extends BaseODCFlowTaskDelegate<ResultS
 
     @Override
     protected boolean cancel(boolean mayInterruptIfRunning, Long taskId, TaskService taskService) {
-        context.cancel(mayInterruptIfRunning);
+        if (context != null) {
+            return context.cancel(mayInterruptIfRunning);
+        }
         return true;
     }
 
     @Override
     public boolean isCancelled() {
+        if (context == null) {
+            return false;
+        }
         return context.isCanceled();
     }
 

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/resultset/ResultSetExportTask.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/resultset/ResultSetExportTask.java
@@ -270,12 +270,12 @@ public class ResultSetExportTask implements Callable<ResultSetExportResult> {
         Verify.verify(result.getDataObjectsInfo().get(0).getStatus() == Status.SUCCESS, "Result export task failed!");
     }
 
-    private String getDumpFilePath(DataTransferTaskResult result, String extension) throws IOException {
+    private String getDumpFilePath(DataTransferTaskResult result, String extension) throws Exception {
         List<URL> exportPaths = result.getDataObjectsInfo().get(0).getExportPaths();
         if (CollectionUtils.isEmpty(exportPaths)) {
             return Paths.get(getDumpFileDirectory(), getFileName(extension)).toString();
         }
-        return exportPaths.get(0).getFile();
+        return exportPaths.get(0).toURI().getPath();
     }
 
     private String getFileName(String extension) {

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/schedule/flowtask/ResultSetExportPreprocessor.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/schedule/flowtask/ResultSetExportPreprocessor.java
@@ -77,7 +77,7 @@ public class ResultSetExportPreprocessor implements Preprocessor {
         BasicResult r = factory.buildAst(sql).getParseResult();
         Verify.verify(ParserUtil.getGeneralSqlType(r) == GeneralSqlType.DQL, "Invalid sql type, query must be DQL!");
 
-        parameter.setSql(sql);
+        parameter.setSql(sqls.get(0));
     }
 
 }

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/schedule/flowtask/ResultSetExportPreprocessor.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/schedule/flowtask/ResultSetExportPreprocessor.java
@@ -53,15 +53,15 @@ public class ResultSetExportPreprocessor implements Preprocessor {
         ConnectionConfig connectionConfig =
                 connectionService.getForConnectionSkipPermissionCheck(req.getConnectionId());
 
-        String sql = parameter.getSql();
-        preCheckSql(sql, connectionConfig.getDialectType());
+        preCheckSql(parameter, connectionConfig.getDialectType());
 
         PreConditions.validArgumentState(FILE_NAME_PATTERN.matcher(parameter.getFileName()).matches(),
                 ErrorCodes.BadArgument, null,
                 "File name must contain only letters, numbers, Chinese characters and \"._-\" ");
     }
 
-    private void preCheckSql(String sql, DialectType dialectType) {
+    private void preCheckSql(ResultSetExportTaskParameter parameter, DialectType dialectType) {
+        String sql = parameter.getSql();
         /*
          * verify single query
          */
@@ -76,6 +76,8 @@ public class ResultSetExportPreprocessor implements Preprocessor {
         }
         BasicResult r = factory.buildAst(sql).getParseResult();
         Verify.verify(ParserUtil.getGeneralSqlType(r) == GeneralSqlType.DQL, "Invalid sql type, query must be DQL!");
+
+        parameter.setSql(sql);
     }
 
 }

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/session/util/SqlRewriteUtil.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/session/util/SqlRewriteUtil.java
@@ -113,7 +113,7 @@ public class SqlRewriteUtil {
         result.append(sql.endsWith(";") ? sql.substring(0, sql.length() - 1) : sql).append(")");
 
         if (session.getDialectType().isMysql()) {
-            result.append(" limit ").append(maxRows);
+            result.append(" as ").append(OdcConstants.ODC_INTERNAL_RESULT_SET).append(" limit ").append(maxRows);
         } else {
             if (VersionUtils.isGreaterThanOrEqualsTo(ConnectionSessionUtil.getVersion(session), "2.2.50")) {
                 result.append(" fetch first ").append(maxRows).append(" rows only");

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/session/util/SqlRewriteUtil.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/session/util/SqlRewriteUtil.java
@@ -26,6 +26,7 @@ import com.oceanbase.odc.common.util.VersionUtils;
 import com.oceanbase.odc.core.session.ConnectionSession;
 import com.oceanbase.odc.core.session.ConnectionSessionConstants;
 import com.oceanbase.odc.core.session.ConnectionSessionUtil;
+import com.oceanbase.odc.core.shared.constant.DialectType;
 import com.oceanbase.odc.core.shared.constant.OdcConstants;
 import com.oceanbase.odc.core.sql.parser.AbstractSyntaxTree;
 import com.oceanbase.tools.sqlparser.statement.Statement;
@@ -112,8 +113,11 @@ public class SqlRewriteUtil {
         StringBuilder result = new StringBuilder("select * from (");
         result.append(sql.endsWith(";") ? sql.substring(0, sql.length() - 1) : sql).append(")");
 
+        if (session.getDialectType() == DialectType.MYSQL) {
+            result.append(" as ").append(OdcConstants.ODC_INTERNAL_RESULT_SET);
+        }
         if (session.getDialectType().isMysql()) {
-            result.append(" as ").append(OdcConstants.ODC_INTERNAL_RESULT_SET).append(" limit ").append(maxRows);
+            result.append(" limit ").append(maxRows);
         } else {
             if (VersionUtils.isGreaterThanOrEqualsTo(ConnectionSessionUtil.getVersion(session), "2.2.50")) {
                 result.append(" fetch first ").append(maxRows).append(" rows only");

--- a/server/plugins/task-plugin-mysql/src/main/java/com/oceanbase/odc/plugin/task/mysql/datatransfer/job/datax/ConfigurationResolver.java
+++ b/server/plugins/task-plugin-mysql/src/main/java/com/oceanbase/odc/plugin/task/mysql/datatransfer/job/datax/ConfigurationResolver.java
@@ -165,6 +165,9 @@ public class ConfigurationResolver {
             pluginParameter.setCsvWriterConfig(getDataXCsvConfig(baseConfig));
             pluginParameter.setSkipHeader(baseConfig.getCsvConfig().isSkipHeader());
             pluginParameter.setNullFormat(baseConfig.getCsvConfig().isBlankToNull() ? "null" : "");
+            if (baseConfig.getCsvConfig().isSkipHeader()) {
+                pluginParameter.setHeader(null);
+            }
         }
 
         return writer;

--- a/server/plugins/task-plugin-mysql/src/main/java/com/oceanbase/odc/plugin/task/mysql/datatransfer/job/datax/ConfigurationResolver.java
+++ b/server/plugins/task-plugin-mysql/src/main/java/com/oceanbase/odc/plugin/task/mysql/datatransfer/job/datax/ConfigurationResolver.java
@@ -165,7 +165,8 @@ public class ConfigurationResolver {
             pluginParameter.setCsvWriterConfig(getDataXCsvConfig(baseConfig));
             pluginParameter.setSkipHeader(baseConfig.getCsvConfig().isSkipHeader());
             pluginParameter.setNullFormat(baseConfig.getCsvConfig().isBlankToNull() ? "null" : "");
-            if (baseConfig.getCsvConfig().isSkipHeader()) {
+            if (baseConfig.getCsvConfig().isSkipHeader()
+                    && baseConfig.getDataTransferFormat() != DataTransferFormat.SQL) {
                 pluginParameter.setHeader(null);
             }
         }


### PR DESCRIPTION
Fix #1283 . When exporting result set, we would rewrite query sql into like `select * from (<original sql>) limit xxx` . 
In ob-mysql , this works normally. But in native mysql, this rewrite would get a syntax error 'Every derived table must have its own alias'. 
Therefore, we will add a `as  __ODC_INTERNAL_RESULT_SET__` into query to fix this.

Fix #1282 . When user set skip header, the `TxtWriterPluginParameter#header` field should not be set.