### PR TITLE
feat(sql-execute): add size limit for sql console query

### DIFF
--- a/server/odc-core/src/main/java/com/oceanbase/odc/core/sql/execute/model/JdbcQueryResult.java
+++ b/server/odc-core/src/main/java/com/oceanbase/odc/core/sql/execute/model/JdbcQueryResult.java
@@ -47,8 +47,10 @@ public class JdbcQueryResult {
         this.metaData = new JdbcResultSetMetaData(metaData);
     }
 
-    public void addLine(@NonNull ResultSet resultSet) throws SQLException, IOException {
-        rows.add(mapper.mapRow(resultSet));
+    public long addLine(@NonNull ResultSet resultSet) throws SQLException, IOException {
+        List<Object> objects = mapper.mapRow(resultSet);
+        rows.add(objects);
+        return objects.stream().mapToLong(o -> o.toString().getBytes().length).sum();
     }
 
     public Object get(int rowIndex, int colIndex) {

--- a/server/odc-core/src/main/java/com/oceanbase/odc/core/sql/execute/model/JdbcQueryResult.java
+++ b/server/odc-core/src/main/java/com/oceanbase/odc/core/sql/execute/model/JdbcQueryResult.java
@@ -50,7 +50,7 @@ public class JdbcQueryResult {
     public long addLine(@NonNull ResultSet resultSet) throws SQLException, IOException {
         List<Object> objects = mapper.mapRow(resultSet);
         rows.add(objects);
-        return objects.stream().mapToLong(o -> o.toString().getBytes().length).sum();
+        return objects.stream().mapToLong(o -> o == null ? 0 : o.toString().getBytes().length).sum();
     }
 
     public Object get(int rowIndex, int colIndex) {

--- a/server/odc-server/src/main/resources/data.sql
+++ b/server/odc-server/src/main/resources/data.sql
@@ -489,6 +489,9 @@ INSERT INTO config_system_configuration(`key`, `value`, `description`) VALUES('o
 INSERT INTO config_system_configuration(`key`, `value`, `description`) VALUES('odc.session.sql-execute.result-set.max-cached-size',
  '1073741824', 'SQL 执行结果集缓存最大字节数，该配置主要影响大字段查看功能，若结果集规模太大可能超过此配置造成无法查看相关二进制数据') ON DUPLICATE KEY UPDATE `id`=`id`;
 
+INSERT INTO config_system_configuration(`key`, `value`, `description`) VALUES('odc.session.sql-execute.result-set.max-query-size',
+ '-1', 'SQL 执行结果集最大字节数，默认为 -1，表示不限制') ON DUPLICATE KEY UPDATE `id`=`id`;
+
 INSERT INTO config_system_configuration(`key`, `value`, `description`) VALUES('odc.session.sql-execute.max-result-set-rows',
    '-1', '结果集查询条数限制，默认为 -1，表示不限制') ON DUPLICATE KEY UPDATE `id`=`id`;
 

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/session/ConnectConsoleService.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/session/ConnectConsoleService.java
@@ -255,6 +255,9 @@ public class ConnectConsoleService {
         statementCallBack.setMaxCachedSize(sessionProperties.getResultSetMaxCachedSize());
         statementCallBack.setMaxCachedLines(sessionProperties.getResultSetMaxCachedLines());
         statementCallBack.setLocale(LocaleContextHolder.getLocale());
+        if (sessionProperties.getResultSetMaxQuerySize() > 0) {
+            statementCallBack.setMaxQuerySize(sessionProperties.getResultSetMaxQuerySize());
+        }
 
         Future<List<JdbcGeneralResult>> futureResult = connectionSession.getAsyncJdbcExecutor(
                 ConnectionSessionConstants.CONSOLE_DS_KEY).execute(statementCallBack);

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/session/OdcStatementCallBack.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/session/OdcStatementCallBack.java
@@ -278,7 +278,7 @@ public class OdcStatementCallBack implements StatementCallback<List<JdbcGeneralR
                     while (resultSet.next()) {
                         if (maxQuerySize != null && resultSetSize > maxQuerySize) {
                             throw new OverLimitException(LimitMetric.TRANSACTION_QUERY_LIMIT, queryLimit.doubleValue(),
-                                    "result set size exceed limit, maximum was " + queryLimit + " bytes");
+                                    "result set size exceed limit, maximum was " + maxQuerySize + " bytes");
                         }
                         resultSetSize += jdbcQueryResult.addLine(resultSet);
                         virtualTable.addLine((line++), resultSet,

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/session/SessionProperties.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/session/SessionProperties.java
@@ -39,6 +39,12 @@ public class SessionProperties {
     private long resultSetMaxCachedSize = 1024 * 1024 * 1024L;
 
     /**
+     * The maximum size limit of the result set, with a default of -1, indicating no restriction
+     */
+    @Value(("${odc.session.sql-execute.result-set.max-query-size:-1}"))
+    private long resultSetMaxQuerySize = -1;
+
+    /**
      * 查询结果集最大行数，默认 100000
      */
     @Value("${odc.session.sql-execute.max-result-set-rows:100000}")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines.
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request.
3. Ensure you have added or ran the appropriate tests for your PR.
5. If the PR is unfinished, you may add or remove a WIP or [WIP] prefix to your pull request title.
-->

#### What type of PR is this?
type-feature
<!--
Add one of the following kinds:
type-bug
type-feature
type-docs
etc.

Optionally add one or more of the following kinds if applicable:
module-resultset
module-sql execution
etc.
-->

#### What this PR does / why we need it:

If the size of query result se is very large, there may be some unexpected exceptions.

So I added a limit for query result set, the default value is -1, indicating no restriction.
This param could be configured in metadb, and it's value must be a positive number.
