### PR TITLE
fix(data-transfer): fix wrong object type names were used

### DIFF
--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/datatransfer/DataTransferService.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/datatransfer/DataTransferService.java
@@ -351,7 +351,7 @@ public class DataTransferService {
         }
         DataTransferTaskResult result = new DataTransferTaskResult();
         List<ObjectResult> objects = config.getExportDbObjects().stream().map(
-                obj -> new ObjectResult(config.getSchemaName(), obj.getObjectName(), obj.getDbObjectType().getName()))
+                obj -> new ObjectResult(config.getSchemaName(), obj.getObjectName(), obj.getDbObjectType().name()))
                 .collect(Collectors.toList());
         if (config.isTransferDDL()) {
             result.setSchemaObjectsInfo(objects);

--- a/server/plugins/task-plugin-api/src/main/java/com/oceanbase/odc/plugin/task/api/datatransfer/model/ObjectResult.java
+++ b/server/plugins/task-plugin-api/src/main/java/com/oceanbase/odc/plugin/task/api/datatransfer/model/ObjectResult.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.oceanbase.tools.loaddump.common.enums.ObjectType;
 import com.oceanbase.tools.loaddump.common.model.ObjectStatus;
 
 import lombok.Data;
@@ -46,7 +47,7 @@ public class ObjectResult extends ObjectStatus {
 
     public static ObjectResult of(ObjectStatus that) {
         ObjectResult result = new ObjectResult();
-        result.setType(that.getType());
+        result.setType(ObjectType.valueOfName(that.getType()).name());
         result.setStatus(that.getStatus());
         result.setName(that.getName());
         result.setSchema(that.getSchema());


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines.
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request.
3. Ensure you have added or ran the appropriate tests for your PR.
5. If the PR is unfinished, you may add or remove a WIP or [WIP] prefix to your pull request title.
-->

#### What type of PR is this?
type-bug
<!--
Add one of the following kinds:
type-bug
type-feature
type-docs
etc.

Optionally add one or more of the following kinds if applicable:
module-resultset
module-sql execution
etc.
-->

#### What this PR does / why we need it:

When use ob-loader-dumper to transfer data, we should use `ObjectType#name` as displayed name. But `ObjectType#getName` was used instead, causing miss match with front-end.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1333 