### PR TITLE
fix(data-transfer): do not create os user in client mode

### DIFF
--- a/server/odc-server/src/main/java/com/oceanbase/odc/server/web/websocket/WebSocketServer.java
+++ b/server/odc-server/src/main/java/com/oceanbase/odc/server/web/websocket/WebSocketServer.java
@@ -64,6 +64,7 @@ import com.oceanbase.odc.core.session.ConnectionSession;
 import com.oceanbase.odc.core.session.ConnectionSessionUtil;
 import com.oceanbase.odc.core.shared.constant.DialectType;
 import com.oceanbase.odc.service.common.util.SidUtils;
+import com.oceanbase.odc.service.common.util.SpringContextUtil;
 import com.oceanbase.odc.service.connection.ConnectionService;
 import com.oceanbase.odc.service.connection.model.ConnectionConfig;
 import com.oceanbase.odc.service.iam.auth.AuthenticationFacade;
@@ -245,7 +246,7 @@ public class WebSocketServer {
 
     private String[] generateCmd(ConnectionConfig connectionConfig, boolean supportSetGBK, String schema) {
         List<String> cmd;
-        if (!SystemUtils.isOnLinux()) {
+        if (SpringContextUtil.isActive("clientMode")) {
             cmd = getRunObClientCmd(connectionConfig, supportSetGBK, schema);
             return cmd.toArray(new String[cmd.size()]);
         }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines.
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request.
3. Ensure you have added or ran the appropriate tests for your PR.
5. If the PR is unfinished, you may add or remove a WIP or [WIP] prefix to your pull request title.
-->

#### What type of PR is this?
type-bug
<!--
Add one of the following kinds:
type-bug
type-feature
type-docs
etc.

Optionally add one or more of the following kinds if applicable:
module-resultset
module-sql execution
etc.
-->

#### What this PR does / why we need it:
When odc are running on ubuntu as client mode , we will create a new os user to run obclient. But if current os user doesn't have access to create user, an exception will be thrown and obclient could not be opened.
In fact we don't need to create a user in client mode , so I changed this assert.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1300