### PR TITLE
fix(sql-execute): do not follback execute when manual commit enabled

### DIFF
--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/session/OdcStatementCallBack.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/session/OdcStatementCallBack.java
@@ -202,7 +202,7 @@ public class OdcStatementCallBack implements StatementCallback<List<JdbcGeneralR
 
         } catch (Exception e) {
             try {
-                if (!statement.getConnection().getAutoCommit()) {
+                if (!statement.getConnection().getAutoCommit() && autoCommit) {
                     rollback(statement.getConnection());
                 }
                 ConnectionSessionUtil.logSocketInfo(statement.getConnection(), "console error");

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/session/OdcStatementCallBack.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/session/OdcStatementCallBack.java
@@ -202,9 +202,6 @@ public class OdcStatementCallBack implements StatementCallback<List<JdbcGeneralR
 
         } catch (Exception e) {
             try {
-                if (!statement.getConnection().getAutoCommit() && autoCommit) {
-                    rollback(statement.getConnection());
-                }
                 ConnectionSessionUtil.logSocketInfo(statement.getConnection(), "console error");
             } catch (Exception exception) {
                 log.warn("Failed to execute abnormal replenishment logic", exception);


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines.
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request.
3. Ensure you have added or ran the appropriate tests for your PR.
5. If the PR is unfinished, you may add or remove a WIP or [WIP] prefix to your pull request title.
-->

#### What type of PR is this?
type-bug
<!--
Add one of the following kinds:
type-bug
type-feature
type-docs
etc.

Optionally add one or more of the following kinds if applicable:
module-resultset
module-sql execution
etc.
-->

#### What this PR does / why we need it:
Now when odc user has enabled manual commit, the transaction will still be rollbacked when exception occurs.
However this action is incorrect. Transactions should only end when the user manually rolls back or commits. ODC should not control transaction status.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1352 