### PR TITLE
fix(taskframework): k8s system config from data.sql is empty string 

### DIFF
--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/task/dispatch/ImmediateJobDispatcher.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/task/dispatch/ImmediateJobDispatcher.java
@@ -95,11 +95,13 @@ public class ImmediateJobDispatcher implements JobDispatcher {
         K8sProperties k8s = taskFrameworkProperties.getK8sProperties();
 
         PodConfig podConfig = new PodConfig();
-        podConfig.setNamespace(StringUtils.isNotBlank(k8s.getNamespace()) ? k8s.getNamespace() : null);
+        if (StringUtils.isNotBlank(k8s.getNamespace())) {
+            podConfig.setNamespace(k8s.getNamespace());
+        }
         JobImageNameProvider jobImageNameProvider = JobConfigurationHolder.getJobConfiguration()
                 .getJobImageNameProvider();
         podConfig.setImage(jobImageNameProvider.provide());
-        podConfig.setCommand(Arrays.asList("sh", "-c", "/opt/odc/bin/start-odc.sh"));
+        podConfig.setCommand(Arrays.asList("sh", "-c", "/opt/odc/bin/start-job.sh"));
         podConfig.setRegion(StringUtils.isNotBlank(k8s.getRegion()) ? k8s.getRegion()
                 : SystemUtils.getEnvOrProperty(JobEnvKeyConstants.OB_ARN_PARTITION));
 

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/task/dispatch/ImmediateJobDispatcher.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/task/dispatch/ImmediateJobDispatcher.java
@@ -18,6 +18,7 @@ package com.oceanbase.odc.service.task.dispatch;
 
 import java.util.Arrays;
 
+import com.oceanbase.odc.common.util.StringUtils;
 import com.oceanbase.odc.common.util.SystemUtils;
 import com.oceanbase.odc.core.shared.exception.UnsupportedException;
 import com.oceanbase.odc.service.task.caller.ExecutorIdentifier;
@@ -94,12 +95,12 @@ public class ImmediateJobDispatcher implements JobDispatcher {
         K8sProperties k8s = taskFrameworkProperties.getK8sProperties();
 
         PodConfig podConfig = new PodConfig();
-        podConfig.setNamespace(k8s.getNamespace());
+        podConfig.setNamespace(StringUtils.isNotBlank(k8s.getNamespace()) ? k8s.getNamespace() : null);
         JobImageNameProvider jobImageNameProvider = JobConfigurationHolder.getJobConfiguration()
                 .getJobImageNameProvider();
         podConfig.setImage(jobImageNameProvider.provide());
         podConfig.setCommand(Arrays.asList("sh", "-c", "/opt/odc/bin/start-odc.sh"));
-        podConfig.setRegion(k8s.getRegion() != null ? k8s.getRegion()
+        podConfig.setRegion(StringUtils.isNotBlank(k8s.getRegion()) ? k8s.getRegion()
                 : SystemUtils.getEnvOrProperty(JobEnvKeyConstants.OB_ARN_PARTITION));
 
         podConfig.setRequestCpu(k8s.getRequestCpu());
@@ -108,7 +109,8 @@ public class ImmediateJobDispatcher implements JobDispatcher {
         podConfig.setLimitMem(k8s.getLimitMem());
         podConfig.setEnableMount(k8s.getEnableMount());
         podConfig.setMountPath(
-                k8s.getMountPath() == null ? JobConstants.ODC_EXECUTOR_DEFAULT_MOUNT_PATH : k8s.getMountPath());
+                StringUtils.isNotBlank(k8s.getMountPath()) ? k8s.getMountPath()
+                        : JobConstants.ODC_EXECUTOR_DEFAULT_MOUNT_PATH);
         podConfig.setMountDiskSize(k8s.getMountDiskSize());
         return podConfig;
     }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines.
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request.
3. Ensure you have added or ran the appropriate tests for your PR.
5. If the PR is unfinished, you may add or remove a WIP or [WIP] prefix to your pull request title.
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
type-bug
type-feature
type-docs
etc.

Optionally add one or more of the following kinds if applicable:
module-resultset
module-sql execution
etc.
-->
type-feature
module-taskframework

#### What this PR does / why we need it:

1. read system config is empty string but not null,  use `StringUtils.isNotBlank` to predicate string is blank or not
2. start pod command by start-job.sh

test passed
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

<!--
This section is used to describe how this PR is implemented. 
If this is a PR that fixes a bug, this section describes how the bug was fixed.
If it's a new feature, this section briefly describes how to implement the new feature.
etc.
-->

#### Additional documentation e.g., usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```