### PR TITLE
feat(structure-compare): add structure comparison

### DIFF
--- a/libs/db-browser/pom.xml
+++ b/libs/db-browser/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.oceanbase</groupId>
     <artifactId>db-browser</artifactId>
-    <version>1.0.4</version>
+    <version>1.0.5</version>
     <name>db-browser</name>
     <url>https://github.com/oceanbase/odc/tree/main/libs/db-browser</url>
 

--- a/libs/db-browser/src/main/java/com/oceanbase/tools/dbbrowser/editor/DBTableEditor.java
+++ b/libs/db-browser/src/main/java/com/oceanbase/tools/dbbrowser/editor/DBTableEditor.java
@@ -182,7 +182,7 @@ public abstract class DBTableEditor implements DBObjectEditor<DBTable> {
         return sqlBuilder.toString();
     }
 
-    protected abstract void generateUpdateTableOptionDDL(DBTable oldTable, DBTable newTable, SqlBuilder sqlBuilder);
+    public abstract void generateUpdateTableOptionDDL(DBTable oldTable, DBTable newTable, SqlBuilder sqlBuilder);
 
     protected abstract SqlBuilder sqlBuilder();
 
@@ -199,7 +199,7 @@ public abstract class DBTableEditor implements DBObjectEditor<DBTable> {
      * 排除唯一性约束</br>
      * 创建一个唯一索引，OB 会自动创建一个同名唯一约束；因此在生成 DDL 时，如果已有唯一索引，则需要忽略掉同名唯一约束，不然生成的 DDL 会无法执行</br>
      */
-    protected List<DBTableConstraint> excludeUniqueConstraint(List<DBTableIndex> indexes,
+    public List<DBTableConstraint> excludeUniqueConstraint(List<DBTableIndex> indexes,
             List<DBTableConstraint> constraints) {
         if (CollectionUtils.isEmpty(indexes) || CollectionUtils.isEmpty(constraints)) {
             return constraints;
@@ -219,7 +219,7 @@ public abstract class DBTableEditor implements DBObjectEditor<DBTable> {
      * 排除主键约束对应的唯一索引</br>
      * 创建主键约束的时候，OB 会自动创建一个同名唯一索引；因此在生成 DDL 时，如果已有主键约束，则需要忽略掉同名唯一索引，不然生成的 DDL 会无法执行</br>
      */
-    protected List<DBTableIndex> excludePrimaryKeyIndex(List<DBTableIndex> indexes,
+    public List<DBTableIndex> excludePrimaryKeyIndex(List<DBTableIndex> indexes,
             List<DBTableConstraint> constraints) {
         if (CollectionUtils.isEmpty(indexes) || CollectionUtils.isEmpty(constraints)) {
             return indexes;

--- a/libs/db-browser/src/main/java/com/oceanbase/tools/dbbrowser/editor/mysql/MySQLTableEditor.java
+++ b/libs/db-browser/src/main/java/com/oceanbase/tools/dbbrowser/editor/mysql/MySQLTableEditor.java
@@ -85,7 +85,7 @@ public class MySQLTableEditor extends DBTableEditor {
     protected void appendMoreTableOptions(DBTable table, SqlBuilder sqlBuilder) {}
 
     @Override
-    protected void generateUpdateTableOptionDDL(@NonNull DBTable oldTable, @NonNull DBTable newTable,
+    public void generateUpdateTableOptionDDL(@NonNull DBTable oldTable, @NonNull DBTable newTable,
             @NonNull SqlBuilder sqlBuilder) {
         if (Objects.isNull(oldTable.getTableOptions()) || Objects.isNull(newTable.getTableOptions())) {
             return;
@@ -95,6 +95,22 @@ public class MySQLTableEditor extends DBTableEditor {
                     .append(getFullyQualifiedTableName(newTable))
                     .append(" COMMENT = ")
                     .value(newTable.getTableOptions().getComment())
+                    .append(";\n");
+        }
+        if (!StringUtils.equals(oldTable.getTableOptions().getCharsetName(),
+                newTable.getTableOptions().getCharsetName())) {
+            sqlBuilder.append("ALTER TABLE ")
+                    .append(getFullyQualifiedTableName(newTable))
+                    .append(" CHARACTER SET = ")
+                    .append(newTable.getTableOptions().getCharsetName())
+                    .append(";\n");
+        }
+        if (!StringUtils.equals(oldTable.getTableOptions().getCollationName(),
+                newTable.getTableOptions().getCollationName())) {
+            sqlBuilder.append("ALTER TABLE ")
+                    .append(getFullyQualifiedTableName(newTable))
+                    .append(" COLLATE = ")
+                    .append(newTable.getTableOptions().getCollationName())
                     .append(";\n");
         }
     }

--- a/libs/db-browser/src/main/java/com/oceanbase/tools/dbbrowser/editor/oracle/OracleTableEditor.java
+++ b/libs/db-browser/src/main/java/com/oceanbase/tools/dbbrowser/editor/oracle/OracleTableEditor.java
@@ -73,7 +73,7 @@ public class OracleTableEditor extends DBTableEditor {
     }
 
     @Override
-    protected void generateUpdateTableOptionDDL(DBTable oldTable, DBTable newTable, SqlBuilder sqlBuilder) {
+    public void generateUpdateTableOptionDDL(DBTable oldTable, DBTable newTable, SqlBuilder sqlBuilder) {
         if (!StringUtils.equals(oldTable.getTableOptions().getComment(), newTable.getTableOptions().getComment())) {
             appendTableComment(newTable, sqlBuilder);
         }

--- a/libs/db-browser/src/main/java/com/oceanbase/tools/dbbrowser/model/DBTableColumn.java
+++ b/libs/db-browser/src/main/java/com/oceanbase/tools/dbbrowser/model/DBTableColumn.java
@@ -35,7 +35,7 @@ import lombok.EqualsAndHashCode;
  * columnName.
  */
 @Data
-@EqualsAndHashCode(exclude = {"name", "warning", "schemaName", "tableName", "ordinalPosition"})
+@EqualsAndHashCode(exclude = {"name", "warning", "schemaName", "tableName", "ordinalPosition", "keyType"})
 public class DBTableColumn implements DBObject, DBObjectWarningDescriptor {
     /**
      * 所属 schemaName

--- a/libs/db-browser/src/main/java/com/oceanbase/tools/dbbrowser/model/DBTableConstraint.java
+++ b/libs/db-browser/src/main/java/com/oceanbase/tools/dbbrowser/model/DBTableConstraint.java
@@ -26,7 +26,7 @@ import lombok.EqualsAndHashCode;
 
 @Data
 @EqualsAndHashCode(
-        exclude = {"name", "warning", "schemaName", "tableName", "createTime", "updateTime", "ordinalPosition",
+        exclude = {"name", "warning", "schemaName", "owner", "tableName", "createTime", "updateTime", "ordinalPosition",
                 "enabled"})
 public class DBTableConstraint implements DBObject, DBObjectWarningDescriptor {
     /**

--- a/libs/db-browser/src/main/java/com/oceanbase/tools/dbbrowser/model/DBTableIndex.java
+++ b/libs/db-browser/src/main/java/com/oceanbase/tools/dbbrowser/model/DBTableIndex.java
@@ -26,7 +26,8 @@ import lombok.EqualsAndHashCode;
 
 @Data
 @EqualsAndHashCode(
-        exclude = {"name", "warning", "schemaName", "tableName", "createTime", "updateTime", "ordinalPosition"})
+        exclude = {"name", "warning", "schemaName", "owner", "tableName", "createTime", "updateTime",
+                "ordinalPosition"})
 public class DBTableIndex implements DBObject, DBObjectWarningDescriptor {
     /**
      * 所属 schemaName

--- a/libs/db-browser/src/test/java/com/oceanbase/tools/dbbrowser/editor/MySQLTableEditorTest.java
+++ b/libs/db-browser/src/test/java/com/oceanbase/tools/dbbrowser/editor/MySQLTableEditorTest.java
@@ -63,7 +63,9 @@ public class MySQLTableEditorTest {
         String ddl =
                 tableEditor.generateUpdateObjectDDL(DBObjectUtilsTest.getOldTable(), DBObjectUtilsTest.getNewTable());
         Assert.assertEquals(
-                "ALTER TABLE `old_table` RENAME TO `whatever_table`;\n",
+                "ALTER TABLE `old_table` RENAME TO `whatever_table`;\n"
+                        + "ALTER TABLE `whatever_schema`.`whatever_table` CHARACTER SET = utf8mb4;\n"
+                        + "ALTER TABLE `whatever_schema`.`whatever_table` COLLATE = utf8mb4_bin;\n",
                 ddl);
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,7 @@
         <alipay.sdk.version>4.20.19.ALL</alipay.sdk.version>
         <bucket4j-core.version>4.10.0</bucket4j-core.version>
         <springfox-swagger-ui.version>2.10.0</springfox-swagger-ui.version>
-        <db-browser.version>1.0.4</db-browser.version>
+        <db-browser.version>1.0.5</db-browser.version>
         <ob-sql-parser.version>1.2.0</ob-sql-parser.version>
         <pf4j.version>3.10.0</pf4j.version>
         <bcpkix-jdk15on.version>1.64</bcpkix-jdk15on.version>

--- a/server/odc-test/src/main/java/com/oceanbase/odc/test/database/TestDBConfiguration.java
+++ b/server/odc-test/src/main/java/com/oceanbase/odc/test/database/TestDBConfiguration.java
@@ -25,12 +25,14 @@ import com.oceanbase.odc.test.cli.MysqlClientArgsParser;
 import com.oceanbase.odc.test.util.JdbcUtil;
 
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 /**
  * @author gaoda.xy
  * @date 2023/2/17 10:47
  */
 @Data
+@NoArgsConstructor
 public class TestDBConfiguration {
     private DataSource dataSource;
     private TestDBType type;
@@ -65,7 +67,7 @@ public class TestDBConfiguration {
         initDataSource();
     }
 
-    private void initDataSource() {
+    public void initDataSource() {
         DruidDataSource dataSource = new DruidDataSource();
         dataSource.setUrl(JdbcUtil.buildUrl(host, port, defaultDBName, type));
         dataSource.setUsername(JdbcUtil.buildUser(username, tenant, cluster));

--- a/server/plugins/schema-plugin-mysql/src/main/java/com/oceanbase/odc/plugin/schema/mysql/MySQLTableExtension.java
+++ b/server/plugins/schema-plugin-mysql/src/main/java/com/oceanbase/odc/plugin/schema/mysql/MySQLTableExtension.java
@@ -20,16 +20,11 @@ import java.sql.Connection;
 import org.pf4j.Extension;
 
 import com.oceanbase.odc.common.util.JdbcOperationsUtil;
+import com.oceanbase.odc.plugin.schema.mysql.utils.DBAccessorUtil;
 import com.oceanbase.odc.plugin.schema.obmysql.OBMySQLTableExtension;
 import com.oceanbase.tools.dbbrowser.editor.DBTableEditor;
-import com.oceanbase.tools.dbbrowser.editor.mysql.MySQLColumnEditor;
-import com.oceanbase.tools.dbbrowser.editor.mysql.MySQLConstraintEditor;
-import com.oceanbase.tools.dbbrowser.editor.mysql.MySQLDBTablePartitionEditor;
-import com.oceanbase.tools.dbbrowser.editor.mysql.MySQLNoGreaterThan5740IndexEditor;
-import com.oceanbase.tools.dbbrowser.editor.mysql.MySQLTableEditor;
 import com.oceanbase.tools.dbbrowser.model.DBTable;
 import com.oceanbase.tools.dbbrowser.schema.DBSchemaAccessor;
-import com.oceanbase.tools.dbbrowser.schema.mysql.MySQLNoGreaterThan5740SchemaAccessor;
 import com.oceanbase.tools.dbbrowser.stats.DBStatsAccessor;
 import com.oceanbase.tools.dbbrowser.stats.mysql.MySQLNoGreaterThan5740StatsAccessor;
 
@@ -61,14 +56,12 @@ public class MySQLTableExtension extends OBMySQLTableExtension {
 
     @Override
     protected DBTableEditor getTableEditor(@NonNull Connection connection) {
-        return new MySQLTableEditor(new MySQLNoGreaterThan5740IndexEditor(), new MySQLColumnEditor(),
-                new MySQLConstraintEditor(),
-                new MySQLDBTablePartitionEditor());
+        return DBAccessorUtil.getTableEditor(connection);
     }
 
     @Override
     protected DBSchemaAccessor getSchemaAccessor(Connection connection) {
-        return new MySQLNoGreaterThan5740SchemaAccessor(JdbcOperationsUtil.getJdbcOperations(connection));
+        return DBAccessorUtil.getSchemaAccessor(connection);
     }
 
     @Override

--- a/server/plugins/schema-plugin-mysql/src/main/java/com/oceanbase/odc/plugin/schema/mysql/utils/DBAccessorUtil.java
+++ b/server/plugins/schema-plugin-mysql/src/main/java/com/oceanbase/odc/plugin/schema/mysql/utils/DBAccessorUtil.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2023 OceanBase.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.oceanbase.odc.plugin.schema.mysql.utils;
+
+import java.sql.Connection;
+
+import com.oceanbase.odc.common.util.JdbcOperationsUtil;
+import com.oceanbase.tools.dbbrowser.editor.DBTableEditor;
+import com.oceanbase.tools.dbbrowser.editor.mysql.MySQLColumnEditor;
+import com.oceanbase.tools.dbbrowser.editor.mysql.MySQLConstraintEditor;
+import com.oceanbase.tools.dbbrowser.editor.mysql.MySQLDBTablePartitionEditor;
+import com.oceanbase.tools.dbbrowser.editor.mysql.MySQLNoGreaterThan5740IndexEditor;
+import com.oceanbase.tools.dbbrowser.editor.mysql.MySQLTableEditor;
+import com.oceanbase.tools.dbbrowser.schema.DBSchemaAccessor;
+import com.oceanbase.tools.dbbrowser.schema.mysql.MySQLNoGreaterThan5740SchemaAccessor;
+
+/**
+ * @author jingtian
+ * @date 2024/1/2
+ * @since ODC_release_4.2.4
+ */
+public class DBAccessorUtil {
+
+    public static DBSchemaAccessor getSchemaAccessor(Connection connection) {
+        return new MySQLNoGreaterThan5740SchemaAccessor(JdbcOperationsUtil.getJdbcOperations(connection));
+    }
+
+    public static DBTableEditor getTableEditor(Connection connection) {
+        return new MySQLTableEditor(new MySQLNoGreaterThan5740IndexEditor(), new MySQLColumnEditor(),
+                new MySQLConstraintEditor(),
+                new MySQLDBTablePartitionEditor());
+    }
+}

--- a/server/plugins/schema-plugin-ob-mysql/src/main/java/com/oceanbase/odc/plugin/schema/obmysql/OBMySQLTableExtension.java
+++ b/server/plugins/schema-plugin-ob-mysql/src/main/java/com/oceanbase/odc/plugin/schema/obmysql/OBMySQLTableExtension.java
@@ -23,20 +23,12 @@ import org.pf4j.Extension;
 
 import com.oceanbase.odc.common.unit.BinarySizeUnit;
 import com.oceanbase.odc.common.util.JdbcOperationsUtil;
-import com.oceanbase.odc.common.util.VersionUtils;
 import com.oceanbase.odc.plugin.schema.api.TableExtensionPoint;
 import com.oceanbase.odc.plugin.schema.obmysql.parser.OBMySQLGetDBTableByParser;
 import com.oceanbase.odc.plugin.schema.obmysql.utils.DBAccessorUtil;
 import com.oceanbase.tools.dbbrowser.editor.DBObjectOperator;
 import com.oceanbase.tools.dbbrowser.editor.DBTableEditor;
-import com.oceanbase.tools.dbbrowser.editor.DBTablePartitionEditor;
-import com.oceanbase.tools.dbbrowser.editor.mysql.MySQLColumnEditor;
-import com.oceanbase.tools.dbbrowser.editor.mysql.MySQLConstraintEditor;
-import com.oceanbase.tools.dbbrowser.editor.mysql.MySQLDBTablePartitionEditor;
 import com.oceanbase.tools.dbbrowser.editor.mysql.MySQLObjectOperator;
-import com.oceanbase.tools.dbbrowser.editor.mysql.OBMySQLIndexEditor;
-import com.oceanbase.tools.dbbrowser.editor.mysql.OBMySQLLessThan2277PartitionEditor;
-import com.oceanbase.tools.dbbrowser.editor.mysql.OBMySQLTableEditor;
 import com.oceanbase.tools.dbbrowser.model.DBObjectIdentity;
 import com.oceanbase.tools.dbbrowser.model.DBObjectType;
 import com.oceanbase.tools.dbbrowser.model.DBTable;
@@ -121,8 +113,7 @@ public class OBMySQLTableExtension implements TableExtensionPoint {
     }
 
     protected DBTableEditor getTableEditor(Connection connection) {
-        return new OBMySQLTableEditor(new OBMySQLIndexEditor(), new MySQLColumnEditor(), new MySQLConstraintEditor(),
-                getDBTablePartitionEditor(connection));
+        return DBAccessorUtil.getTableEditor(connection);
     }
 
     protected DBSchemaAccessor getSchemaAccessor(Connection connection) {
@@ -135,15 +126,6 @@ public class OBMySQLTableExtension implements TableExtensionPoint {
 
     private DBObjectOperator getTableOperator(Connection connection) {
         return new MySQLObjectOperator(JdbcOperationsUtil.getJdbcOperations(connection));
-    }
-
-    protected DBTablePartitionEditor getDBTablePartitionEditor(Connection connection) {
-        String dbVersion = DBAccessorUtil.getDbVersion(connection);
-        if (VersionUtils.isLessThan(dbVersion, "2.2.77")) {
-            return new OBMySQLLessThan2277PartitionEditor();
-        } else {
-            return new MySQLDBTablePartitionEditor();
-        }
     }
 
 }

--- a/server/plugins/schema-plugin-ob-mysql/src/main/java/com/oceanbase/odc/plugin/schema/obmysql/utils/DBAccessorUtil.java
+++ b/server/plugins/schema-plugin-ob-mysql/src/main/java/com/oceanbase/odc/plugin/schema/obmysql/utils/DBAccessorUtil.java
@@ -18,9 +18,18 @@ package com.oceanbase.odc.plugin.schema.obmysql.utils;
 import java.sql.Connection;
 
 import com.oceanbase.odc.common.util.JdbcOperationsUtil;
+import com.oceanbase.odc.common.util.VersionUtils;
 import com.oceanbase.odc.plugin.connect.obmysql.OBMySQLInformationExtension;
 import com.oceanbase.odc.plugin.schema.obmysql.browser.DBSchemaAccessors;
 import com.oceanbase.odc.plugin.schema.obmysql.browser.DBStatsAccessors;
+import com.oceanbase.tools.dbbrowser.editor.DBTableEditor;
+import com.oceanbase.tools.dbbrowser.editor.DBTablePartitionEditor;
+import com.oceanbase.tools.dbbrowser.editor.mysql.MySQLColumnEditor;
+import com.oceanbase.tools.dbbrowser.editor.mysql.MySQLConstraintEditor;
+import com.oceanbase.tools.dbbrowser.editor.mysql.MySQLDBTablePartitionEditor;
+import com.oceanbase.tools.dbbrowser.editor.mysql.OBMySQLIndexEditor;
+import com.oceanbase.tools.dbbrowser.editor.mysql.OBMySQLLessThan2277PartitionEditor;
+import com.oceanbase.tools.dbbrowser.editor.mysql.OBMySQLTableEditor;
 import com.oceanbase.tools.dbbrowser.schema.DBSchemaAccessor;
 import com.oceanbase.tools.dbbrowser.stats.DBStatsAccessor;
 
@@ -40,5 +49,19 @@ public class DBAccessorUtil {
 
     public static DBStatsAccessor getStatsAccessor(Connection connection) {
         return DBStatsAccessors.create(JdbcOperationsUtil.getJdbcOperations(connection), getDbVersion(connection));
+    }
+
+    public static DBTableEditor getTableEditor(Connection connection) {
+        return new OBMySQLTableEditor(new OBMySQLIndexEditor(), new MySQLColumnEditor(), new MySQLConstraintEditor(),
+                getDBTablePartitionEditor(connection));
+    }
+
+    private static DBTablePartitionEditor getDBTablePartitionEditor(Connection connection) {
+        String dbVersion = getDbVersion(connection);
+        if (VersionUtils.isLessThan(dbVersion, "2.2.77")) {
+            return new OBMySQLLessThan2277PartitionEditor();
+        } else {
+            return new MySQLDBTablePartitionEditor();
+        }
     }
 }

--- a/server/plugins/schema-plugin-ob-oracle/src/main/java/com/oceanbase/odc/plugin/schema/oboracle/OBOracleTableExtension.java
+++ b/server/plugins/schema-plugin-ob-oracle/src/main/java/com/oceanbase/odc/plugin/schema/oboracle/OBOracleTableExtension.java
@@ -28,11 +28,6 @@ import com.oceanbase.odc.plugin.schema.obmysql.OBMySQLTableExtension;
 import com.oceanbase.odc.plugin.schema.oboracle.parser.OBOracleGetDBTableByParser;
 import com.oceanbase.odc.plugin.schema.oboracle.utils.DBAccessorUtil;
 import com.oceanbase.tools.dbbrowser.editor.DBTableEditor;
-import com.oceanbase.tools.dbbrowser.editor.oracle.OBOracleIndexEditor;
-import com.oceanbase.tools.dbbrowser.editor.oracle.OracleColumnEditor;
-import com.oceanbase.tools.dbbrowser.editor.oracle.OracleConstraintEditor;
-import com.oceanbase.tools.dbbrowser.editor.oracle.OracleDBTablePartitionEditor;
-import com.oceanbase.tools.dbbrowser.editor.oracle.OracleTableEditor;
 import com.oceanbase.tools.dbbrowser.model.DBIndexType;
 import com.oceanbase.tools.dbbrowser.model.DBTable;
 import com.oceanbase.tools.dbbrowser.model.DBTable.DBTableOptions;
@@ -144,7 +139,6 @@ public class OBOracleTableExtension extends OBMySQLTableExtension {
 
     @Override
     protected DBTableEditor getTableEditor(Connection connection) {
-        return new OracleTableEditor(new OBOracleIndexEditor(), new OracleColumnEditor(),
-                new OracleConstraintEditor(), new OracleDBTablePartitionEditor());
+        return DBAccessorUtil.getTableEditor();
     }
 }

--- a/server/plugins/schema-plugin-ob-oracle/src/main/java/com/oceanbase/odc/plugin/schema/oboracle/utils/DBAccessorUtil.java
+++ b/server/plugins/schema-plugin-ob-oracle/src/main/java/com/oceanbase/odc/plugin/schema/oboracle/utils/DBAccessorUtil.java
@@ -21,6 +21,12 @@ import com.oceanbase.odc.common.util.JdbcOperationsUtil;
 import com.oceanbase.odc.plugin.connect.oboracle.OBOracleInformationExtension;
 import com.oceanbase.odc.plugin.schema.oboracle.browser.DBSchemaAccessors;
 import com.oceanbase.odc.plugin.schema.oboracle.browser.DBStatsAccessors;
+import com.oceanbase.tools.dbbrowser.editor.DBTableEditor;
+import com.oceanbase.tools.dbbrowser.editor.oracle.OBOracleIndexEditor;
+import com.oceanbase.tools.dbbrowser.editor.oracle.OracleColumnEditor;
+import com.oceanbase.tools.dbbrowser.editor.oracle.OracleConstraintEditor;
+import com.oceanbase.tools.dbbrowser.editor.oracle.OracleDBTablePartitionEditor;
+import com.oceanbase.tools.dbbrowser.editor.oracle.OracleTableEditor;
 import com.oceanbase.tools.dbbrowser.schema.DBSchemaAccessor;
 import com.oceanbase.tools.dbbrowser.stats.DBStatsAccessor;
 
@@ -40,6 +46,11 @@ public class DBAccessorUtil {
 
     public static DBStatsAccessor getStatsAccessor(Connection connection) {
         return DBStatsAccessors.create(JdbcOperationsUtil.getJdbcOperations(connection), getDbVersion(connection));
+    }
+
+    public static DBTableEditor getTableEditor() {
+        return new OracleTableEditor(new OBOracleIndexEditor(), new OracleColumnEditor(),
+                new OracleConstraintEditor(), new OracleDBTablePartitionEditor());
     }
 
 }

--- a/server/plugins/schema-plugin-odp-sharding-ob-mysql/src/main/java/com/oceanbase/odc/plugin/schema/odpsharding/obmysql/ODPShardingOBMySQLTableExtension.java
+++ b/server/plugins/schema-plugin-odp-sharding-ob-mysql/src/main/java/com/oceanbase/odc/plugin/schema/odpsharding/obmysql/ODPShardingOBMySQLTableExtension.java
@@ -21,8 +21,12 @@ import org.pf4j.Extension;
 
 import com.oceanbase.odc.common.util.JdbcOperationsUtil;
 import com.oceanbase.odc.plugin.schema.obmysql.OBMySQLTableExtension;
-import com.oceanbase.tools.dbbrowser.editor.DBTablePartitionEditor;
+import com.oceanbase.tools.dbbrowser.editor.DBTableEditor;
+import com.oceanbase.tools.dbbrowser.editor.mysql.MySQLColumnEditor;
+import com.oceanbase.tools.dbbrowser.editor.mysql.MySQLConstraintEditor;
 import com.oceanbase.tools.dbbrowser.editor.mysql.MySQLDBTablePartitionEditor;
+import com.oceanbase.tools.dbbrowser.editor.mysql.OBMySQLIndexEditor;
+import com.oceanbase.tools.dbbrowser.editor.mysql.OBMySQLTableEditor;
 import com.oceanbase.tools.dbbrowser.model.DBTable;
 import com.oceanbase.tools.dbbrowser.schema.DBSchemaAccessor;
 import com.oceanbase.tools.dbbrowser.schema.mysql.ODPOBMySQLSchemaAccessor;
@@ -61,7 +65,8 @@ public class ODPShardingOBMySQLTableExtension extends OBMySQLTableExtension {
     }
 
     @Override
-    protected DBTablePartitionEditor getDBTablePartitionEditor(Connection connection) {
-        return new MySQLDBTablePartitionEditor();
+    protected DBTableEditor getTableEditor(Connection connection) {
+        return new OBMySQLTableEditor(new OBMySQLIndexEditor(), new MySQLColumnEditor(), new MySQLConstraintEditor(),
+                new MySQLDBTablePartitionEditor());
     }
 }

--- a/server/plugins/task-plugin-api/src/main/java/com/oceanbase/odc/plugin/task/api/structurecompare/StructureComparator.java
+++ b/server/plugins/task-plugin-api/src/main/java/com/oceanbase/odc/plugin/task/api/structurecompare/StructureComparator.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2023 OceanBase.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.oceanbase.odc.plugin.task.api.structurecompare;
+
+import java.util.List;
+
+import com.oceanbase.odc.plugin.task.api.structurecompare.model.DBObjectComparisonResult;
+
+/**
+ * @author jingtian
+ * @date 2023/12/29
+ * @since ODC_release_4.2.4
+ */
+public interface StructureComparator {
+    /**
+     * Compare all the TABLE definition between source database and target database.
+     *
+     * @return {@link DBObjectComparisonResult}
+     */
+    List<DBObjectComparisonResult> compareTables();
+
+    /**
+     * Compare specified TABLE definition between source database and target database.
+     *
+     * @param tableNames table names to be compared
+     * @return {@link DBObjectComparisonResult}
+     */
+    List<DBObjectComparisonResult> compareTables(List<String> tableNames);
+}

--- a/server/plugins/task-plugin-api/src/main/java/com/oceanbase/odc/plugin/task/api/structurecompare/StructureCompareExtensionPoint.java
+++ b/server/plugins/task-plugin-api/src/main/java/com/oceanbase/odc/plugin/task/api/structurecompare/StructureCompareExtensionPoint.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2023 OceanBase.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.oceanbase.odc.plugin.task.api.structurecompare;
+
+import java.sql.SQLException;
+
+import org.pf4j.ExtensionPoint;
+
+import com.oceanbase.odc.plugin.task.api.structurecompare.model.StructureCompareConfig;
+
+/**
+ * @author jingtian
+ * @date 2023/12/29
+ * @since ODC_release_4.2.4
+ */
+public interface StructureCompareExtensionPoint extends ExtensionPoint {
+    /**
+     * Get structure comparator
+     *
+     * @param config {@link StructureCompareConfig}
+     * @return {@link StructureComparator}
+     */
+    StructureComparator getStructureComparator(StructureCompareConfig config) throws SQLException;
+}

--- a/server/plugins/task-plugin-api/src/main/java/com/oceanbase/odc/plugin/task/api/structurecompare/model/ComparisonResult.java
+++ b/server/plugins/task-plugin-api/src/main/java/com/oceanbase/odc/plugin/task/api/structurecompare/model/ComparisonResult.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2023 OceanBase.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.oceanbase.odc.plugin.task.api.structurecompare.model;
+
+/**
+ * @author jingtian
+ * @date 2023/12/29
+ * @since ODC_release_4.2.4
+ */
+public enum ComparisonResult {
+    ONLY_IN_SOURCE,
+    ONLY_IN_TARGET,
+    CONSISTENT,
+    INCONSISTENT,
+    MISSING_IN_SOURCE,
+    UNSUPPORTED
+}

--- a/server/plugins/task-plugin-api/src/main/java/com/oceanbase/odc/plugin/task/api/structurecompare/model/DBObjectComparisonResult.java
+++ b/server/plugins/task-plugin-api/src/main/java/com/oceanbase/odc/plugin/task/api/structurecompare/model/DBObjectComparisonResult.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2023 OceanBase.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.oceanbase.odc.plugin.task.api.structurecompare.model;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.oceanbase.tools.dbbrowser.model.DBObjectType;
+
+import lombok.Data;
+
+/**
+ * @author jingtian
+ * @date 2023/12/29
+ * @since ODC_release_4.2.4
+ */
+@Data
+public class DBObjectComparisonResult {
+    private DBObjectType dbObjectType;
+    private String dbObjectName;
+    private String sourceSchemaName;
+    private String targetSchemaName;
+    private String sourceDdl;
+    private String targetDdl;
+    private ComparisonResult comparisonResult;
+    /**
+     * For TABLE object, such as COLUMN, INDEX, CONSTRAINT and PARTITION when comparisonResult is
+     * UPDATE.
+     */
+    private List<DBObjectComparisonResult> subDBObjectComparisonResult = new ArrayList<>();
+    private String changeScript;
+
+    public DBObjectComparisonResult(DBObjectType dbObjectType, String dbObjectName, String sourceSchemaName,
+            String targetSchemaName) {
+        this.dbObjectType = dbObjectType;
+        this.dbObjectName = dbObjectName;
+        this.sourceSchemaName = sourceSchemaName;
+        this.targetSchemaName = targetSchemaName;
+    }
+
+    public DBObjectComparisonResult(DBObjectType dbObjectType, String sourceSchemaName, String targetSchemaName) {
+        this.dbObjectType = dbObjectType;
+        this.sourceSchemaName = sourceSchemaName;
+        this.targetSchemaName = targetSchemaName;
+    }
+
+}

--- a/server/plugins/task-plugin-api/src/main/java/com/oceanbase/odc/plugin/task/api/structurecompare/model/StructureCompareConfig.java
+++ b/server/plugins/task-plugin-api/src/main/java/com/oceanbase/odc/plugin/task/api/structurecompare/model/StructureCompareConfig.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2023 OceanBase.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.oceanbase.odc.plugin.task.api.structurecompare.model;
+
+import javax.sql.DataSource;
+import javax.validation.constraints.NotNull;
+
+import com.oceanbase.odc.core.shared.constant.DialectType;
+
+import lombok.Data;
+
+/**
+ * @author jingtian
+ * @date 2023/12/29
+ * @since ODC_release_4.2.4
+ */
+@Data
+public class StructureCompareConfig {
+    @NotNull
+    private String sourceSchemaName;
+    @NotNull
+    private String targetSchemaName;
+    @NotNull
+    private DialectType sourceDialectType;
+    @NotNull
+    private DialectType targetDialectType;
+    @NotNull
+    private DataSource sourceDataSource;
+    @NotNull
+    private DataSource targetDataSource;
+}

--- a/server/plugins/task-plugin-mysql/src/main/java/com/oceanbase/odc/plugin/task/mysql/structurecompare/MySQLStructureCompareExtension.java
+++ b/server/plugins/task-plugin-mysql/src/main/java/com/oceanbase/odc/plugin/task/mysql/structurecompare/MySQLStructureCompareExtension.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2023 OceanBase.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.oceanbase.odc.plugin.task.mysql.structurecompare;
+
+import java.sql.SQLException;
+
+import javax.sql.DataSource;
+
+import org.pf4j.Extension;
+
+import com.oceanbase.odc.core.shared.constant.DialectType;
+import com.oceanbase.odc.plugin.schema.mysql.utils.DBAccessorUtil;
+import com.oceanbase.odc.plugin.task.api.structurecompare.StructureComparator;
+import com.oceanbase.odc.plugin.task.api.structurecompare.StructureCompareExtensionPoint;
+import com.oceanbase.odc.plugin.task.api.structurecompare.model.StructureCompareConfig;
+import com.oceanbase.odc.plugin.task.obmysql.structurecompare.OdcStructureComparator;
+
+/**
+ * @author jingtian
+ * @date 2024/1/2
+ * @since ODC_release_4.2.4
+ */
+@Extension
+public class MySQLStructureCompareExtension implements StructureCompareExtensionPoint {
+    @Override
+    public StructureComparator getStructureComparator(StructureCompareConfig config) throws SQLException {
+        checkConfig(config);
+        DataSource srcDataSource = config.getSourceDataSource();
+        DataSource tgtDataSource = config.getTargetDataSource();
+        return new OdcStructureComparator(config.getSourceSchemaName(), config.getTargetSchemaName(),
+                DBAccessorUtil.getSchemaAccessor(srcDataSource.getConnection()),
+                DBAccessorUtil.getSchemaAccessor(tgtDataSource.getConnection()),
+                DBAccessorUtil.getTableEditor(tgtDataSource.getConnection()), config.getTargetDialectType());
+    }
+
+    private void checkConfig(StructureCompareConfig config) {
+        if (config.getSourceDialectType() != DialectType.MYSQL
+                || config.getTargetDialectType() != DialectType.MYSQL) {
+            throw new IllegalArgumentException("Source and target dialect type must be MYSQL");
+        }
+    }
+}

--- a/server/plugins/task-plugin-ob-mysql/src/main/java/com/oceanbase/odc/plugin/task/obmysql/structurecompare/OBMySQLStructureCompareExtension.java
+++ b/server/plugins/task-plugin-ob-mysql/src/main/java/com/oceanbase/odc/plugin/task/obmysql/structurecompare/OBMySQLStructureCompareExtension.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2023 OceanBase.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.oceanbase.odc.plugin.task.obmysql.structurecompare;
+
+import java.sql.SQLException;
+
+import javax.sql.DataSource;
+
+import org.pf4j.Extension;
+
+import com.oceanbase.odc.core.shared.constant.DialectType;
+import com.oceanbase.odc.plugin.schema.obmysql.utils.DBAccessorUtil;
+import com.oceanbase.odc.plugin.task.api.structurecompare.StructureComparator;
+import com.oceanbase.odc.plugin.task.api.structurecompare.StructureCompareExtensionPoint;
+import com.oceanbase.odc.plugin.task.api.structurecompare.model.StructureCompareConfig;
+
+/**
+ * @author jingtian
+ * @date 2024/1/2
+ * @since ODC_release_4.2.4
+ */
+@Extension
+public class OBMySQLStructureCompareExtension implements StructureCompareExtensionPoint {
+    @Override
+    public StructureComparator getStructureComparator(StructureCompareConfig config) throws SQLException {
+        checkConfig(config);
+        DataSource srcDataSource = config.getSourceDataSource();
+        DataSource tgtDataSource = config.getTargetDataSource();
+        return new OdcStructureComparator(config.getSourceSchemaName(), config.getTargetSchemaName(),
+                DBAccessorUtil.getSchemaAccessor(srcDataSource.getConnection()),
+                DBAccessorUtil.getSchemaAccessor(tgtDataSource.getConnection()),
+                DBAccessorUtil.getTableEditor(tgtDataSource.getConnection()), config.getTargetDialectType());
+    }
+
+    private void checkConfig(StructureCompareConfig config) {
+        if (config.getSourceDialectType() != DialectType.OB_MYSQL
+                || config.getTargetDialectType() != DialectType.OB_MYSQL) {
+            throw new IllegalArgumentException("Source and target dialect type must be OB_MYSQL");
+        }
+    }
+}

--- a/server/plugins/task-plugin-ob-mysql/src/main/java/com/oceanbase/odc/plugin/task/obmysql/structurecompare/OdcStructureComparator.java
+++ b/server/plugins/task-plugin-ob-mysql/src/main/java/com/oceanbase/odc/plugin/task/obmysql/structurecompare/OdcStructureComparator.java
@@ -1,0 +1,572 @@
+/*
+ * Copyright (c) 2023 OceanBase.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.oceanbase.odc.plugin.task.obmysql.structurecompare;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Queue;
+import java.util.stream.Collectors;
+
+import org.apache.commons.compress.utils.Lists;
+import org.springframework.beans.BeanUtils;
+
+import com.oceanbase.odc.core.shared.constant.DialectType;
+import com.oceanbase.odc.plugin.task.api.structurecompare.StructureComparator;
+import com.oceanbase.odc.plugin.task.api.structurecompare.model.ComparisonResult;
+import com.oceanbase.odc.plugin.task.api.structurecompare.model.DBObjectComparisonResult;
+import com.oceanbase.tools.dbbrowser.editor.DBTableEditor;
+import com.oceanbase.tools.dbbrowser.editor.GeneralSqlStatementBuilder;
+import com.oceanbase.tools.dbbrowser.model.DBConstraintType;
+import com.oceanbase.tools.dbbrowser.model.DBObjectType;
+import com.oceanbase.tools.dbbrowser.model.DBTable;
+import com.oceanbase.tools.dbbrowser.model.DBTable.DBTableOptions;
+import com.oceanbase.tools.dbbrowser.model.DBTableColumn;
+import com.oceanbase.tools.dbbrowser.model.DBTableConstraint;
+import com.oceanbase.tools.dbbrowser.model.DBTableIndex;
+import com.oceanbase.tools.dbbrowser.model.DBTablePartition;
+import com.oceanbase.tools.dbbrowser.model.DBTablePartitionType;
+import com.oceanbase.tools.dbbrowser.schema.DBSchemaAccessor;
+import com.oceanbase.tools.dbbrowser.util.MySQLSqlBuilder;
+import com.oceanbase.tools.dbbrowser.util.OracleSqlBuilder;
+import com.oceanbase.tools.dbbrowser.util.SqlBuilder;
+
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * @author jingtian
+ * @date 2024/1/2
+ * @since ODC_release_4.2.4
+ */
+@Slf4j
+public class OdcStructureComparator implements StructureComparator {
+    private String sourceSchemaName;
+    private String targetSchemaName;
+    private DBSchemaAccessor targetAccessor;
+    private DBSchemaAccessor sourceAccessor;
+    private DBTableEditor targetTableEditor;
+    private DialectType targetDialectType;
+    private Map<String, DBTable> sourceTableMapping = new HashMap<>();
+    private Map<String, DBTable> targetTableMapping = new HashMap<>();
+    private final String DEFAULT_SQL_DELIMITER = ";";
+
+    public OdcStructureComparator(@NonNull String sourceSchemaName, @NonNull String targetSchemaName,
+            @NonNull DBSchemaAccessor sourceAccessor,
+            @NonNull DBSchemaAccessor targetAccessor, @NonNull DBTableEditor targetTableEditor,
+            @NonNull DialectType targetDialectType) {
+        this.sourceSchemaName = sourceSchemaName;
+        this.targetSchemaName = targetSchemaName;
+        this.sourceAccessor = sourceAccessor;
+        this.targetAccessor = targetAccessor;
+        this.targetTableEditor = targetTableEditor;
+        this.targetDialectType = targetDialectType;
+    }
+
+    @Override
+    public List<DBObjectComparisonResult> compareTables() {
+        List<DBObjectComparisonResult> returnVal = new LinkedList<>();
+        initTableMapping();
+        if (this.sourceTableMapping.isEmpty() && this.targetTableMapping.isEmpty()) {
+            return returnVal;
+        }
+
+        List<String> toCreatedNames = new ArrayList<>();
+        List<String> toComparedNames = new ArrayList<>();
+        List<String> toDroppedNames = new ArrayList<>();
+        for (String tableName : sourceTableMapping.keySet()) {
+            if (!targetTableMapping.containsKey(tableName)) {
+                toCreatedNames.add(tableName);
+            } else {
+                toComparedNames.add(tableName);
+            }
+        }
+        for (String tableName : targetTableMapping.keySet()) {
+            if (!sourceTableMapping.containsKey(tableName)) {
+                toDroppedNames.add(tableName);
+            }
+        }
+
+        List<DBObjectComparisonResult> createdResults =
+                buildCreatedTableResults(toCreatedNames, sourceTableMapping, sourceSchemaName, targetSchemaName);
+        List<DBObjectComparisonResult> dropResults =
+                buildDroppedTableResults(toDroppedNames, targetTableMapping, sourceSchemaName, targetSchemaName);
+
+        List<DBObjectComparisonResult> comparedResults = new ArrayList<>();
+        toComparedNames.forEach(name -> {
+            comparedResults.add(compareSingleTable(sourceTableMapping.get(name), targetTableMapping.get(name)));
+        });
+
+        returnVal.addAll(createdResults);
+        returnVal.addAll(comparedResults);
+        returnVal.addAll(dropResults);
+
+        return returnVal;
+    }
+
+    @Override
+    public List<DBObjectComparisonResult> compareTables(List<String> tableNames) {
+        List<DBObjectComparisonResult> returnVal = new LinkedList<>();
+        initTableMapping();
+        if (tableNames.isEmpty()) {
+            return returnVal;
+        }
+
+        tableNames.forEach(name -> {
+            DBObjectComparisonResult result =
+                    new DBObjectComparisonResult(DBObjectType.TABLE, name, sourceSchemaName, targetSchemaName);
+            if (!sourceTableMapping.containsKey(name)) {
+                result.setComparisonResult(ComparisonResult.MISSING_IN_SOURCE);
+            } else {
+                if (!targetTableMapping.containsKey(name)) {
+                    // table to be created
+                    result.setComparisonResult(ComparisonResult.ONLY_IN_SOURCE);
+                    DBTable copiedSrcTable = new DBTable();
+                    BeanUtils.copyProperties(sourceTableMapping.get(name), copiedSrcTable);
+                    copiedSrcTable.setSchemaName(this.targetSchemaName);
+                    result.setChangeScript(this.targetTableEditor.generateCreateObjectDDL(copiedSrcTable));
+                } else {
+                    // table to be compared
+                    result = compareSingleTable(sourceTableMapping.get(name), targetTableMapping.get(name));
+                }
+            }
+            returnVal.add(result);
+        });
+
+        return returnVal;
+    }
+
+    private List<DBObjectComparisonResult> buildCreatedTableResults(List<String> toCreate,
+            Map<String, DBTable> sourceTableMapping, String sourceSchemaName, String targetSchemaName) {
+        List<DBObjectComparisonResult> returnVal = new LinkedList<>();
+        if (toCreate.isEmpty()) {
+            return returnVal;
+        }
+        toCreate = getTableNamesByDependencyOrder(toCreate, sourceTableMapping, sourceSchemaName);
+
+        toCreate.forEach(name -> {
+            DBObjectComparisonResult result =
+                    new DBObjectComparisonResult(DBObjectType.TABLE, name, sourceSchemaName, targetSchemaName);
+            result.setComparisonResult(ComparisonResult.ONLY_IN_SOURCE);
+            DBTable sourceTable = sourceTableMapping.get(name);
+            result.setSourceDdl(sourceTable.getDDL());
+            DBTable targetTable = new DBTable();
+            BeanUtils.copyProperties(sourceTable, targetTable);
+            targetTable.setSchemaName(targetSchemaName);
+            result.setChangeScript(this.targetTableEditor.generateCreateObjectDDL(targetTable));
+            returnVal.add(result);
+        });
+        return returnVal;
+    }
+
+    private List<DBObjectComparisonResult> buildDroppedTableResults(List<String> toDrop,
+            Map<String, DBTable> targetTableMapping,
+            String sourceSchemaName, String targetSchemaName) {
+        List<DBObjectComparisonResult> returnVal = new LinkedList<>();
+        if (toDrop.isEmpty()) {
+            return returnVal;
+        }
+        toDrop = getTableNamesByDependencyOrder(toDrop, targetTableMapping, targetSchemaName);
+        Collections.reverse(toDrop);
+
+        toDrop.forEach(name -> {
+            DBObjectComparisonResult result =
+                    new DBObjectComparisonResult(DBObjectType.TABLE, name, sourceSchemaName, targetSchemaName);
+            result.setComparisonResult(ComparisonResult.ONLY_IN_TARGET);
+            result.setTargetDdl(targetTableMapping.get(name).getDDL());
+            SqlBuilder sqlBuilder = getTargetDBSqlBuilder();
+            result.setChangeScript(
+                    GeneralSqlStatementBuilder.drop(sqlBuilder, DBObjectType.TABLE, targetSchemaName, name));
+            returnVal.add(result);
+        });
+        return returnVal;
+    }
+
+    private DBObjectComparisonResult compareSingleTable(DBTable sourceTable, DBTable targetTable) {
+        DBObjectComparisonResult result = new DBObjectComparisonResult(DBObjectType.TABLE, sourceTable.getName(),
+                this.sourceSchemaName, this.targetSchemaName);
+
+        // compare table options
+        SqlBuilder tableOptionDdl = getTargetDBSqlBuilder();
+        DBTable copiedSrcTable = new DBTable();
+        BeanUtils.copyProperties(sourceTable, copiedSrcTable);
+        copiedSrcTable.setSchemaName(this.targetSchemaName);
+        this.targetTableEditor.generateUpdateTableOptionDDL(targetTable, copiedSrcTable, tableOptionDdl);
+        result.setChangeScript(tableOptionDdl.toString());
+        result.setSourceDdl(sourceTable.getDDL());
+        result.setTargetDdl(targetTable.getDDL());
+
+        // compare table columns
+        List<DBObjectComparisonResult> columns =
+                compareTableColumns(sourceTable.getColumns(), targetTable.getColumns());
+        // compare table index
+        List<DBObjectComparisonResult> indexes =
+                compareTableIndexes(
+                        this.targetTableEditor.excludePrimaryKeyIndex(sourceTable.getIndexes(),
+                                sourceTable.getConstraints()),
+                        this.targetTableEditor.excludePrimaryKeyIndex(targetTable.getIndexes(),
+                                targetTable.getConstraints()));
+        // compare table constraints
+        List<DBObjectComparisonResult> constraints =
+                compareTableConstraints(
+                        this.targetTableEditor.excludeUniqueConstraint(sourceTable.getIndexes(),
+                                sourceTable.getConstraints()),
+                        this.targetTableEditor.excludeUniqueConstraint(targetTable.getIndexes(),
+                                targetTable.getConstraints()));
+        // compare table partition
+        DBObjectComparisonResult partition =
+                compareTablePartition(sourceTable.getPartition(), targetTable.getPartition());
+
+        if (columns.stream().allMatch(item -> item.getComparisonResult().equals(ComparisonResult.CONSISTENT))
+                && indexes.stream().allMatch(item -> item.getComparisonResult().equals(ComparisonResult.CONSISTENT))
+                && constraints.stream().allMatch(item -> item.getComparisonResult().equals(ComparisonResult.CONSISTENT))
+                && partition.getComparisonResult().equals(ComparisonResult.CONSISTENT)
+                && tableOptionDdl.toString().isEmpty()) {
+            result.setComparisonResult(ComparisonResult.CONSISTENT);
+        } else {
+            result.setComparisonResult(ComparisonResult.INCONSISTENT);
+        }
+
+        result.setSubDBObjectComparisonResult(columns);
+        result.getSubDBObjectComparisonResult().addAll(indexes);
+        result.getSubDBObjectComparisonResult().addAll(constraints);
+        result.getSubDBObjectComparisonResult().add(partition);
+
+        return result;
+    }
+
+    private List<DBObjectComparisonResult> compareTableColumns(List<DBTableColumn> srcTabCols,
+            List<DBTableColumn> tgtTabCols) {
+        List<DBObjectComparisonResult> returnVal = new ArrayList<>();
+        if (srcTabCols.isEmpty() && tgtTabCols.isEmpty()) {
+            return returnVal;
+        }
+
+        List<String> srcColNames = srcTabCols.stream().map(DBTableColumn::getName).collect(Collectors.toList());
+        List<String> tarColNames = tgtTabCols.stream().map(DBTableColumn::getName).collect(Collectors.toList());
+        Map<String, DBTableColumn> srcColMapping =
+                srcTabCols.stream().collect(Collectors.toMap(DBTableColumn::getName, col -> col));
+        Map<String, DBTableColumn> tarColMapping =
+                tgtTabCols.stream().collect(Collectors.toMap(DBTableColumn::getName, col -> col));
+
+        tarColNames.forEach(tarColName -> {
+            if (!srcColNames.contains(tarColName)) {
+                // column to be dropped
+                DBObjectComparisonResult result = new DBObjectComparisonResult(DBObjectType.COLUMN, tarColName,
+                        this.sourceSchemaName, this.targetSchemaName);
+                result.setComparisonResult(ComparisonResult.ONLY_IN_TARGET);
+                result.setChangeScript(
+                        appendDelimiterIfNotExist(this.targetTableEditor.getColumnEditor()
+                                .generateDropObjectDDL(tarColMapping.get(tarColName))));
+                returnVal.add(result);
+            }
+        });
+
+        srcColNames.forEach(srcColName -> {
+            DBObjectComparisonResult result = new DBObjectComparisonResult(DBObjectType.COLUMN, srcColName,
+                    this.sourceSchemaName, this.targetSchemaName);
+            DBTableColumn copiedSrcCol = new DBTableColumn();
+            BeanUtils.copyProperties(srcColMapping.get(srcColName), copiedSrcCol);
+            copiedSrcCol.setSchemaName(this.targetSchemaName);
+            if (tarColNames.contains(srcColName)) {
+                String ddl = this.targetTableEditor.getColumnEditor().generateUpdateObjectDDL(
+                        tarColMapping.get(srcColName), copiedSrcCol);
+                if (!ddl.isEmpty()) {
+                    // column to be updated
+                    result.setComparisonResult(ComparisonResult.INCONSISTENT);
+                    result.setChangeScript(appendDelimiterIfNotExist(ddl));
+                } else {
+                    result.setComparisonResult(ComparisonResult.CONSISTENT);
+                }
+            } else {
+                // column to be created
+                result.setComparisonResult(ComparisonResult.ONLY_IN_SOURCE);
+                result.setChangeScript(appendDelimiterIfNotExist(
+                        this.targetTableEditor.getColumnEditor().generateCreateObjectDDL(copiedSrcCol)));
+            }
+            returnVal.add(result);
+        });
+
+        return returnVal;
+    }
+
+    private List<DBObjectComparisonResult> compareTableIndexes(List<DBTableIndex> srcTabIdx,
+            List<DBTableIndex> tgtTabIdx) {
+        List<DBObjectComparisonResult> returnVal = new ArrayList<>();
+        if (srcTabIdx.isEmpty() && tgtTabIdx.isEmpty()) {
+            return returnVal;
+        }
+
+        List<String> srcIdxNames = srcTabIdx.stream().map(DBTableIndex::getName).collect(Collectors.toList());
+        List<String> tarIdxNames = tgtTabIdx.stream().map(DBTableIndex::getName).collect(Collectors.toList());
+        Map<String, DBTableIndex> srcIdxMapping =
+                srcTabIdx.stream().collect(Collectors.toMap(DBTableIndex::getName, col -> col));
+        Map<String, DBTableIndex> tarIdxMapping =
+                tgtTabIdx.stream().collect(Collectors.toMap(DBTableIndex::getName, col -> col));
+
+        tarIdxNames.forEach(tarIdxName -> {
+            if (!srcIdxNames.contains(tarIdxName)) {
+                // index to be dropped
+                DBObjectComparisonResult result = new DBObjectComparisonResult(DBObjectType.INDEX, tarIdxName,
+                        this.sourceSchemaName, this.targetSchemaName);
+                result.setComparisonResult(ComparisonResult.ONLY_IN_TARGET);
+                result.setChangeScript(
+                        appendDelimiterIfNotExist(this.targetTableEditor.getIndexEditor()
+                                .generateDropObjectDDL(tarIdxMapping.get(tarIdxName))));
+                returnVal.add(result);
+            }
+        });
+
+        srcIdxNames.forEach(srcIdxName -> {
+            DBObjectComparisonResult result = new DBObjectComparisonResult(DBObjectType.INDEX, srcIdxName,
+                    this.sourceSchemaName, this.targetSchemaName);
+            DBTableIndex copiedSrcIdx = new DBTableIndex();
+            BeanUtils.copyProperties(srcIdxMapping.get(srcIdxName), copiedSrcIdx);
+            copiedSrcIdx.setSchemaName(this.targetSchemaName);
+            if (tarIdxNames.contains(srcIdxName)) {
+                String ddl = this.targetTableEditor.getIndexEditor().generateUpdateObjectDDL(
+                        tarIdxMapping.get(srcIdxName), copiedSrcIdx);
+                if (!ddl.isEmpty()) {
+                    // index to be updated
+                    result.setComparisonResult(ComparisonResult.INCONSISTENT);
+                    result.setChangeScript(appendDelimiterIfNotExist(ddl));
+                } else {
+                    result.setComparisonResult(ComparisonResult.CONSISTENT);
+                }
+            } else {
+                // index to be created
+                result.setComparisonResult(ComparisonResult.ONLY_IN_SOURCE);
+                result.setChangeScript(appendDelimiterIfNotExist(
+                        this.targetTableEditor.getIndexEditor().generateCreateObjectDDL(copiedSrcIdx)));
+            }
+            returnVal.add(result);
+        });
+
+        return returnVal;
+    }
+
+    private List<DBObjectComparisonResult> compareTableConstraints(List<DBTableConstraint> srcTabCons,
+            List<DBTableConstraint> tgtTabCons) {
+        List<DBObjectComparisonResult> returnVal = new ArrayList<>();
+        if (srcTabCons.isEmpty() && tgtTabCons.isEmpty()) {
+            return returnVal;
+        }
+
+        List<String> srcConsNames = srcTabCons.stream().map(DBTableConstraint::getName).collect(Collectors.toList());
+        List<String> tarConsNames = tgtTabCons.stream().map(DBTableConstraint::getName).collect(Collectors.toList());
+        Map<String, DBTableConstraint> srcConsMapping =
+                srcTabCons.stream().collect(Collectors.toMap(DBTableConstraint::getName, col -> col));
+        Map<String, DBTableConstraint> tarConsMapping =
+                tgtTabCons.stream().collect(Collectors.toMap(DBTableConstraint::getName, col -> col));
+
+        tarConsNames.forEach(tarConsName -> {
+            if (!srcConsNames.contains(tarConsName)) {
+                // constraint to be dropped
+                DBObjectComparisonResult result = new DBObjectComparisonResult(DBObjectType.CONSTRAINT, tarConsName,
+                        this.sourceSchemaName, this.targetSchemaName);
+                result.setComparisonResult(ComparisonResult.ONLY_IN_TARGET);
+                result.setChangeScript(appendDelimiterIfNotExist(this.targetTableEditor.getConstraintEditor()
+                        .generateDropObjectDDL(tarConsMapping.get(tarConsName))));
+                returnVal.add(result);
+            }
+        });
+
+        srcConsNames.forEach(srcConsName -> {
+            DBObjectComparisonResult result = new DBObjectComparisonResult(DBObjectType.CONSTRAINT, srcConsName,
+                    this.sourceSchemaName, this.targetSchemaName);
+            DBTableConstraint copiedSrcCons = new DBTableConstraint();
+            BeanUtils.copyProperties(srcConsMapping.get(srcConsName), copiedSrcCons);
+            copiedSrcCons.setSchemaName(this.targetSchemaName);
+            if (tarConsNames.contains(srcConsName)) {
+                String ddl = this.targetTableEditor.getConstraintEditor().generateUpdateObjectDDL(
+                        tarConsMapping.get(srcConsName), copiedSrcCons);
+                if (!ddl.isEmpty()) {
+                    // constraint to be updated
+                    result.setComparisonResult(ComparisonResult.INCONSISTENT);
+                    result.setChangeScript(appendDelimiterIfNotExist(ddl));
+                } else {
+                    result.setComparisonResult(ComparisonResult.CONSISTENT);
+                }
+            } else {
+                // constraint to be created
+                result.setComparisonResult(ComparisonResult.ONLY_IN_SOURCE);
+                result.setChangeScript(
+                        appendDelimiterIfNotExist(
+                                this.targetTableEditor.getConstraintEditor().generateCreateObjectDDL(copiedSrcCons)));
+            }
+            returnVal.add(result);
+        });
+
+        return returnVal;
+    }
+
+    private DBObjectComparisonResult compareTablePartition(DBTablePartition srcPartition,
+            DBTablePartition tgtPartition) {
+        DBTablePartitionType srcPartitionType = srcPartition.getPartitionOption().getType();
+        DBTablePartitionType tgtPartitionType = tgtPartition.getPartitionOption().getType();
+        DBObjectComparisonResult result =
+                new DBObjectComparisonResult(DBObjectType.PARTITION, this.sourceSchemaName, this.targetSchemaName);
+        if (DBTablePartitionType.NOT_PARTITIONED.equals(srcPartitionType)
+                && DBTablePartitionType.NOT_PARTITIONED.equals(tgtPartitionType)) {
+            result.setComparisonResult(ComparisonResult.CONSISTENT);
+        } else if (DBTablePartitionType.NOT_PARTITIONED.equals(srcPartitionType)) {
+            // partition to be dropped
+            result.setComparisonResult(ComparisonResult.ONLY_IN_TARGET);
+            result.setChangeScript(appendDelimiterIfNotExist(
+                    this.targetTableEditor.getPartitionEditor().generateDropObjectDDL(tgtPartition)));
+        } else if (DBTablePartitionType.NOT_PARTITIONED.equals(tgtPartitionType)) {
+            // partition to be created
+            result.setComparisonResult(ComparisonResult.ONLY_IN_SOURCE);
+            DBTablePartition copiedSrcPartition = new DBTablePartition();
+            BeanUtils.copyProperties(srcPartition, copiedSrcPartition);
+            copiedSrcPartition.setSchemaName(this.targetSchemaName);
+            result.setChangeScript(
+                    appendDelimiterIfNotExist(
+                            this.targetTableEditor.getPartitionEditor().generateCreateObjectDDL(copiedSrcPartition)));
+        } else {
+            DBTablePartition copiedSrcPartition = new DBTablePartition();
+            BeanUtils.copyProperties(srcPartition, copiedSrcPartition);
+            copiedSrcPartition.setSchemaName(this.targetSchemaName);
+            String ddl = this.targetTableEditor.getPartitionEditor().generateUpdateObjectDDL(tgtPartition,
+                    copiedSrcPartition);
+            if (ddl.isEmpty()) {
+                result.setComparisonResult(ComparisonResult.CONSISTENT);
+            } else {
+                // partition to be updated
+                result.setComparisonResult(ComparisonResult.INCONSISTENT);
+                result.setChangeScript(appendDelimiterIfNotExist(ddl));
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Construct a topology graph based on foreign key dependencies and obtain a list of table names
+     * sorted by the topology graph.
+     */
+    private List<String> getTableNamesByDependencyOrder(List<String> tableNames, Map<String, DBTable> tableMapping,
+            String schemaName) {
+        Map<String, List<String>> dependencyGraph = new HashMap<>();
+        Map<String, Integer> inDegree = new HashMap<>();
+
+        // Build dependency graph and in-degree map
+        tableNames.forEach(tableName -> {
+            for (DBTableConstraint constraint : tableMapping.get(tableName).getConstraints()) {
+                if (constraint.getType().equals(DBConstraintType.FOREIGN_KEY)) {
+                    String referenceTableName = constraint.getReferenceTableName();
+                    if (schemaName.equals(constraint.getReferenceSchemaName())
+                            && tableNames.contains(referenceTableName)) {
+                        dependencyGraph.computeIfAbsent(referenceTableName, k -> new ArrayList<>()).add(tableName);
+                        inDegree.put(tableName, inDegree.getOrDefault(tableName, 0) + 1);
+                    }
+                }
+            }
+            dependencyGraph.putIfAbsent(tableName, new ArrayList<>());
+            inDegree.putIfAbsent(tableName, 0);
+        });
+
+        List<String> tabNamesByDependencyOrder = new ArrayList<>();
+        Queue<String> queue = new LinkedList<>();
+
+        // Add all tables with in-degree of 0 to the queue
+        for (Map.Entry<String, Integer> entry : inDegree.entrySet()) {
+            if (entry.getValue() == 0) {
+                queue.add(entry.getKey());
+            }
+        }
+
+        // Topological sort
+        while (!queue.isEmpty()) {
+            String currentTable = queue.poll();
+            tabNamesByDependencyOrder.add(currentTable);
+
+            for (String dependentTable : dependencyGraph.get(currentTable)) {
+                int updatedInDegree = inDegree.get(dependentTable) - 1;
+                inDegree.put(dependentTable, updatedInDegree);
+
+                if (updatedInDegree == 0) {
+                    queue.add(dependentTable);
+                }
+            }
+        }
+
+        // Check for a cycle, if the graph has a cycle, tables names will not be sorted
+        if (tabNamesByDependencyOrder.size() != tableNames.size()) {
+            log.warn("Dependency cycle detected, schemaName: {}", schemaName);
+            return tableNames;
+        }
+
+        return tabNamesByDependencyOrder;
+    }
+
+    private void initTableMapping() {
+        this.sourceTableMapping =
+                this.sourceTableMapping.isEmpty() ? buildSchemaTables(sourceAccessor, sourceSchemaName)
+                        : this.sourceTableMapping;
+        this.targetTableMapping =
+                this.targetTableMapping.isEmpty() ? buildSchemaTables(targetAccessor, targetSchemaName)
+                        : this.targetTableMapping;
+    }
+
+    private Map<String, DBTable> buildSchemaTables(DBSchemaAccessor accessor, String schemaName) {
+        Map<String, DBTable> returnVal = new HashMap<>();
+        List<String> tableNames = accessor.showTables(schemaName);
+        if (tableNames.isEmpty()) {
+            return returnVal;
+        }
+        Map<String, List<DBTableColumn>> tableName2Columns = accessor.listTableColumns(schemaName);
+        Map<String, List<DBTableIndex>> tableName2Indexes = accessor.listTableIndexes(schemaName);
+        Map<String, List<DBTableConstraint>> tableName2Constraints = accessor.listTableConstraints(schemaName);
+        Map<String, DBTableOptions> tableName2Options = accessor.listTableOptions(schemaName);
+        for (String tableName : tableNames) {
+            if (!tableName2Columns.containsKey(tableName)) {
+                log.warn("Table: {} has no columns, schema name: {}", tableName, schemaName);
+                continue;
+            }
+            DBTable table = new DBTable();
+            table.setSchemaName(schemaName);
+            table.setOwner(schemaName);
+            table.setName(tableName);
+            table.setColumns(tableName2Columns.getOrDefault(tableName, Lists.newArrayList()));
+            table.setIndexes(tableName2Indexes.getOrDefault(tableName, Lists.newArrayList()));
+            table.setConstraints(tableName2Constraints.getOrDefault(tableName, Lists.newArrayList()));
+            table.setTableOptions(tableName2Options.getOrDefault(tableName, new DBTableOptions()));
+            table.setPartition(accessor.getPartition(schemaName, tableName));
+            table.setDDL(accessor.getTableDDL(schemaName, tableName));
+            returnVal.put(tableName, table);
+        }
+        return returnVal;
+    }
+
+    private SqlBuilder getTargetDBSqlBuilder() {
+        if (this.targetDialectType.isMysql()) {
+            return new MySQLSqlBuilder();
+        } else {
+            return new OracleSqlBuilder();
+        }
+    }
+
+    private String appendDelimiterIfNotExist(String sql) {
+        String returnVal = sql.trim();
+        if (!returnVal.endsWith(DEFAULT_SQL_DELIMITER)) {
+            return returnVal + DEFAULT_SQL_DELIMITER + "\n";
+        }
+        return sql;
+    }
+}

--- a/server/plugins/task-plugin-ob-mysql/src/test/java/com/oceanbase/odc/plugin/task/obmysql/structurecompare/OBMySQLStructureCompareExtensionTest.java
+++ b/server/plugins/task-plugin-ob-mysql/src/test/java/com/oceanbase/odc/plugin/task/obmysql/structurecompare/OBMySQLStructureCompareExtensionTest.java
@@ -1,0 +1,296 @@
+/*
+ * Copyright (c) 2023 OceanBase.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.oceanbase.odc.plugin.task.obmysql.structurecompare;
+
+import java.sql.SQLException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.springframework.beans.BeanUtils;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import com.oceanbase.odc.core.shared.constant.DialectType;
+import com.oceanbase.odc.plugin.task.api.structurecompare.StructureComparator;
+import com.oceanbase.odc.plugin.task.api.structurecompare.model.ComparisonResult;
+import com.oceanbase.odc.plugin.task.api.structurecompare.model.DBObjectComparisonResult;
+import com.oceanbase.odc.plugin.task.api.structurecompare.model.StructureCompareConfig;
+import com.oceanbase.odc.test.database.TestDBConfiguration;
+import com.oceanbase.odc.test.database.TestDBConfigurations;
+import com.oceanbase.odc.test.util.FileUtil;
+import com.oceanbase.tools.dbbrowser.model.DBObjectType;
+
+/**
+ * @author jingtian
+ * @date 2024/1/2
+ * @since ODC_release_4.2.4
+ */
+public class OBMySQLStructureCompareExtensionTest {
+    private static final String BASE_PATH = "src/test/resources/structurecompare/";
+    private static String sourceSchemaDdl = FileUtil.loadAsString(BASE_PATH + "source_schema_ddl.sql");
+    private static String targetSchemaDdl = FileUtil.loadAsString(BASE_PATH + "target_schema_ddl.sql");
+    private static final String sourceDrop = FileUtil.loadAsString(BASE_PATH + "source_drop.sql");
+    private static final String targetDrop = FileUtil.loadAsString(BASE_PATH + "target_drop.sql");
+    private static TestDBConfiguration configuration = TestDBConfigurations.getInstance().getTestOBMysqlConfiguration();
+    private static JdbcTemplate jdbcTemplate = new JdbcTemplate(configuration.getDataSource());
+    private final static String sourceSchemaName = generateSchemaName() + "_source";
+    private final static String targetSchemaName = generateSchemaName() + "_target";
+    private static StructureComparator comparator;
+    private static List<DBObjectComparisonResult> results;
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    @BeforeClass
+    public static void setUp() throws SQLException {
+        jdbcTemplate.execute("create database `" + sourceSchemaName + "`");
+        jdbcTemplate.execute("create database `" + targetSchemaName + "`");
+
+        TestDBConfiguration srcConfiguration = new TestDBConfiguration();
+        BeanUtils.copyProperties(configuration, srcConfiguration);
+        srcConfiguration.setDefaultDBName(sourceSchemaName);
+        srcConfiguration.initDataSource();
+
+        TestDBConfiguration tgtConfiguration = new TestDBConfiguration();
+        BeanUtils.copyProperties(configuration, tgtConfiguration);
+        tgtConfiguration.setDefaultDBName(targetSchemaName);
+        tgtConfiguration.initDataSource();
+
+        jdbcTemplate.execute("use `" + sourceSchemaName + "`");
+        jdbcTemplate.execute(sourceDrop);
+        jdbcTemplate.execute(sourceSchemaDdl);
+        jdbcTemplate.execute("use `" + targetSchemaName + "`");
+        jdbcTemplate.execute(targetDrop);
+        jdbcTemplate.execute(targetSchemaDdl);
+        jdbcTemplate.execute("use `" + configuration.getDefaultDBName() + "`");
+
+        OBMySQLStructureCompareExtension extension = new OBMySQLStructureCompareExtension();
+        StructureCompareConfig config = new StructureCompareConfig();
+        config.setSourceSchemaName(sourceSchemaName);
+        config.setTargetSchemaName(targetSchemaName);
+        config.setSourceDialectType(DialectType.OB_MYSQL);
+        config.setTargetDialectType(DialectType.OB_MYSQL);
+        config.setSourceDataSource(srcConfiguration.getDataSource());
+        config.setTargetDataSource(tgtConfiguration.getDataSource());
+        comparator = extension.getStructureComparator(config);
+        results = comparator.compareTables();
+    }
+
+    @AfterClass
+    public static void clear() {
+        jdbcTemplate.execute("drop database `" + sourceSchemaName + "`");
+        jdbcTemplate.execute("drop database `" + targetSchemaName + "`");
+    }
+
+    private static String generateSchemaName() {
+        return "odc_db_compare_test_" + UUID.randomUUID().toString().replaceAll("-", "").substring(0, 15).toLowerCase();
+    }
+
+    @Test
+    public void test_not_supported_dialect() throws SQLException {
+        StructureCompareConfig config = new StructureCompareConfig();
+        config.setSourceSchemaName(sourceSchemaName);
+        config.setTargetSchemaName(targetSchemaName);
+        config.setSourceDialectType(DialectType.OB_MYSQL);
+        config.setTargetDialectType(DialectType.OB_ORACLE);
+        config.setSourceDataSource(configuration.getDataSource());
+        config.setTargetDataSource(configuration.getDataSource());
+        thrown.expect(IllegalArgumentException.class);
+        thrown.expectMessage("Source and target dialect type must be OB_MYSQL");
+        StructureComparator structureComparator = new OBMySQLStructureCompareExtension().getStructureComparator(config);
+    }
+
+    @Test
+    public void compareAllTables_create_by_dependency_order() {
+        int dependentTableOrder1 = 0;
+        int dependentTableOrder2 = 0;
+        int foreignKeyTableOrder = 0;
+
+        for (int i = 0; i < results.size(); i++) {
+            if (results.get(i).getDbObjectName().equals("fk_dependency_only_in_source1")) {
+                Assert.assertEquals(results.get(i).getComparisonResult(), ComparisonResult.ONLY_IN_SOURCE);
+                Assert.assertNotNull(results.get(i).getSourceDdl());
+                dependentTableOrder1 = i;
+            } else if (results.get(i).getDbObjectName().equals("fk_dependency_only_in_source2")) {
+                Assert.assertEquals(results.get(i).getComparisonResult(), ComparisonResult.ONLY_IN_SOURCE);
+                Assert.assertNotNull(results.get(i).getSourceDdl());
+                dependentTableOrder2 = i;
+            } else if (results.get(i).getDbObjectName().equals("fk_only_in_source")) {
+                Assert.assertEquals(results.get(i).getComparisonResult(), ComparisonResult.ONLY_IN_SOURCE);
+                Assert.assertNotNull(results.get(i).getSourceDdl());
+                foreignKeyTableOrder = i;
+            }
+        }
+        Assert.assertTrue(dependentTableOrder1 < foreignKeyTableOrder);
+        Assert.assertTrue(dependentTableOrder2 < foreignKeyTableOrder);
+    }
+
+    @Test
+    public void compareAllTables_delete_by_dependency_order() {
+        int dependentTableOrder1 = 0;
+        int dependentTableOrder2 = 0;
+        int foreignKeyTableOrder = 0;
+
+        for (int i = 0; i < results.size(); i++) {
+            if (results.get(i).getDbObjectName().equals("fk_dependency_only_in_target1")) {
+                Assert.assertEquals(results.get(i).getComparisonResult(), ComparisonResult.ONLY_IN_TARGET);
+                Assert.assertNotNull(results.get(i).getTargetDdl());
+                dependentTableOrder1 = i;
+            } else if (results.get(i).getDbObjectName().equals("fk_dependency_only_in_target2")) {
+                Assert.assertEquals(results.get(i).getComparisonResult(), ComparisonResult.ONLY_IN_TARGET);
+                Assert.assertNotNull(results.get(i).getTargetDdl());
+                dependentTableOrder2 = i;
+            } else if (results.get(i).getDbObjectName().equals("fk_only_in_target")) {
+                Assert.assertEquals(results.get(i).getComparisonResult(), ComparisonResult.ONLY_IN_TARGET);
+                Assert.assertNotNull(results.get(i).getTargetDdl());
+                foreignKeyTableOrder = i;
+            }
+        }
+        Assert.assertTrue(dependentTableOrder1 > foreignKeyTableOrder);
+        Assert.assertTrue(dependentTableOrder2 > foreignKeyTableOrder);
+    }
+
+    @Test
+    public void compareAllTables_update_primary_key() {
+        DBObjectComparisonResult updatePk = results.stream().filter(
+                result -> result.getDbObjectName().equals("primary_key_test")).collect(Collectors.toList()).get(0);
+        Assert.assertEquals(updatePk.getComparisonResult(), ComparisonResult.INCONSISTENT);
+        updatePk.getSubDBObjectComparisonResult().forEach(item -> {
+            if (item.getDbObjectType().equals(DBObjectType.CONSTRAINT)) {
+                Assert.assertEquals(item.getComparisonResult(), ComparisonResult.INCONSISTENT);
+                Assert.assertNotNull(item.getChangeScript());
+            }
+        });
+    }
+
+    @Test
+    public void compareAllTables_update_columns() {
+        DBObjectComparisonResult result = results.stream().filter(
+                item -> item.getDbObjectName().equals("update_column")).collect(Collectors.toList()).get(0);
+        Assert.assertEquals(result.getComparisonResult(), ComparisonResult.INCONSISTENT);
+        Assert.assertEquals(8, result.getSubDBObjectComparisonResult().size());
+
+        result.getSubDBObjectComparisonResult().forEach(item -> {
+            if (item.getDbObjectType().equals(DBObjectType.PARTITION)) {
+                Assert.assertEquals(item.getComparisonResult(), ComparisonResult.CONSISTENT);
+            } else if (item.getDbObjectName().equals("c1") || item.getDbObjectName().equals("c2")
+                    || item.getDbObjectName().equals("c3")) {
+                Assert.assertEquals(item.getComparisonResult(), ComparisonResult.INCONSISTENT);
+                Assert.assertNotNull(item.getChangeScript());
+            } else if (item.getDbObjectName().equals("only_in_source_col")) {
+                Assert.assertEquals(item.getComparisonResult(), ComparisonResult.ONLY_IN_SOURCE);
+                Assert.assertNotNull(item.getChangeScript());
+            } else if (item.getDbObjectName().equals("only_in_target_col")) {
+                Assert.assertEquals(item.getComparisonResult(), ComparisonResult.ONLY_IN_TARGET);
+                Assert.assertNotNull(item.getChangeScript());
+            }
+        });
+    }
+
+    @Test
+    public void compareAllTables_update_index() {
+        DBObjectComparisonResult result = results.stream().filter(
+                item -> item.getDbObjectName().equals("update_index")).collect(Collectors.toList()).get(0);
+        Assert.assertEquals(result.getComparisonResult(), ComparisonResult.INCONSISTENT);
+        Assert.assertEquals(7, result.getSubDBObjectComparisonResult().size());
+
+        result.getSubDBObjectComparisonResult().forEach(item -> {
+            if (item.getDbObjectType().equals(DBObjectType.PARTITION)) {
+                Assert.assertEquals(item.getComparisonResult(), ComparisonResult.CONSISTENT);
+            } else if (item.getDbObjectName().equals("idx1")) {
+                Assert.assertEquals(item.getComparisonResult(), ComparisonResult.INCONSISTENT);
+                Assert.assertNotNull(item.getChangeScript());
+            } else if (item.getDbObjectName().equals("idx_only_in_source")) {
+                Assert.assertEquals(item.getComparisonResult(), ComparisonResult.ONLY_IN_SOURCE);
+                Assert.assertNotNull(item.getChangeScript());
+            } else if (item.getDbObjectName().equals("idx_only_in_target")) {
+                Assert.assertEquals(item.getComparisonResult(), ComparisonResult.ONLY_IN_TARGET);
+                Assert.assertNotNull(item.getChangeScript());
+            }
+        });
+    }
+
+    @Test
+    public void compareAllTables_update_constraint() {
+        DBObjectComparisonResult result = results.stream().filter(
+                item -> item.getDbObjectName().equals("update_constraint")).collect(Collectors.toList()).get(0);
+        Assert.assertEquals(result.getComparisonResult(), ComparisonResult.INCONSISTENT);
+        Assert.assertEquals(7, result.getSubDBObjectComparisonResult().size());
+
+        result.getSubDBObjectComparisonResult().forEach(item -> {
+            if (item.getDbObjectType().equals(DBObjectType.PARTITION)) {
+                Assert.assertEquals(item.getComparisonResult(), ComparisonResult.CONSISTENT);
+            } else if (item.getDbObjectName().equals("cons")) {
+                Assert.assertEquals(item.getComparisonResult(), ComparisonResult.INCONSISTENT);
+                Assert.assertNotNull(item.getChangeScript());
+            } else if (item.getDbObjectName().equals("cons_only_in_source")) {
+                Assert.assertEquals(item.getComparisonResult(), ComparisonResult.ONLY_IN_SOURCE);
+                Assert.assertNotNull(item.getChangeScript());
+            } else if (item.getDbObjectName().equals("cons_only_in_target")) {
+                Assert.assertEquals(item.getComparisonResult(), ComparisonResult.ONLY_IN_TARGET);
+                Assert.assertNotNull(item.getChangeScript());
+            }
+        });
+    }
+
+    @Test
+    public void compareAllTables_update_partition() {
+        DBObjectComparisonResult result1 = results.stream().filter(
+                item -> item.getDbObjectName().equals("update_partition1")).collect(Collectors.toList()).get(0);
+        Assert.assertEquals(result1.getComparisonResult(), ComparisonResult.INCONSISTENT);
+        Assert.assertEquals(4, result1.getSubDBObjectComparisonResult().size());
+
+        result1.getSubDBObjectComparisonResult().forEach(item -> {
+            if (item.getDbObjectType().equals(DBObjectType.PARTITION)) {
+                Assert.assertEquals(item.getComparisonResult(), ComparisonResult.INCONSISTENT);
+                Assert.assertNotNull(item.getChangeScript());
+            }
+        });
+
+        DBObjectComparisonResult result2 = results.stream().filter(
+                item -> item.getDbObjectName().equals("update_partition2")).collect(Collectors.toList()).get(0);
+        Assert.assertEquals(result2.getComparisonResult(), ComparisonResult.INCONSISTENT);
+
+        result2.getSubDBObjectComparisonResult().forEach(item -> {
+            if (item.getDbObjectType().equals(DBObjectType.PARTITION)) {
+                Assert.assertEquals(item.getComparisonResult(), ComparisonResult.ONLY_IN_SOURCE);
+                Assert.assertNotNull(item.getChangeScript());
+            }
+        });
+    }
+
+    @Test
+    public void compareAllTables_update_table_option() {
+        DBObjectComparisonResult result = results.stream().filter(
+                item -> item.getDbObjectName().equals("update_options")).collect(Collectors.toList()).get(0);
+        Assert.assertEquals(result.getComparisonResult(), ComparisonResult.INCONSISTENT);
+        Assert.assertNotNull(result.getChangeScript());
+    }
+
+    @Test
+    public void compare_specified_tables() {
+        List<DBObjectComparisonResult> results =
+                comparator.compareTables(Arrays.asList("update_column", "update_index", "fk_dependency_only_in_source1",
+                        "fk_only_in_source"));
+        Assert.assertEquals(results.size(), 4);
+    }
+}

--- a/server/plugins/task-plugin-ob-mysql/src/test/resources/structurecompare/source_drop.sql
+++ b/server/plugins/task-plugin-ob-mysql/src/test/resources/structurecompare/source_drop.sql
@@ -1,0 +1,10 @@
+drop table if exists `fk_only_in_source`;
+drop table if exists `fk_dependency_only_in_source1`;
+drop table if exists `fk_dependency_only_in_source2`;
+drop table if exists `primary_key_test`;
+drop table if exists `update_column`;
+drop table if exists `update_index`;
+drop table if exists `update_constraint`;
+drop table if exists `update_partition1`;
+drop table if exists `update_partition2`;
+drop table if exists `update_options`;

--- a/server/plugins/task-plugin-ob-mysql/src/test/resources/structurecompare/source_schema_ddl.sql
+++ b/server/plugins/task-plugin-ob-mysql/src/test/resources/structurecompare/source_schema_ddl.sql
@@ -1,0 +1,75 @@
+-- 按照外键依赖顺序创建表 case
+CREATE TABLE `fk_dependency_only_in_source1` (
+    `customer_id` INT AUTO_INCREMENT PRIMARY KEY,
+    `customer_name` VARCHAR(100) NOT NULL
+);
+
+CREATE TABLE `fk_dependency_only_in_source2` (
+    `product_id` INT AUTO_INCREMENT PRIMARY KEY,
+    `product_name` VARCHAR(100) NOT NULL
+);
+
+CREATE TABLE `fk_only_in_source` (
+    `order_id` INT AUTO_INCREMENT,
+    `customer_id` INT ,
+    `product_id` INT ,
+    `amount` DECIMAL(10, 2) NOT NULL,
+    PRIMARY KEY (`order_id`),
+    FOREIGN KEY (`customer_id`) REFERENCES `fk_dependency_only_in_source1` (`customer_id`),
+    FOREIGN KEY (`product_id`) REFERENCES `fk_dependency_only_in_source2` (`product_id`)
+);
+
+-- 更新主键 case
+create table `primary_key_test`(`c1` INT(11) PRIMARY KEY, `c2` int(11) NOT NULL);
+
+-- 更新表列 case
+CREATE TABLE `update_column` (
+    `id` INT(11) PRIMARY KEY,
+    `c1` VARCHAR(100),
+    `c2` date NOT NULL,
+    `C3` DECIMAL(10, 2) NOT NULL,
+    `only_in_source_col` INT(11)
+);
+
+-- 更新索引 case
+CREATE TABLE `update_index` (
+    `c1` INT(11) NOT NULL,
+    `c2` INT(11) NOT NULL,
+    `C3` INT(11) NOT NULL,
+    INDEX `idx1` (`c1`),
+    INDEX `idx_only_in_source` (`c2`)
+);
+
+-- 更新约束 case
+CREATE TABLE `update_constraint` (
+    `c1` INT(11) NOT NULL,
+    `c2` INT(11) NOT NULL,
+    `C3` INT(11) NOT NULL,
+    CONSTRAINT `cons` UNIQUE (`c1`),
+    CONSTRAINT `cons_only_in_source` UNIQUE (`c2`)
+);
+
+-- 更新分区 case
+CREATE TABLE `update_partition1` (
+    `id` INT NOT NULL,
+    `created_at` DATETIME NOT NULL,
+    PRIMARY KEY (`id`, `created_at`)
+)
+PARTITION BY RANGE (YEAR(`created_at`)) (
+    PARTITION p0 VALUES LESS THAN (1995),
+    PARTITION p1 VALUES LESS THAN (2005),
+    PARTITION p2 VALUES LESS THAN (2015),
+    PARTITION p3 VALUES LESS THAN (2025)
+);
+
+CREATE TABLE `update_partition2` (
+    `id` INT(11) AUTO_INCREMENT NOT NULL PRIMARY KEY
+)
+PARTITION BY KEY(`id`)
+PARTITIONS 4;
+
+-- 更新表属性 case
+create table `update_options`(
+  `c1` INT(11) NOT NULL,
+  `c2` INT(11) NOT NULL
+) CHARACTER SET = utf8mb4 COLLATE = utf8mb4_bin COMMENT = 'comment1';

--- a/server/plugins/task-plugin-ob-mysql/src/test/resources/structurecompare/target_drop.sql
+++ b/server/plugins/task-plugin-ob-mysql/src/test/resources/structurecompare/target_drop.sql
@@ -1,0 +1,10 @@
+drop table if exists `fk_only_in_target`;
+drop table if exists `fk_dependency_only_in_target1`;
+drop table if exists `fk_dependency_only_in_target2`;
+drop table if exists `primary_key_test`;
+drop table if exists `update_column`;
+drop table if exists `update_index`;
+drop table if exists `update_constraint`;
+drop table if exists `update_partition1`;
+drop table if exists `update_partition2`;
+drop table if exists `update_options`;

--- a/server/plugins/task-plugin-ob-mysql/src/test/resources/structurecompare/target_schema_ddl.sql
+++ b/server/plugins/task-plugin-ob-mysql/src/test/resources/structurecompare/target_schema_ddl.sql
@@ -1,0 +1,74 @@
+-- 按照外键依赖顺序删除表 case
+CREATE TABLE `fk_dependency_only_in_target1` (
+    `customer_id` INT AUTO_INCREMENT PRIMARY KEY,
+    `customer_name` VARCHAR(100) NOT NULL
+);
+
+CREATE TABLE `fk_dependency_only_in_target2` (
+    `product_id` INT AUTO_INCREMENT PRIMARY KEY,
+    `product_name` VARCHAR(100) NOT NULL
+);
+
+CREATE TABLE `fk_only_in_target` (
+    `order_id` INT AUTO_INCREMENT,
+    `customer_id` INT ,
+    `product_id` INT ,
+    `amount` DECIMAL(10, 2) NOT NULL,
+    PRIMARY KEY (`order_id`),
+    FOREIGN KEY (`customer_id`) REFERENCES `fk_dependency_only_in_target1` (`customer_id`),
+    FOREIGN KEY (`product_id`) REFERENCES `fk_dependency_only_in_target2` (`product_id`)
+);
+
+-- 更新主键 case
+create table `primary_key_test`(`c1` INT(11) NOT NULL, `c2` INT(11) PRIMARY KEY);
+
+-- 更新表列 case
+CREATE TABLE `update_column` (
+    `id` INT(11) PRIMARY KEY,
+    `c1` VARCHAR(50),
+    `c2` INT(11) DEFAULT NULL,
+    `C3` DECIMAL(9, 5) NOT NULL,
+    `only_in_target_col` INT(11)
+);
+
+-- 更新索引 case
+CREATE TABLE `update_index` (
+    `c1` INT(11) NOT NULL,
+    `c2` INT(11) NOT NULL,
+    `C3` INT(11) NOT NULL,
+    INDEX `idx1` (`c1`, `c3`),
+    INDEX `idx_only_in_target` (`c2`)
+);
+
+-- 更新约束 case
+CREATE TABLE `update_constraint` (
+    `c1` INT(11) NOT NULL,
+    `c2` INT(11) NOT NULL,
+    `C3` INT(11) NOT NULL,
+    CONSTRAINT `cons` UNIQUE (`c1`, `c2`),
+    CONSTRAINT `cons_only_in_target` UNIQUE (`c2`)
+);
+
+-- 更新分区 case
+CREATE TABLE `update_partition1` (
+    `id` INT NOT NULL,
+    `created_at` DATETIME NOT NULL,
+    PRIMARY KEY (`id`, `created_at`)
+)
+PARTITION BY RANGE (YEAR(`created_at`)) (
+    PARTITION p0 VALUES LESS THAN (1995),
+    PARTITION p1 VALUES LESS THAN (2005),
+    PARTITION p2 VALUES LESS THAN (2015),
+    PARTITION p3 VALUES LESS THAN (2025),
+    PARTITION p4 VALUES LESS THAN MAXVALUE
+);
+
+CREATE TABLE `update_partition2` (
+    `id` INT(11) AUTO_INCREMENT NOT NULL PRIMARY KEY
+);
+
+-- 更新表属性 case
+create table `update_options`(
+  `c1` INT(11) NOT NULL,
+  `c2` INT(11) NOT NULL
+) CHARACTER SET = gb18030 COLLATE = gb18030_chinese_ci COMMENT = 'comment2';

--- a/server/plugins/task-plugin-ob-oracle/pom.xml
+++ b/server/plugins/task-plugin-ob-oracle/pom.xml
@@ -20,12 +20,16 @@
             <groupId>com.oceanbase</groupId>
             <artifactId>task-plugin-ob-mysql</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.oceanbase</groupId>
+            <artifactId>schema-plugin-ob-oracle</artifactId>
+        </dependency>
     </dependencies>
 
     <properties>
         <root-project.basedir>${project.parent.parent.basedir}</root-project.basedir>
         <plugin.class>com.oceanbase.odc.plugin.task.oboracle.OBOracleTaskPlugin</plugin.class>
-        <plugin.dependencies>task-plugin-ob-mysql</plugin.dependencies>
+        <plugin.dependencies>task-plugin-ob-mysql, schema-plugin-ob-oracle</plugin.dependencies>
     </properties>
 
     <build>

--- a/server/plugins/task-plugin-ob-oracle/src/main/java/com/oceanbase/odc/plugin/task/oboracle/structurecompare/OBOracleStructureCompareExtension.java
+++ b/server/plugins/task-plugin-ob-oracle/src/main/java/com/oceanbase/odc/plugin/task/oboracle/structurecompare/OBOracleStructureCompareExtension.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2023 OceanBase.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.oceanbase.odc.plugin.task.oboracle.structurecompare;
+
+import java.sql.SQLException;
+
+import javax.sql.DataSource;
+
+import org.pf4j.Extension;
+
+import com.oceanbase.odc.core.shared.constant.DialectType;
+import com.oceanbase.odc.plugin.schema.oboracle.utils.DBAccessorUtil;
+import com.oceanbase.odc.plugin.task.api.structurecompare.StructureComparator;
+import com.oceanbase.odc.plugin.task.api.structurecompare.StructureCompareExtensionPoint;
+import com.oceanbase.odc.plugin.task.api.structurecompare.model.StructureCompareConfig;
+import com.oceanbase.odc.plugin.task.obmysql.structurecompare.OdcStructureComparator;
+
+/**
+ * @author jingtian
+ * @date 2024/1/2
+ * @since ODC_release_4.2.4
+ */
+@Extension
+public class OBOracleStructureCompareExtension implements StructureCompareExtensionPoint {
+    @Override
+    public StructureComparator getStructureComparator(StructureCompareConfig config) throws SQLException {
+        checkConfig(config);
+        DataSource srcDataSource = config.getSourceDataSource();
+        DataSource tgtDataSource = config.getTargetDataSource();
+        return new OdcStructureComparator(config.getSourceSchemaName(), config.getTargetSchemaName(),
+                DBAccessorUtil.getSchemaAccessor(srcDataSource.getConnection()),
+                DBAccessorUtil.getSchemaAccessor(tgtDataSource.getConnection()),
+                DBAccessorUtil.getTableEditor(), config.getTargetDialectType());
+    }
+
+    private void checkConfig(StructureCompareConfig config) {
+        if (config.getSourceDialectType() != DialectType.OB_ORACLE
+                || config.getTargetDialectType() != DialectType.OB_ORACLE) {
+            throw new IllegalArgumentException("Source and target dialect type must be OB_ORACLE");
+        }
+    }
+}


### PR DESCRIPTION


#### What type of PR is this?
type-feature
modul-structure-compare


#### What this PR does / why we need it:
Place the implementation of the `StructureComparator` interface in the` task-plugin` layer to facilitate the access of new data sources to structure comparison tasks in the future.
1. add `StructureCompareExtensionPoint`  in `task-plugin-api` 
2. `OdcDBStructureComparator` ：Implement `DBStructureComparator` interface based on `db-browser`.
If we can call `DBCat` SDK in the future, we only need to write another DBCat DBStructureComparator interface implementation class, and the service layer does not need to be aware of it.
3. The table's columns, indexes, constraints, and partition object's comparison results will be sub-objects of the table `DBObjectComparisonResult`，refer to `DBObjectComparisonResult#getSubDBObjectComparisonResult()`.
For table object, `DBObjectComparisonResult#getChangeScript()` only only record the change script of table options.
4. Add support alter table charset and collate code in `MySQLTableEditor#generateUpdateTableOptionDDL`. Oracle do not support alter table charset and collate.

ut test coverage：
<img width="700" alt="image" src="https://github.com/oceanbase/odc/assets/140503120/e508f4f3-4092-4ab8-b471-2095db0f13ac">


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #816

#### Special notes for your reviewer:

<!--
This section is used to describe how this PR is implemented. 
If this is a PR that fixes a bug, this section describes how the bug was fixed.
If it's a new feature, this section briefly describes how to implement the new feature.
etc.
-->

#### Additional documentation e.g., usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```