### PR TITLE
feat(data-transfer): not compress export output in client mode

### DIFF
--- a/server/integration-test/src/test/java/com/oceanbase/odc/service/datatransfer/DataTransferServiceTest.java
+++ b/server/integration-test/src/test/java/com/oceanbase/odc/service/datatransfer/DataTransferServiceTest.java
@@ -25,7 +25,6 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Paths;
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -41,7 +40,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 

--- a/server/integration-test/src/test/java/com/oceanbase/odc/service/datatransfer/DataTransferServiceTest.java
+++ b/server/integration-test/src/test/java/com/oceanbase/odc/service/datatransfer/DataTransferServiceTest.java
@@ -25,6 +25,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Paths;
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -506,12 +507,11 @@ public class DataTransferServiceTest extends ServiceTestEnv {
     }
 
     private File getDumpFile() throws IOException {
-        File target = new File(fileManager
+        File dir = new File(fileManager
                 .getWorkingDir(TaskType.EXPORT, DataTransferService.CLIENT_DIR_PREFIX + BUCKET).getAbsolutePath());
-        List<File> files = Arrays.stream(target.listFiles()).filter(file -> file.getName().endsWith("zip"))
-                .collect(Collectors.toList());
-        Assert.assertEquals(1, files.size());
-        return files.get(0);
+        File target = new File(dir, BUCKET + ".zip");
+        new ExportOutput(dir).toZip(target);
+        return target;
     }
 
     private ConnectionConfig buildTestConnection(DialectType dialectType) {

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/datatransfer/DefaultDataTransferAdapter.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/datatransfer/DefaultDataTransferAdapter.java
@@ -16,12 +16,15 @@
 
 package com.oceanbase.odc.service.datatransfer;
 
+import static com.oceanbase.odc.service.datatransfer.task.DataTransferTask.OUTPUT_FILTER_FILES;
+
 import java.io.File;
 import java.io.IOException;
 
 import org.apache.commons.io.FileUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import com.oceanbase.odc.plugin.task.api.datatransfer.dumper.ExportOutput;
 import com.oceanbase.odc.plugin.task.api.datatransfer.model.DataTransferConfig;
 import com.oceanbase.odc.plugin.task.api.datatransfer.model.DataTransferTaskResult;
 import com.oceanbase.odc.service.objectstorage.cloud.CloudObjectStorageService;
@@ -47,19 +50,19 @@ public class DefaultDataTransferAdapter implements DataTransferAdapter {
     @Override
     public void afterHandle(DataTransferConfig config, DataTransferTaskResult result, File exportFile)
             throws IOException {
-        if (!cloudObjectStorageService.supported()) {
-            return;
+        File dest = exportFile;
+        if (exportFile.isDirectory()) {
+            File workingDir = exportFile.getParentFile();
+            dest = new File(workingDir.getPath() + File.separator + workingDir.getName() + "_export_file.zip");
+            result.setExportZipFilePath(dest.getName());
+            new ExportOutput(exportFile).toZip(dest, file -> !OUTPUT_FILTER_FILES.contains(file.getFileName()));
+            FileUtils.deleteQuietly(exportFile);
+            result.setExportZipFilePath(dest.getName());
         }
-        try {
-            String objectName = cloudObjectStorageService.uploadTemp(exportFile.getName(), exportFile);
+        if (cloudObjectStorageService.supported()) {
+            String objectName = cloudObjectStorageService.uploadTemp(dest.getName(), dest);
             log.info("Upload the data file to the oss successfully, objectName={}", objectName);
             result.setExportZipFilePath(objectName);
-        } finally {
-            /**
-             * 公有云模式下本地导出文件和目录都不必要保存，直接删除
-             */
-            boolean deleteRes = FileUtils.deleteQuietly(exportFile);
-            log.info("Temporary data file deleted, filePath={}, result={}", exportFile.getName(), deleteRes);
         }
     }
 

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/datatransfer/DefaultDataTransferAdapter.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/datatransfer/DefaultDataTransferAdapter.java
@@ -62,6 +62,7 @@ public class DefaultDataTransferAdapter implements DataTransferAdapter {
         if (cloudObjectStorageService.supported()) {
             String objectName = cloudObjectStorageService.uploadTemp(dest.getName(), dest);
             log.info("Upload the data file to the oss successfully, objectName={}", objectName);
+            FileUtils.deleteQuietly(dest);
             result.setExportZipFilePath(objectName);
         }
     }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines.
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request.
3. Ensure you have added or ran the appropriate tests for your PR.
5. If the PR is unfinished, you may add or remove a WIP or [WIP] prefix to your pull request title.
-->

#### What type of PR is this?
type-feature
<!--
Add one of the following kinds:
type-bug
type-feature
type-docs
etc.

Optionally add one or more of the following kinds if applicable:
module-resultset
module-sql execution
etc.
-->

#### What this PR does / why we need it:

Now we would compress export output to zip format no mater on the web mode or the client mode.
However, the zip format supports up to 4GB of compressed data. And we don't have a limit on exporting data size in the desktop version. So in the client mode, we will not compress it.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Feat #829