### PR TITLE
fix(sql-execute): fail to execute statement on OceanBase 2.2.30

### DIFF
--- a/server/odc-common/src/main/java/com/oceanbase/odc/common/util/ReflectionUtils.java
+++ b/server/odc-common/src/main/java/com/oceanbase/odc/common/util/ReflectionUtils.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2024 OceanBase.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.oceanbase.odc.common.util;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Proxy;
+
+/**
+ * @author liuyizhuo.lyz
+ * @date 2024/1/30
+ */
+public class ReflectionUtils {
+
+    public static <T> T getProxiedFieldValue(Object any, Class<?> type, String fieldName) {
+        if (!Proxy.isProxyClass(any.getClass()) || Proxy.getInvocationHandler(any).getClass() != type) {
+            return null;
+        }
+        InvocationHandler handler = Proxy.getInvocationHandler(any);
+        return getFieldValue(handler, fieldName);
+    }
+
+    public static <T> T getFieldValue(Object any, String fieldName) {
+        try {
+            Field field = any.getClass().getDeclaredField(fieldName);
+            if (!field.isAccessible()) {
+                field.setAccessible(true);
+            }
+            return (T) field.get(any);
+        } catch (NoSuchFieldException | IllegalAccessException | ClassCastException e) {
+            return null;
+        }
+    }
+
+}

--- a/server/odc-common/src/main/java/com/oceanbase/odc/common/util/ReflectionUtils.java
+++ b/server/odc-common/src/main/java/com/oceanbase/odc/common/util/ReflectionUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 OceanBase.
+ * Copyright (c) 2023 OceanBase.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.oceanbase.odc.common.util;
 
 import java.lang.reflect.Field;

--- a/server/odc-common/src/test/java/com/oceanbase/odc/common/util/ReflectionUtilsTest.java
+++ b/server/odc-common/src/test/java/com/oceanbase/odc/common/util/ReflectionUtilsTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2024 OceanBase.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.oceanbase.odc.common.util;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * @author liuyizhuo.lyz
+ * @date 2024/1/30
+ */
+public class ReflectionUtilsTest {
+
+    @Test
+    public void test_getFieldValue() throws NoSuchFieldException, IllegalAccessException {
+        Pojo pojo = new Pojo("fuzzyname");
+        Object name = ReflectionUtils.getFieldValue(pojo, "name");
+        Assert.assertEquals("fuzzyname", name);
+    }
+
+    @Test
+    public void test_getProxiedFieldValue() throws NoSuchFieldException, IllegalAccessException {
+        Object instance = Proxy.newProxyInstance(Pojo.class.getClassLoader(), new Class[] {FooInterface.class},
+                new PojoInvocationHandler(new FooInterface() {}));
+        Object target = ReflectionUtils.getProxiedFieldValue(instance, PojoInvocationHandler.class, "target");
+        Assert.assertTrue(target instanceof FooInterface);
+    }
+
+    private static class Pojo {
+        private final String name;
+
+        public Pojo(String name) {
+            this.name = name;
+        }
+    }
+
+    private interface FooInterface {
+    }
+
+    private static class PojoInvocationHandler implements InvocationHandler {
+
+        private FooInterface target;
+
+        public PojoInvocationHandler(FooInterface target) {
+            this.target = target;
+        }
+
+        @Override
+        public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+            return null;
+        }
+    }
+
+}

--- a/server/odc-common/src/test/java/com/oceanbase/odc/common/util/ReflectionUtilsTest.java
+++ b/server/odc-common/src/test/java/com/oceanbase/odc/common/util/ReflectionUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 OceanBase.
+ * Copyright (c) 2023 OceanBase.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.oceanbase.odc.common.util;
 
 import java.lang.reflect.InvocationHandler;

--- a/server/odc-core/src/main/java/com/oceanbase/odc/core/datasource/SingleConnectionDataSource.java
+++ b/server/odc-core/src/main/java/com/oceanbase/odc/core/datasource/SingleConnectionDataSource.java
@@ -206,7 +206,7 @@ public class SingleConnectionDataSource extends BaseClassBasedDataSource impleme
      * @since ODC_release_3.2.2
      * @see java.lang.reflect.InvocationHandler
      */
-    private static class CloseIgnoreInvocationHandler implements InvocationHandler {
+    public static class CloseIgnoreInvocationHandler implements InvocationHandler {
         private final Connection target;
         private final Lock lock;
 
@@ -242,6 +242,11 @@ public class SingleConnectionDataSource extends BaseClassBasedDataSource impleme
                 throw ex.getTargetException();
             }
         }
+
+        public Connection getTarget() {
+            return target;
+        }
+
     }
 
 }

--- a/server/odc-core/src/main/java/com/oceanbase/odc/core/datasource/SingleConnectionDataSource.java
+++ b/server/odc-core/src/main/java/com/oceanbase/odc/core/datasource/SingleConnectionDataSource.java
@@ -242,11 +242,6 @@ public class SingleConnectionDataSource extends BaseClassBasedDataSource impleme
                 throw ex.getTargetException();
             }
         }
-
-        public Connection getTarget() {
-            return target;
-        }
-
     }
 
 }

--- a/server/plugins/connect-plugin-ob-mysql/src/main/java/com/oceanbase/odc/plugin/connect/obmysql/OBMySQLSessionExtension.java
+++ b/server/plugins/connect-plugin-ob-mysql/src/main/java/com/oceanbase/odc/plugin/connect/obmysql/OBMySQLSessionExtension.java
@@ -23,6 +23,8 @@ import org.pf4j.Extension;
 
 import com.oceanbase.jdbc.OceanBaseConnection;
 import com.oceanbase.odc.common.util.JdbcOperationsUtil;
+import com.oceanbase.odc.common.util.ReflectionUtils;
+import com.oceanbase.odc.core.datasource.SingleConnectionDataSource.CloseIgnoreInvocationHandler;
 import com.oceanbase.odc.plugin.connect.api.SessionExtensionPoint;
 
 import lombok.extern.slf4j.Slf4j;
@@ -65,6 +67,10 @@ public class OBMySQLSessionExtension implements SessionExtensionPoint {
         } catch (Exception e) {
             if (connection instanceof OceanBaseConnection) {
                 connectionId = ((OceanBaseConnection) connection).getServerThreadId() + "";
+            } else {
+                OceanBaseConnection actual =
+                        ReflectionUtils.getProxiedFieldValue(connection, CloseIgnoreInvocationHandler.class, "target");
+                connectionId = actual == null ? "" : actual.getServerThreadId() + "";
             }
         }
         return connectionId;

--- a/server/plugins/connect-plugin-ob-oracle/src/main/java/com/oceanbase/odc/plugin/connect/oboracle/OBOracleSessionExtension.java
+++ b/server/plugins/connect-plugin-ob-oracle/src/main/java/com/oceanbase/odc/plugin/connect/oboracle/OBOracleSessionExtension.java
@@ -15,6 +15,7 @@
  */
 package com.oceanbase.odc.plugin.connect.oboracle;
 
+import java.lang.reflect.Proxy;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.Objects;
@@ -24,6 +25,7 @@ import org.pf4j.Extension;
 import com.oceanbase.jdbc.OceanBaseConnection;
 import com.oceanbase.odc.common.util.JdbcOperationsUtil;
 import com.oceanbase.odc.common.util.StringUtils;
+import com.oceanbase.odc.core.datasource.SingleConnectionDataSource.CloseIgnoreInvocationHandler;
 import com.oceanbase.odc.plugin.connect.api.SessionExtensionPoint;
 
 import lombok.extern.slf4j.Slf4j;
@@ -67,6 +69,9 @@ public class OBOracleSessionExtension implements SessionExtensionPoint {
         } catch (Exception e) {
             if (connection instanceof OceanBaseConnection) {
                 connectionId = ((OceanBaseConnection) connection).getServerThreadId() + "";
+            } else if (Proxy.isProxyClass(connection.getClass())) {
+                Connection actual = ((CloseIgnoreInvocationHandler) Proxy.getInvocationHandler(connection)).getTarget();
+                connectionId = ((OceanBaseConnection) actual).getServerThreadId() + "";
             }
         }
         return connectionId;

--- a/server/plugins/connect-plugin-ob-oracle/src/main/java/com/oceanbase/odc/plugin/connect/oboracle/OBOracleSessionExtension.java
+++ b/server/plugins/connect-plugin-ob-oracle/src/main/java/com/oceanbase/odc/plugin/connect/oboracle/OBOracleSessionExtension.java
@@ -15,7 +15,6 @@
  */
 package com.oceanbase.odc.plugin.connect.oboracle;
 
-import java.lang.reflect.Proxy;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.Objects;
@@ -24,6 +23,7 @@ import org.pf4j.Extension;
 
 import com.oceanbase.jdbc.OceanBaseConnection;
 import com.oceanbase.odc.common.util.JdbcOperationsUtil;
+import com.oceanbase.odc.common.util.ReflectionUtils;
 import com.oceanbase.odc.common.util.StringUtils;
 import com.oceanbase.odc.core.datasource.SingleConnectionDataSource.CloseIgnoreInvocationHandler;
 import com.oceanbase.odc.plugin.connect.api.SessionExtensionPoint;
@@ -69,9 +69,10 @@ public class OBOracleSessionExtension implements SessionExtensionPoint {
         } catch (Exception e) {
             if (connection instanceof OceanBaseConnection) {
                 connectionId = ((OceanBaseConnection) connection).getServerThreadId() + "";
-            } else if (Proxy.isProxyClass(connection.getClass())) {
-                Connection actual = ((CloseIgnoreInvocationHandler) Proxy.getInvocationHandler(connection)).getTarget();
-                connectionId = ((OceanBaseConnection) actual).getServerThreadId() + "";
+            } else {
+                OceanBaseConnection actual =
+                        ReflectionUtils.getProxiedFieldValue(connection, CloseIgnoreInvocationHandler.class, "target");
+                connectionId = actual == null ? "" : actual.getServerThreadId() + "";
             }
         }
         return connectionId;


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines.
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request.
3. Ensure you have added or ran the appropriate tests for your PR.
5. If the PR is unfinished, you may add or remove a WIP or [WIP] prefix to your pull request title.
-->

#### What type of PR is this?
type-bug
<!--
Add one of the following kinds:
type-bug
type-feature
type-docs
etc.

Optionally add one or more of the following kinds if applicable:
module-resultset
module-sql execution
etc.
-->

#### What this PR does / why we need it:

`userenv('sessionid')` are not supported on OB 2230, so we use `OceanBaseConnection#getServerThreadId` instead.
But in `BaseSqlExecuteCallable` , the connection is generated from `SingleConnectionDataSource`. It's not instance of `OceanBaseConnection`. So we should get the real connection to get the id.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1475