### PR TITLE
fix(object-storage): remove dependency on OssTaskReferManager

### DIFF
--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/datatransfer/DefaultDataTransferAdapter.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/datatransfer/DefaultDataTransferAdapter.java
@@ -24,7 +24,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 import com.oceanbase.odc.plugin.task.api.datatransfer.model.DataTransferConfig;
 import com.oceanbase.odc.plugin.task.api.datatransfer.model.DataTransferTaskResult;
-import com.oceanbase.odc.service.flow.task.OssTaskReferManager;
 import com.oceanbase.odc.service.objectstorage.cloud.CloudObjectStorageService;
 
 import lombok.extern.slf4j.Slf4j;
@@ -32,8 +31,6 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class DefaultDataTransferAdapter implements DataTransferAdapter {
 
-    @Autowired
-    private OssTaskReferManager taskReferManager;
     @Autowired
     private CloudObjectStorageService cloudObjectStorageService;
 
@@ -56,7 +53,7 @@ public class DefaultDataTransferAdapter implements DataTransferAdapter {
         try {
             String objectName = cloudObjectStorageService.uploadTemp(exportFile.getName(), exportFile);
             log.info("Upload the data file to the oss successfully, objectName={}", objectName);
-            taskReferManager.put(exportFile.getName(), objectName);
+            result.setExportZipFilePath(objectName);
         } finally {
             /**
              * 公有云模式下本地导出文件和目录都不必要保存，直接删除

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/flow/FlowTaskInstanceService.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/flow/FlowTaskInstanceService.java
@@ -439,7 +439,7 @@ public class FlowTaskInstanceService {
         } else if (taskEntity.getTaskType() == TaskType.EXPORT_RESULT_SET) {
             List<ResultSetExportResult> results = getResultSetExportResult(taskEntity);
             Verify.singleton(results, "ResultSetExportResult");
-            String objectName = ossTaskReferManager.get(results.get(0).getFileName());
+            String objectName = results.get(0).getFileName();
             PreConditions.validExists(ResourceType.ODC_FILE, "taskId", taskEntity.getId(),
                     () -> StringUtils.isNotBlank(objectName));
             return Collections.singletonList(generatePresignedUrl(objectName, expirationSecs));

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/flow/FlowTaskInstanceService.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/flow/FlowTaskInstanceService.java
@@ -428,8 +428,7 @@ public class FlowTaskInstanceService {
             List<DataTransferTaskResult> taskResults = getDataTransferResult(taskEntity);
             Verify.singleton(taskResults, "DataTransferTaskResult");
 
-            DataTransferTaskResult taskResult = taskResults.get(0);
-            String objectName = ossTaskReferManager.get(taskResult.getExportZipFilePath());
+            String objectName = taskResults.get(0).getExportZipFilePath();
             PreConditions.validExists(ResourceType.ODC_FILE, "taskId", taskEntity.getId(),
                     () -> StringUtils.isNotBlank(objectName));
             URL url = generatePresignedUrl(objectName, expirationSecs);

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/flow/FlowTaskInstanceService.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/flow/FlowTaskInstanceService.java
@@ -416,7 +416,7 @@ public class FlowTaskInstanceService {
             List<MockDataTaskResult> details = getMockDataResult(taskEntity);
             Verify.singleton(details, "MockDataDetail");
 
-            String objectName = ossTaskReferManager.get(taskEntity.getId() + "");
+            String objectName = details.get(0).getObjectName();
             PreConditions.validExists(ResourceType.ODC_FILE, "taskId", taskEntity.getId(),
                     () -> StringUtils.isNotBlank(objectName));
             URL url = generatePresignedUrl(objectName, expirationSecs);

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/flow/task/model/MockDataTaskResult.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/flow/task/model/MockDataTaskResult.java
@@ -52,6 +52,7 @@ public class MockDataTaskResult implements FlowTaskResult {
     private Long currentRecord;
     private Long totalGen;
     private String sessionName;
+    private String objectName;
     @NormalDialectTypeOutput
     private DialectType dbMode;
     @Deprecated


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines.
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request.
3. Ensure you have added or ran the appropriate tests for your PR.
5. If the PR is unfinished, you may add or remove a WIP or [WIP] prefix to your pull request title.
-->

#### What type of PR is this?
type-bug
<!--
Add one of the following kinds:
type-bug
type-feature
type-docs
etc.

Optionally add one or more of the following kinds if applicable:
module-resultset
module-sql execution
etc.
-->

#### What this PR does / why we need it:
Now ODC would upload some task results to cloud object storage if it's available. But the `objectName` is storaged in memory of `OssTaskReferManager`. If the odc-server is reboot, these all data will be lost.

So we remove the dependency on this cache in this PR.