### PR TITLE
fix(table): query table data with no column comments

### DIFF
--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/session/ConnectConsoleService.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/session/ConnectConsoleService.java
@@ -171,6 +171,7 @@ public class ConnectConsoleService {
         // avoid rewrite while execute
         asyncExecuteReq.setAddROWID(false);
         asyncExecuteReq.setQueryLimit(queryLimit);
+        asyncExecuteReq.setShowTableColumnInfo(true);
 
         SqlAsyncExecuteResp resp = execute(sessionId, asyncExecuteReq, false);
         String requestId = resp.getRequestId();


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines.
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request.
3. Ensure you have added or ran the appropriate tests for your PR.
5. If the PR is unfinished, you may add or remove a WIP or [WIP] prefix to your pull request title.
-->

#### What type of PR is this?
type-bug
<!--
Add one of the following kinds:
type-bug
type-feature
type-docs
etc.

Optionally add one or more of the following kinds if applicable:
module-resultset
module-sql execution
etc.
-->

#### What this PR does / why we need it:

When querying table data, there is no column comment info. But it works correctly in sql console.
This is because the query api didn't set `SqlAsyncExecuteReq#showTableColumnInfo` to true when calling `execute` method.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1482