### PR TITLE
fix(db-browser): optimize the visualization of mysql table ddl and supports empty string ''

### DIFF
--- a/libs/db-browser/src/main/java/com/oceanbase/tools/dbbrowser/editor/mysql/MySQLColumnEditor.java
+++ b/libs/db-browser/src/main/java/com/oceanbase/tools/dbbrowser/editor/mysql/MySQLColumnEditor.java
@@ -49,12 +49,12 @@ public class MySQLColumnEditor extends DBTableColumnEditor {
     @Override
     protected List<DBColumnModifier> getSupportColumnModifiers() {
         return Arrays.asList(new DataTypeModifier(),
-                new CharsetModifier(),
-                new CollationModifier(),
+                new NullNotNullModifier(),
                 new DefaultOptionModifier(),
                 new ExtraInfoModifier(),
-                new CommentModifier(),
-                new NullNotNullModifier());
+                new CharsetModifier(),
+                new CollationModifier(),
+                new CommentModifier());
     }
 
     @Override
@@ -130,6 +130,9 @@ public class MySQLColumnEditor extends DBTableColumnEditor {
                 if (isDefaultValueBuiltInFunction(column)) {
                     // 默认值是 内置函数，则不需要用引号转义，直接拼接即可
                     sqlBuilder.append(defaultValue);
+                } else if (defaultValue.equals("(empty_string)")) {
+                    // 如果默认值是(empty_string),设置default 为 ''
+                    sqlBuilder.append("''");
                 } else {
                     /**
                      * 不是内置函数作为默认值的话，都可以用单引号包围，不是字符串类型的，也会被转义成对应的类型值。比如： col1 int(11) DEFAULT '2' 会被内核自动转换为 col1 int(11)


### PR DESCRIPTION
#### What type of PR is this?
type-feature dbbrowser


#### What this PR does / why we need it:
Optimize the visualization of MySQL table structure design to arrange the generation of field
information, supporting strings enclosed in single quotes ('').

#### Which issue(s) this PR fixes:
Fixes #1317

#### Special notes for your reviewer:
This PR also has a corresponding frontend PR.
https://github.com/oceanbase/odc-client/pull/37

#### Additional documentation e.g., usage docs, etc.:

```docs

```