### PR TITLE
feat(databaseChange): Automatically adjust the timeout if the database change task involves time-consuming index change operations

### DIFF
--- a/server/integration-test/src/test/java/com/oceanbase/odc/service/flow/FlowInstanceServiceTest.java
+++ b/server/integration-test/src/test/java/com/oceanbase/odc/service/flow/FlowInstanceServiceTest.java
@@ -191,7 +191,7 @@ public class FlowInstanceServiceTest extends ServiceTestEnv {
         connectionConfig.setType(ConnectType.OB_MYSQL);
         Database database = TestRandom.nextObject(Database.class);
         connectionConfig.setVisibleScope(ConnectionVisibleScope.ORGANIZATION);
-        when(sqlCheckService.check(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any()))
+        when(sqlCheckService.check(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any()))
                 .thenReturn(Collections.emptyList());
         when(connectionService.getForConnectionSkipPermissionCheck(Mockito.anyLong())).thenReturn(connectionConfig);
         when(databaseService.findDataSourceForConnectById(Mockito.anyLong())).thenReturn(connectionConfig);

--- a/server/integration-test/src/test/java/com/oceanbase/odc/service/flow/FlowInstanceServiceTest.java
+++ b/server/integration-test/src/test/java/com/oceanbase/odc/service/flow/FlowInstanceServiceTest.java
@@ -191,7 +191,7 @@ public class FlowInstanceServiceTest extends ServiceTestEnv {
         connectionConfig.setType(ConnectType.OB_MYSQL);
         Database database = TestRandom.nextObject(Database.class);
         connectionConfig.setVisibleScope(ConnectionVisibleScope.ORGANIZATION);
-        when(sqlCheckService.check(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any()))
+        when(sqlCheckService.check(Mockito.any(Long.class), Mockito.any(String.class), Mockito.any(), Mockito.any()))
                 .thenReturn(Collections.emptyList());
         when(connectionService.getForConnectionSkipPermissionCheck(Mockito.anyLong())).thenReturn(connectionConfig);
         when(databaseService.findDataSourceForConnectById(Mockito.anyLong())).thenReturn(connectionConfig);

--- a/server/odc-core/src/main/resources/i18n/BusinessMessages.properties
+++ b/server/odc-core/src/main/resources/i18n/BusinessMessages.properties
@@ -698,6 +698,10 @@ com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.restrict-auto-incre
 com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.restrict-auto-increment-datatypes.allowed-datatypes=Allowed data types
 com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.restrict-auto-increment-datatypes.allowed-datatypes.description=A collection of data types that allow columns to be marked as auto-increment
 
+com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.index-change-time-consuming-exists.message=The DDL of this table involves time-consuming operations of creating and modifying indexes, and the timeout has been automatically adjusted
+com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.index-change-time-consuming-exists.name=The table's DDL involves time-consuming operations of creating and modifying indexes
+com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.index-change-time-consuming-exists.description=The table's DDL involves time-consuming operations of creating and modifying indexes
+
 # below masking algorithm built-in
 com.oceanbase.odc.builtin-resource.masking-algorithm.mask-all.name=Mask all (system default)
 com.oceanbase.odc.builtin-resource.masking-algorithm.personal-name-chinese.name=Personal name (Chinese character)

--- a/server/odc-core/src/main/resources/i18n/BusinessMessages_zh_CN.properties
+++ b/server/odc-core/src/main/resources/i18n/BusinessMessages_zh_CN.properties
@@ -635,6 +635,10 @@ com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.restrict-auto-incre
 com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.restrict-auto-increment-datatypes.allowed-datatypes=允许的数据类型
 com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.restrict-auto-increment-datatypes.allowed-datatypes.description=允许被标记为自增的列的数据类型集合
 
+com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.index-change-time-consuming-exists.message=表的 DDL 中涉及创建、修改索引的耗时操作，已自动调整超时时间
+com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.index-change-time-consuming-exists.name=表的 DDL 中涉及创建、修改索引的耗时操作
+com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.index-change-time-consuming-exists.description=表的 DDL 中涉及创建、修改索引的耗时操作
+
 # below masking algorithm built-in
 com.oceanbase.odc.builtin-resource.masking-algorithm.mask-all.name=全部遮掩（系统默认）
 com.oceanbase.odc.builtin-resource.masking-algorithm.personal-name-chinese.name=个人姓名（汉字类型）

--- a/server/odc-core/src/main/resources/i18n/BusinessMessages_zh_TW.properties
+++ b/server/odc-core/src/main/resources/i18n/BusinessMessages_zh_TW.properties
@@ -702,6 +702,10 @@ com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.restrict-auto-incre
 com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.restrict-auto-increment-datatypes.allowed-datatypes=允許的數據類型
 com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.restrict-auto-increment-datatypes.allowed-datatypes.description=允許被標記為自增的列的數據類型集合
 
+com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.index-change-time-consuming-exists.message=錶的 DDL 中涉及創建、修改索引的耗時操作，已自動調整超時時間
+com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.index-change-time-consuming-exists.name=錶的 DDL 中涉及創建、修改索引的耗時操作
+com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.index-change-time-consuming-exists.description=錶的 DDL 中涉及創建、修改索引的耗時操作
+
 # below masking algorithm built-in
 com.oceanbase.odc.builtin-resource.masking-algorithm.mask-all.name=全部遮掩（系統默認）
 com.oceanbase.odc.builtin-resource.masking-algorithm.personal-name-chinese.name=個人姓名（漢字類型）

--- a/server/odc-server/src/main/resources/data.sql
+++ b/server/odc-server/src/main/resources/data.sql
@@ -750,3 +750,8 @@ INSERT INTO config_system_configuration ( `key`, `value`, `description` ) VALUES
 ---
 INSERT INTO config_system_configuration(`key`, `value`, `description`) VALUES('odc.iam.permission.expired-retention-time-seconds',
  '7776000', 'How long expired permissions are retained, in seconds, defaults to 90 days') ON DUPLICATE KEY UPDATE `id`=`id`;
+
+INSERT INTO config_system_configuration ( `key`, `value`, `description` )
+VALUES
+  ( 'odc.task.async.index-change-max-timeout-millis', '432000000', 'If the change content of the database change task involves time-consuming index change operations, the timeout period for the automatically modified database change task, unit: milliseconds. Default value is 5 days.' )
+  ON DUPLICATE KEY UPDATE `id` = `id`;

--- a/server/odc-service/src/main/java/com/oceanbase/odc/metadb/flow/ServiceTaskInstanceRepository.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/metadb/flow/ServiceTaskInstanceRepository.java
@@ -75,7 +75,7 @@ public interface ServiceTaskInstanceRepository extends OdcJpaRepository<ServiceT
     Optional<ServiceTaskInstanceEntity> findByInstanceTypeAndName(@Param("instanceType") FlowNodeType instanceType,
             @Param("name") String name, @Param("flowInstanceId") Long flowInstanceId);
 
-    Optional<ServiceTaskInstanceEntity> findByFlowInstanceId(Long flowInstanceId);
+    List<ServiceTaskInstanceEntity> findByFlowInstanceId(Long flowInstanceId);
 
     @Query(value = "select b.* from flow_instance a left join flow_instance_node_task b "
             + "on a.id = b.flow_instance_id "

--- a/server/odc-service/src/main/java/com/oceanbase/odc/metadb/flow/ServiceTaskInstanceRepository.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/metadb/flow/ServiceTaskInstanceRepository.java
@@ -75,8 +75,6 @@ public interface ServiceTaskInstanceRepository extends OdcJpaRepository<ServiceT
     Optional<ServiceTaskInstanceEntity> findByInstanceTypeAndName(@Param("instanceType") FlowNodeType instanceType,
             @Param("name") String name, @Param("flowInstanceId") Long flowInstanceId);
 
-    List<ServiceTaskInstanceEntity> findByFlowInstanceId(Long flowInstanceId);
-
     @Query(value = "select b.* from flow_instance a left join flow_instance_node_task b "
             + "on a.id = b.flow_instance_id "
             + "where a.parent_instance_id=:id and b.task_type=:#{#type.name()} and b.status in (:statuses)",

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/flow/task/DatabaseChangeRuntimeFlowableTask.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/flow/task/DatabaseChangeRuntimeFlowableTask.java
@@ -18,6 +18,7 @@ package com.oceanbase.odc.service.flow.task;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
+import org.apache.commons.lang3.Validate;
 import org.flowable.engine.delegate.DelegateExecution;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -28,8 +29,11 @@ import com.oceanbase.odc.core.session.ConnectionSessionUtil;
 import com.oceanbase.odc.core.shared.Verify;
 import com.oceanbase.odc.core.shared.constant.DialectType;
 import com.oceanbase.odc.core.shared.constant.FlowStatus;
+import com.oceanbase.odc.core.shared.constant.ResourceType;
+import com.oceanbase.odc.core.shared.exception.NotFoundException;
 import com.oceanbase.odc.core.sql.split.SqlCommentProcessor;
 import com.oceanbase.odc.metadb.task.TaskEntity;
+import com.oceanbase.odc.metadb.task.TaskRepository;
 import com.oceanbase.odc.service.connection.model.ConnectProperties;
 import com.oceanbase.odc.service.connection.model.ConnectionConfig;
 import com.oceanbase.odc.service.datasecurity.DataMaskingService;
@@ -37,8 +41,10 @@ import com.oceanbase.odc.service.datasecurity.accessor.DatasourceColumnAccessor;
 import com.oceanbase.odc.service.flow.exception.ServiceTaskCancelledException;
 import com.oceanbase.odc.service.flow.exception.ServiceTaskError;
 import com.oceanbase.odc.service.flow.exception.ServiceTaskExpiredException;
+import com.oceanbase.odc.service.flow.model.PreCheckTaskResult;
 import com.oceanbase.odc.service.flow.task.model.DatabaseChangeParameters;
 import com.oceanbase.odc.service.flow.task.model.DatabaseChangeResult;
+import com.oceanbase.odc.service.flow.task.model.FlowTaskProperties;
 import com.oceanbase.odc.service.flow.task.model.RollbackPlanTaskResult;
 import com.oceanbase.odc.service.flow.util.FlowTaskUtil;
 import com.oceanbase.odc.service.objectstorage.ObjectStorageFacade;
@@ -70,6 +76,13 @@ public class DatabaseChangeRuntimeFlowableTask extends BaseODCFlowTaskDelegate<D
     private ObjectStorageFacade objectStorageFacade;
     @Autowired
     private DBSessionManageFacade sessionManageFacade;
+    @Autowired
+    private TaskService taskService;
+    @Autowired
+    private TaskRepository taskRepository;
+    @Autowired
+    private FlowTaskProperties flowTaskProperties;
+    private boolean autoModifyTimeout = false;
 
     @Override
     public boolean cancel(boolean mayInterruptIfRunning, Long taskId, TaskService taskService) {
@@ -101,6 +114,7 @@ public class DatabaseChangeRuntimeFlowableTask extends BaseODCFlowTaskDelegate<D
             }
             result = asyncTaskThread.getResult();
             result.setRollbackPlanResult(rollbackPlanTaskResult);
+            result.setAutoModifyTimeout(this.autoModifyTimeout);
             if (asyncTaskThread.isAbort()) {
                 isFailure = true;
                 taskService.fail(taskId, asyncTaskThread.getProgressPercentage(), result);
@@ -173,6 +187,7 @@ public class DatabaseChangeRuntimeFlowableTask extends BaseODCFlowTaskDelegate<D
     private DatabaseChangeThread generateOdcAsyncTaskThread(Long taskId, DelegateExecution execution) {
         Long creatorId = FlowTaskUtil.getTaskCreator(execution).getId();
         DatabaseChangeParameters parameters = FlowTaskUtil.getAsyncParameter(execution);
+        modifyTimeoutIfInvolveIndexChange(execution, parameters);
         ConnectionConfig connectionConfig = FlowTaskUtil.getConnectionConfig(execution);
         connectionConfig.setQueryTimeoutSeconds((int) TimeUnit.MILLISECONDS.toSeconds(parameters.getTimeoutMillis()));
         DefaultConnectSessionFactory sessionFactory = new DefaultConnectSessionFactory(connectionConfig);
@@ -193,4 +208,23 @@ public class DatabaseChangeRuntimeFlowableTask extends BaseODCFlowTaskDelegate<D
         return returnVal;
     }
 
+    private void modifyTimeoutIfInvolveIndexChange(DelegateExecution execution, DatabaseChangeParameters parameters) {
+        Long taskId = FlowTaskUtil.getTaskId(execution);
+        Long preCheckTaskId = FlowTaskUtil.getPreCheckTaskId(execution);
+        TaskEntity preCheckTask = taskRepository.findById(preCheckTaskId)
+                .orElseThrow(() -> new NotFoundException(ResourceType.ODC_TASK, "taskId", preCheckTaskId));
+
+        PreCheckTaskResult preCheckResult = JsonUtils.fromJson(preCheckTask.getResultJson(), PreCheckTaskResult.class);
+        Validate.notNull(preCheckResult, "Pre check task result can not be null");
+        long autoModifiedTimeout = flowTaskProperties.getIndexChangeMaxTimeoutMillisecond();
+        if (Objects.nonNull(preCheckResult.getSqlCheckResult())
+                && preCheckResult.getSqlCheckResult().isInvolveIndexChange()
+                && autoModifiedTimeout > parameters.getTimeoutMillis()) {
+            this.autoModifyTimeout = true;
+            parameters.setTimeoutMillis(autoModifiedTimeout);
+            TaskEntity databaseChangeTaskEntity = taskService.detail(taskId);
+            databaseChangeTaskEntity.setParametersJson(JsonUtils.toJson(parameters));
+            taskService.updateParametersJson(databaseChangeTaskEntity);
+        }
+    }
 }

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/flow/task/DatabaseChangeRuntimeFlowableTaskCopied.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/flow/task/DatabaseChangeRuntimeFlowableTaskCopied.java
@@ -237,7 +237,7 @@ public class DatabaseChangeRuntimeFlowableTaskCopied extends BaseODCFlowTaskDele
         long autoModifiedTimeout = flowTaskProperties.getIndexChangeMaxTimeoutMillisecond();
 
         if (Objects.nonNull(preCheckResult.getSqlCheckResult())
-                && preCheckResult.getSqlCheckResult().isInvolveTimeConsumingSql()
+                && preCheckResult.getSqlCheckResult().isTimeConsumingSqlExists()
                 && autoModifiedTimeout > parameters.getTimeoutMillis()) {
             parameters.setTimeoutMillis(autoModifiedTimeout);
             taskParameters.setAutoModifyTimeout(true);

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/flow/task/DatabaseChangeRuntimeFlowableTaskCopied.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/flow/task/DatabaseChangeRuntimeFlowableTaskCopied.java
@@ -20,9 +20,11 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.lang3.Validate;
 import org.flowable.engine.delegate.DelegateExecution;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -30,12 +32,18 @@ import com.oceanbase.odc.common.json.JsonUtils;
 import com.oceanbase.odc.core.shared.PreConditions;
 import com.oceanbase.odc.core.shared.constant.ErrorCodes;
 import com.oceanbase.odc.core.shared.constant.FlowStatus;
+import com.oceanbase.odc.core.shared.constant.ResourceType;
 import com.oceanbase.odc.core.shared.constant.TaskType;
+import com.oceanbase.odc.core.shared.exception.NotFoundException;
 import com.oceanbase.odc.metadb.task.JobEntity;
+import com.oceanbase.odc.metadb.task.TaskEntity;
+import com.oceanbase.odc.metadb.task.TaskRepository;
 import com.oceanbase.odc.service.connection.model.ConnectProperties;
 import com.oceanbase.odc.service.connection.model.ConnectionConfig;
+import com.oceanbase.odc.service.flow.model.PreCheckTaskResult;
 import com.oceanbase.odc.service.flow.task.model.DatabaseChangeParameters;
 import com.oceanbase.odc.service.flow.task.model.DatabaseChangeResult;
+import com.oceanbase.odc.service.flow.task.model.FlowTaskProperties;
 import com.oceanbase.odc.service.flow.util.FlowTaskUtil;
 import com.oceanbase.odc.service.objectstorage.ObjectStorageFacade;
 import com.oceanbase.odc.service.objectstorage.model.ObjectMetadata;
@@ -75,6 +83,14 @@ public class DatabaseChangeRuntimeFlowableTaskCopied extends BaseODCFlowTaskDele
     private TaskFrameworkService taskFrameworkService;
     @Autowired
     private TaskFrameworkProperties taskFrameworkProperties;
+    @Autowired
+    private TaskService taskService;
+    @Autowired
+    private TaskRepository taskRepository;
+    @Autowired
+    private FlowTaskProperties flowTaskProperties;
+    private boolean autoModifyTimeout = false;
+
 
     @Override
     public boolean cancel(boolean mayInterruptIfRunning, Long taskId, TaskService taskService) {
@@ -123,6 +139,10 @@ public class DatabaseChangeRuntimeFlowableTaskCopied extends BaseODCFlowTaskDele
         }
         jobEntity = taskFrameworkService.find(jobId);
         result = JsonUtils.fromJson(jobEntity.getResultJson(), DatabaseChangeResult.class);
+        if (this.autoModifyTimeout) {
+            result.setAutoModifyTimeout(true);
+            taskService.updateResult(taskId, result);
+        }
         JobStatus status = jobEntity.getStatus();
         isSuccessful = status == JobStatus.DONE;
         isFailure = !isSuccessful;
@@ -180,7 +200,7 @@ public class DatabaseChangeRuntimeFlowableTaskCopied extends BaseODCFlowTaskDele
         jobData.put(JobParametersKeyConstants.FLOW_INSTANCE_ID, FlowTaskUtil.getFlowInstanceId(execution) + "");
         jobData.put(JobParametersKeyConstants.CURRENT_SCHEMA, FlowTaskUtil.getSchemaName(execution));
         jobData.put(JobParametersKeyConstants.SESSION_TIME_ZONE, connectProperties.getDefaultTimeZone());
-        jobData.put(JobParametersKeyConstants.TASK_EXECUTION_TIMEOUT_MILLIS, parameters.getTimeoutMillis() + "");
+        modifyTimeoutIfInvolveIndexChange(execution, parameters, jobData);
         if (CollectionUtils.isNotEmpty(parameters.getSqlObjectIds())) {
             List<ObjectMetadata> objectMetadatas = new ArrayList<>();
             for (String objectId : parameters.getSqlObjectIds()) {
@@ -196,6 +216,31 @@ public class DatabaseChangeRuntimeFlowableTaskCopied extends BaseODCFlowTaskDele
                 .jobType(TaskType.ASYNC.name())
                 .jobParameters(jobData)
                 .build();
+    }
+
+    private void modifyTimeoutIfInvolveIndexChange(DelegateExecution execution, DatabaseChangeParameters parameters,
+            Map<String, String> jobData) {
+        Long taskId = FlowTaskUtil.getTaskId(execution);
+        Long preCheckTaskId = FlowTaskUtil.getPreCheckTaskId(execution);
+        TaskEntity preCheckTask = taskRepository.findById(preCheckTaskId)
+                .orElseThrow(() -> new NotFoundException(ResourceType.ODC_TASK, "taskId", preCheckTaskId));
+
+        PreCheckTaskResult preCheckResult = JsonUtils.fromJson(preCheckTask.getResultJson(), PreCheckTaskResult.class);
+        Validate.notNull(preCheckResult, "Pre check task result can not be null");
+        long autoModifiedTimeout = flowTaskProperties.getIndexChangeMaxTimeoutMillisecond();
+
+        if (Objects.nonNull(preCheckResult.getSqlCheckResult())
+                && preCheckResult.getSqlCheckResult().isInvolveIndexChange()
+                && autoModifiedTimeout > parameters.getTimeoutMillis()) {
+            this.autoModifyTimeout = true;
+            parameters.setTimeoutMillis(autoModifiedTimeout);
+            jobData.put(JobParametersKeyConstants.TASK_EXECUTION_TIMEOUT_MILLIS, autoModifiedTimeout + "");
+            TaskEntity databaseChangeTaskEntity = taskService.detail(taskId);
+            databaseChangeTaskEntity.setParametersJson(JsonUtils.toJson(parameters));
+            taskService.updateParametersJson(databaseChangeTaskEntity);
+        } else {
+            jobData.put(JobParametersKeyConstants.TASK_EXECUTION_TIMEOUT_MILLIS, parameters.getTimeoutMillis() + "");
+        }
     }
 
 }

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/flow/task/model/DatabaseChangeResult.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/flow/task/model/DatabaseChangeResult.java
@@ -38,4 +38,5 @@ public class DatabaseChangeResult implements FlowTaskResult {
     private Long resultPreviewMaxSizeBytes;
     private String errorRecordsFilePath;
     private RollbackPlanTaskResult rollbackPlanResult;
+    private boolean autoModifyTimeout;
 }

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/flow/task/model/FlowTaskProperties.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/flow/task/model/FlowTaskProperties.java
@@ -50,4 +50,7 @@ public class FlowTaskProperties {
 
     @Value("${odc.task.async.rollback.max-rollback-content-size-bytes:268435456}")
     private long maxRollbackContentSizeBytes;
+
+    @Value("${odc.task.async.index-change-max-timeout-millis:432000000}")
+    private long indexChangeMaxTimeoutMillisecond;
 }

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/flow/task/model/SqlCheckTaskResult.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/flow/task/model/SqlCheckTaskResult.java
@@ -48,10 +48,10 @@ public class SqlCheckTaskResult implements Serializable, FlowTaskResult {
     private String error;
     private String fileName;
     private List<CheckResult> results = new ArrayList<>();
-    private boolean involveTimeConsumingSql;
+    private boolean timeConsumingSqlExists;
 
     public static SqlCheckTaskResult success(@NonNull List<CheckViolation> violations,
-            @NonNull boolean involveTimeConsumingSql) {
+            @NonNull boolean timeConsumingSqlExists) {
         SqlCheckTaskResult result = new SqlCheckTaskResult();
         result.setSuccess(true);
         result.setIssueCount(violations.size());
@@ -60,7 +60,7 @@ public class SqlCheckTaskResult implements Serializable, FlowTaskResult {
         Optional<CheckViolation> v = violations.stream()
                 .max(Comparator.comparingInt(CheckViolation::getLevel));
         result.setMaxLevel(v.isPresent() ? v.get().getLevel() : 0);
-        result.setInvolveTimeConsumingSql(involveTimeConsumingSql);
+        result.setTimeConsumingSqlExists(timeConsumingSqlExists);
         return result;
     }
 

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/flow/task/model/SqlCheckTaskResult.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/flow/task/model/SqlCheckTaskResult.java
@@ -48,9 +48,10 @@ public class SqlCheckTaskResult implements Serializable, FlowTaskResult {
     private String error;
     private String fileName;
     private List<CheckResult> results = new ArrayList<>();
+    private boolean involveIndexChange;
 
-    public static SqlCheckTaskResult success(
-            @NonNull List<CheckViolation> violations) {
+    public static SqlCheckTaskResult success(@NonNull List<CheckViolation> violations,
+            @NonNull boolean involveIndexChange) {
         SqlCheckTaskResult result = new SqlCheckTaskResult();
         result.setSuccess(true);
         result.setIssueCount(violations.size());
@@ -59,6 +60,7 @@ public class SqlCheckTaskResult implements Serializable, FlowTaskResult {
         Optional<CheckViolation> v = violations.stream()
                 .max(Comparator.comparingInt(CheckViolation::getLevel));
         result.setMaxLevel(v.isPresent() ? v.get().getLevel() : 0);
+        result.setInvolveIndexChange(involveIndexChange);
         return result;
     }
 

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/flow/task/model/SqlCheckTaskResult.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/flow/task/model/SqlCheckTaskResult.java
@@ -48,10 +48,10 @@ public class SqlCheckTaskResult implements Serializable, FlowTaskResult {
     private String error;
     private String fileName;
     private List<CheckResult> results = new ArrayList<>();
-    private boolean involveIndexChange;
+    private boolean involveTimeConsumingSql;
 
     public static SqlCheckTaskResult success(@NonNull List<CheckViolation> violations,
-            @NonNull boolean involveIndexChange) {
+            @NonNull boolean involveTimeConsumingSql) {
         SqlCheckTaskResult result = new SqlCheckTaskResult();
         result.setSuccess(true);
         result.setIssueCount(violations.size());
@@ -60,7 +60,7 @@ public class SqlCheckTaskResult implements Serializable, FlowTaskResult {
         Optional<CheckViolation> v = violations.stream()
                 .max(Comparator.comparingInt(CheckViolation::getLevel));
         result.setMaxLevel(v.isPresent() ? v.get().getLevel() : 0);
-        result.setInvolveIndexChange(involveIndexChange);
+        result.setInvolveTimeConsumingSql(involveTimeConsumingSql);
         return result;
     }
 

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/sqlcheck/SqlCheckService.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/sqlcheck/SqlCheckService.java
@@ -94,7 +94,7 @@ public class SqlCheckService {
     }
 
     public List<CheckViolation> check(@NotNull Long environmentId, @NonNull String databaseName,
-            @NotNull List<OffsetString> sqls, @NotNull ConnectionConfig config) {
+            @NotNull List<OffsetString> sqls, @NotNull ConnectionConfig config, List<SqlCheckRule> defaultRules) {
         if (CollectionUtils.isEmpty(sqls)) {
             return Collections.emptyList();
         }
@@ -106,6 +106,9 @@ public class SqlCheckService {
         try (SingleConnectionDataSource dataSource = (SingleConnectionDataSource) factory.getDataSource()) {
             JdbcTemplate jdbc = new JdbcTemplate(dataSource);
             List<SqlCheckRule> checkRules = getRules(rules, config.getDialectType(), jdbc);
+            if (!CollectionUtils.isEmpty(defaultRules)) {
+                checkRules.addAll(defaultRules);
+            }
             DefaultSqlChecker sqlChecker = new DefaultSqlChecker(config.getDialectType(), null, checkRules);
             List<CheckViolation> checkViolations = new ArrayList<>();
             for (OffsetString sql : sqls) {

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/sqlcheck/model/SqlCheckRuleType.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/sqlcheck/model/SqlCheckRuleType.java
@@ -231,7 +231,11 @@ public enum SqlCheckRuleType implements Translatable {
     /**
      * 限制被声明为 auto-increment 的列的类型
      */
-    RESTRICT_AUTO_INCREMENT_DATATYPES("restrict-auto-increment-datatypes");
+    RESTRICT_AUTO_INCREMENT_DATATYPES("restrict-auto-increment-datatypes"),
+    /**
+     * 表的 DDL 中涉及创建、修改索引的耗时操作
+     */
+    INDEX_CHANGE_TIME_CONSUMING_EXISTS("index-change-time-consuming-exists");
 
     private final String name;
     private static final String NAME_CODE = "name";

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/sqlcheck/rule/IndexChangeTimeConsumingExists.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/sqlcheck/rule/IndexChangeTimeConsumingExists.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2023 OceanBase.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.oceanbase.odc.service.sqlcheck.rule;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import com.oceanbase.odc.core.shared.constant.DialectType;
+import com.oceanbase.odc.service.sqlcheck.SqlCheckContext;
+import com.oceanbase.odc.service.sqlcheck.SqlCheckRule;
+import com.oceanbase.odc.service.sqlcheck.SqlCheckUtil;
+import com.oceanbase.odc.service.sqlcheck.model.CheckViolation;
+import com.oceanbase.odc.service.sqlcheck.model.SqlCheckRuleType;
+import com.oceanbase.tools.sqlparser.statement.Statement;
+import com.oceanbase.tools.sqlparser.statement.alter.table.AlterTable;
+import com.oceanbase.tools.sqlparser.statement.createindex.CreateIndex;
+import com.oceanbase.tools.sqlparser.statement.createtable.OutOfLineConstraint;
+
+import lombok.NonNull;
+
+/**
+ * {@link IndexChangeTimeConsumingExists}
+ *
+ * @author jingtian
+ * @date 2024/2/19
+ * @since ODC_release_4.2.4
+ */
+public class IndexChangeTimeConsumingExists implements SqlCheckRule {
+
+    @Override
+    public SqlCheckRuleType getType() {
+        return SqlCheckRuleType.INDEX_CHANGE_TIME_CONSUMING_EXISTS;
+    }
+
+    @Override
+    public List<DialectType> getSupportsDialectTypes() {
+        return Arrays.asList(DialectType.MYSQL, DialectType.OB_MYSQL, DialectType.OB_ORACLE,
+                DialectType.ODP_SHARDING_OB_MYSQL);
+    }
+
+    @Override
+    public List<CheckViolation> check(@NonNull Statement statement, @NonNull SqlCheckContext context) {
+        if (statement instanceof AlterTable) {
+            return ((AlterTable) statement).getAlterTableActions().stream().filter(action -> {
+                if (action.getAddIndex() != null || action.getModifyPrimaryKey() != null) {
+                    return true;
+                } else if (action.getAddConstraint() != null) {
+                    OutOfLineConstraint addConstraint = action.getAddConstraint();
+                    return addConstraint.isPrimaryKey() || addConstraint.isUniqueKey();
+                } else {
+                    return false;
+                }
+            }).collect(Collectors.toList()).stream().map(action -> SqlCheckUtil.buildViolation(statement.getText(),
+                    statement, getType(), new Object[] {})).collect(Collectors.toList());
+        } else if (statement instanceof CreateIndex) {
+            return Collections.singletonList(
+                    SqlCheckUtil.buildViolation(statement.getText(), statement, getType(), new Object[] {}));
+        }
+        return Collections.emptyList();
+    }
+}

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/task/executor/task/DatabaseChangeTask.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/task/executor/task/DatabaseChangeTask.java
@@ -313,7 +313,7 @@ public class DatabaseChangeTask extends BaseTask<FlowTaskResult> {
         taskResult.setJsonFileName(jsonFileName);
         taskResult.setContainQuery(containQuery);
         taskResult.setErrorRecordsFilePath(errorRecordsFilePath);
-        taskResult.setAutoModifyTimeout(false);
+        taskResult.setAutoModifyTimeout(parameters.isAutoModifyTimeout());
         return taskResult;
     }
 

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/task/executor/task/DatabaseChangeTask.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/task/executor/task/DatabaseChangeTask.java
@@ -279,6 +279,7 @@ public class DatabaseChangeTask extends BaseTask<FlowTaskResult> {
         taskResult.setJsonFileName(jsonFileName);
         taskResult.setContainQuery(containQuery);
         taskResult.setErrorRecordsFilePath(errorRecordsFilePath);
+        taskResult.setAutoModifyTimeout(false);
         return taskResult;
     }
 

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/task/runtime/DatabaseChangeTaskParameters.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/task/runtime/DatabaseChangeTaskParameters.java
@@ -53,5 +53,9 @@ public class DatabaseChangeTaskParameters {
      * Whether data masking is needed
      */
     private boolean needDataMasking;
+    /**
+     * Whether the task's timeout period is automatically modified
+     */
+    private boolean autoModifyTimeout;
 
 }

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/task/runtime/PreCheckTask.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/task/runtime/PreCheckTask.java
@@ -70,6 +70,8 @@ import com.oceanbase.odc.service.sqlcheck.SqlCheckContext;
 import com.oceanbase.odc.service.sqlcheck.SqlCheckRule;
 import com.oceanbase.odc.service.sqlcheck.SqlCheckRuleFactory;
 import com.oceanbase.odc.service.sqlcheck.model.CheckViolation;
+import com.oceanbase.odc.service.sqlcheck.model.SqlCheckRuleType;
+import com.oceanbase.odc.service.sqlcheck.rule.IndexChangeTimeConsumingExists;
 import com.oceanbase.odc.service.sqlcheck.rule.SqlCheckRules;
 import com.oceanbase.odc.service.task.caller.JobContext;
 import com.oceanbase.odc.service.task.constants.JobParametersKeyConstants;
@@ -125,7 +127,15 @@ public class PreCheckTask extends BaseTask<FlowTaskResult> {
                 log.info("Database permission check successfully, taskId={}", taskId);
             }
             this.permissionCheckResult = new DatabasePermissionCheckResult(unauthorizedDatabases);
-            this.sqlCheckResult = SqlCheckTaskResult.success(violations);
+            if (violations.stream().filter(Objects::nonNull)
+                    .anyMatch(v -> v.getType() == SqlCheckRuleType.INDEX_CHANGE_TIME_CONSUMING_EXISTS)) {
+                violations = violations.stream()
+                        .filter(v -> v.getType() != SqlCheckRuleType.INDEX_CHANGE_TIME_CONSUMING_EXISTS)
+                        .collect(Collectors.toList());
+                this.sqlCheckResult = SqlCheckTaskResult.success(violations, true);
+            } else {
+                this.sqlCheckResult = SqlCheckTaskResult.success(violations, false);
+            }
             this.success = true;
             log.info("Pre-check task end up running, task id: {}", taskId);
         } finally {
@@ -273,6 +283,7 @@ public class PreCheckTask extends BaseTask<FlowTaskResult> {
         try (SingleConnectionDataSource dataSource = (SingleConnectionDataSource) factory.getDataSource()) {
             JdbcTemplate jdbc = new JdbcTemplate(dataSource);
             List<SqlCheckRule> checkRules = getRules(rules, config.getDialectType(), jdbc);
+            checkRules.add(new IndexChangeTimeConsumingExists());
             DefaultSqlChecker sqlChecker = new DefaultSqlChecker(config.getDialectType(), null, checkRules);
             List<CheckViolation> checkViolations = new ArrayList<>();
             for (OffsetString sql : sqls) {

--- a/server/odc-service/src/test/java/com/oceanbase/odc/service/sqlcheck/MySQLCheckerTest.java
+++ b/server/odc-service/src/test/java/com/oceanbase/odc/service/sqlcheck/MySQLCheckerTest.java
@@ -35,6 +35,7 @@ import com.oceanbase.odc.service.sqlcheck.rule.ColumnCharsetExists;
 import com.oceanbase.odc.service.sqlcheck.rule.ColumnCollationExists;
 import com.oceanbase.odc.service.sqlcheck.rule.ColumnNameInBlackList;
 import com.oceanbase.odc.service.sqlcheck.rule.ForeignConstraintExists;
+import com.oceanbase.odc.service.sqlcheck.rule.IndexChangeTimeConsumingExists;
 import com.oceanbase.odc.service.sqlcheck.rule.MySQLColumnCalculation;
 import com.oceanbase.odc.service.sqlcheck.rule.MySQLLeftFuzzyMatch;
 import com.oceanbase.odc.service.sqlcheck.rule.MySQLMissingRequiredColumns;
@@ -1299,6 +1300,20 @@ public class MySQLCheckerTest {
         List<CheckViolation> expect = Collections.singletonList(c1);
         Assert.assertEquals(expect, actual);
     }
+
+    @Test
+    public void check_timeConsumingIndexChangeExists_violationGenerated() {
+        String sql = "alter table tab add unique index uq_idx(c1)";
+        SqlChecker sqlChecker = new DefaultSqlChecker(DialectType.OB_MYSQL, ";",
+                Collections.singletonList(new IndexChangeTimeConsumingExists()));
+        List<CheckViolation> actual = sqlChecker.check(sql);
+
+        CheckViolation c = new CheckViolation(sql, 1, 0, 0, 42,
+                SqlCheckRuleType.INDEX_CHANGE_TIME_CONSUMING_EXISTS, 0, new Object[] {});
+        List<CheckViolation> expect = Collections.singletonList(c);
+        Assert.assertEquals(expect, actual);
+    }
+
 
     private String joinAndAppend(String[] sqls, String delimiter) {
         return String.join(delimiter, sqls) + delimiter;

--- a/server/odc-service/src/test/java/com/oceanbase/odc/service/sqlcheck/OracleSqlCheckerTest.java
+++ b/server/odc-service/src/test/java/com/oceanbase/odc/service/sqlcheck/OracleSqlCheckerTest.java
@@ -36,6 +36,7 @@ import com.oceanbase.odc.service.sqlcheck.rule.ColumnCharsetExists;
 import com.oceanbase.odc.service.sqlcheck.rule.ColumnCollationExists;
 import com.oceanbase.odc.service.sqlcheck.rule.ColumnNameInBlackList;
 import com.oceanbase.odc.service.sqlcheck.rule.ForeignConstraintExists;
+import com.oceanbase.odc.service.sqlcheck.rule.IndexChangeTimeConsumingExists;
 import com.oceanbase.odc.service.sqlcheck.rule.NoDefaultValueExists;
 import com.oceanbase.odc.service.sqlcheck.rule.NoIndexNameExists;
 import com.oceanbase.odc.service.sqlcheck.rule.NoPrimaryKeyExists;
@@ -1164,6 +1165,19 @@ public class OracleSqlCheckerTest {
         CheckResult r1 = new CheckResult("1", Arrays.asList(c1, c3));
         CheckResult r2 = new CheckResult("2", Collections.singletonList(c2));
         List<CheckResult> expect = Arrays.asList(r1, r2);
+        Assert.assertEquals(expect, actual);
+    }
+
+    @Test
+    public void check_timeConsumingIndexChangeExists_violationGenerated() {
+        String sql = "alter table tab modify primary key(c1,c2)";
+        SqlChecker sqlChecker = new DefaultSqlChecker(DialectType.OB_ORACLE, ";",
+                Collections.singletonList(new IndexChangeTimeConsumingExists()));
+        List<CheckViolation> actual = sqlChecker.check(sql);
+
+        CheckViolation c = new CheckViolation(sql, 1, 0, 0, 40,
+                SqlCheckRuleType.INDEX_CHANGE_TIME_CONSUMING_EXISTS, 0, new Object[] {});
+        List<CheckViolation> expect = Collections.singletonList(c);
         Assert.assertEquals(expect, actual);
     }
 


### PR DESCRIPTION
#### What type of PR is this?
type-feature
module-database change

#### What this PR does / why we need it:
Automatically adjust the timeout if the database change task involves time-consuming index change operations.
1. create `IndexChangeTimeConsumingExists` to check if sqls involve time-consuming operations like creating index and modifying primary key. This SQL check result should not be displayed to the user, so this check result will be filtered out at the end.
2. if involves, `SqlCheckTaskResult#timeConsumingSqlExists` will be true, and `DatabaseChangeResult#isAutoModifyTimeout` will be true.

`ServiceTaskInstanceRepository#findByFlowInstanceId` is a bug, it would return multiple rows of data，But this method is not actually called. Delete this method.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #772 

#### Special notes for your reviewer:

<!--
This section is used to describe how this PR is implemented. 
If this is a PR that fixes a bug, this section describes how the bug was fixed.
If it's a new feature, this section briefly describes how to implement the new feature.
etc.
-->

#### Additional documentation e.g., usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```