### PR TITLE
fix(db-browser): failed to list tables when ob's version is no greater than 2.2.30

### DIFF
--- a/libs/db-browser/src/main/java/com/oceanbase/tools/dbbrowser/schema/oracle/OBOracleLessThan400SchemaAccessor.java
+++ b/libs/db-browser/src/main/java/com/oceanbase/tools/dbbrowser/schema/oracle/OBOracleLessThan400SchemaAccessor.java
@@ -22,10 +22,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import org.springframework.jdbc.core.BeanPropertyRowMapper;
 import org.springframework.jdbc.core.JdbcOperations;
 
-import com.oceanbase.tools.dbbrowser.model.DBObjectIdentity;
 import com.oceanbase.tools.dbbrowser.model.DBSynonymType;
 import com.oceanbase.tools.dbbrowser.model.DBTable.DBTableOptions;
 import com.oceanbase.tools.dbbrowser.model.DBTableColumn;
@@ -53,30 +51,6 @@ public class OBOracleLessThan400SchemaAccessor extends OBOracleSchemaAccessor {
             OracleDataDictTableNames dataDictTableNames) {
         super(jdbcOperations, dataDictTableNames);
         this.sqlMapper = DBSchemaAccessorSqlMappers.get(StatementsFiles.OBORACLE_3_x);
-    }
-
-    @Override
-    public List<DBObjectIdentity> listTables(String schemaName, String tableNameLike) {
-        OracleSqlBuilder sb = new OracleSqlBuilder();
-        sb.append("select\n"
-                + "  t1.DATABASE_NAME as schema_name,\n"
-                + "  t2.TABLE_NAME as name,\n"
-                + "  'TABLE' as type \n"
-                + "from \n"
-                + "  SYS.ALL_VIRTUAL_DATABASE_REAL_AGENT t1,\n"
-                + "  SYS.ALL_VIRTUAL_TABLE_REAL_AGENT t2\n"
-                + "where \n"
-                + "  t1.database_id=t2.database_id\n"
-                + "  and t2.table_type = 3\n");
-
-        if (StringUtils.isNotBlank(schemaName)) {
-            sb.append("  and t1.database_name = ").value(schemaName);
-        }
-        if (StringUtils.isNotBlank(tableNameLike)) {
-            sb.append("  and t2.table_name LIKE ").value(tableNameLike);
-        }
-        sb.append(" order by t1.database_name, t2.table_name");
-        return jdbcOperations.query(sb.toString(), new BeanPropertyRowMapper<>(DBObjectIdentity.class));
     }
 
     @Override

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/db/browser/DBSchemaAccessors.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/db/browser/DBSchemaAccessors.java
@@ -98,11 +98,11 @@ public class DBSchemaAccessors {
             if (VersionUtils.isGreaterThanOrEqualsTo(obVersion, "4.0.0")) {
                 // OB 版本 >= 4.0.0
                 return new OBOracleSchemaAccessor(syncJdbcExecutor, new ALLDataDictTableNames());
-            } else if (VersionUtils.isGreaterThanOrEqualsTo(obVersion, "2.2.7")) {
-                // OB 版本为 [2.2.7, 4.0.0)
+            } else if (VersionUtils.isGreaterThanOrEqualsTo(obVersion, "2.2.70")) {
+                // OB 版本为 [2.2.70, 4.0.0)
                 return new OBOracleLessThan400SchemaAccessor(syncJdbcExecutor, new ALLDataDictTableNames());
             } else {
-                // OB 版本 < 2.2.7
+                // OB 版本 < 2.2.70
                 return new OBOracleLessThan2270SchemaAccessor(syncJdbcExecutor, new ALLDataDictTableNames());
             }
         } else if (connectType == ConnectType.ODP_SHARDING_OB_MYSQL) {

--- a/server/plugins/schema-plugin-ob-oracle/src/main/java/com/oceanbase/odc/plugin/schema/oboracle/browser/DBSchemaAccessors.java
+++ b/server/plugins/schema-plugin-ob-oracle/src/main/java/com/oceanbase/odc/plugin/schema/oboracle/browser/DBSchemaAccessors.java
@@ -37,11 +37,11 @@ public class DBSchemaAccessors {
         if (VersionUtils.isGreaterThanOrEqualsTo(dbVersion, "4.0.0")) {
             // OB 版本 >= 4.0.0
             return new OBOracleSchemaAccessor(jdbcOperations, new ALLDataDictTableNames());
-        } else if (VersionUtils.isGreaterThanOrEqualsTo(dbVersion, "2.2.7")) {
+        } else if (VersionUtils.isGreaterThanOrEqualsTo(dbVersion, "2.2.70")) {
             // OB 版本为 [2.2.7, 4.0.0)
             return new OBOracleLessThan400SchemaAccessor(jdbcOperations, new ALLDataDictTableNames());
         } else {
-            // OB 版本 < 2.2.7
+            // OB 版本 < 2.2.70
             return new OBOracleLessThan2270SchemaAccessor(jdbcOperations, new ALLDataDictTableNames());
         }
     }


### PR DESCRIPTION

#### What type of PR is this?
type-bug
module-db-browser

#### What this PR does / why we need it:
1. ob oracle 2230 do not have `SYS.ALL_VIRTUAL_DATABASE_REAL_AGENT` internal table, In ob oracle mode, `ALL_TABLES` view information is uniformly queried to listTables.

2. fix get the DBSchemaAccessor for different versions

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1476

#### Special notes for your reviewer:

<!--
This section is used to describe how this PR is implemented. 
If this is a PR that fixes a bug, this section describes how the bug was fixed.
If it's a new feature, this section briefly describes how to implement the new feature.
etc.
-->

#### Additional documentation e.g., usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```