### PR TITLE
fix(database-permission): DB permission interceptor invalid when executing PL in the SQL console

### DIFF
--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/session/util/SchemaExtractor.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/session/util/SchemaExtractor.java
@@ -43,7 +43,12 @@ import com.oceanbase.tools.sqlparser.obmysql.OBParser.Normal_relation_factorCont
 import com.oceanbase.tools.sqlparser.obmysql.OBParser.Relation_factorContext;
 import com.oceanbase.tools.sqlparser.obmysql.OBParser.Relation_factor_with_starContext;
 import com.oceanbase.tools.sqlparser.obmysql.OBParserBaseVisitor;
+import com.oceanbase.tools.sqlparser.obmysql.PLParser.IdentContext;
+import com.oceanbase.tools.sqlparser.obmysql.PLParser.Sp_nameContext;
+import com.oceanbase.tools.sqlparser.obmysql.PLParserBaseVisitor;
 import com.oceanbase.tools.sqlparser.oboracle.OBParser;
+import com.oceanbase.tools.sqlparser.oboracle.PLParser.IdentifierContext;
+import com.oceanbase.tools.sqlparser.oboracle.PLParser.Pl_schema_nameContext;
 import com.oceanbase.tools.sqlparser.statement.common.RelationFactor;
 
 import lombok.Getter;
@@ -115,10 +120,18 @@ public class SchemaExtractor {
     }
 
     private static Set<String> listSchemaNames(AbstractSyntaxTree ast, String defaultSchema, DialectType dialectType) {
+        List<RelationFactor> relationFactorList;
+        BasicResult basicResult = ast.getParseResult();
         if (dialectType.isMysql() || dialectType.isDoris()) {
-            OBMySQLRelationFactorVisitor visitor = new OBMySQLRelationFactorVisitor();
-            visitor.visit(ast.getRoot());
-            List<RelationFactor> relationFactorList = visitor.getRelationFactorList();
+            if (basicResult.isPlDdl()) {
+                OBMySQLPLRelationFactorVisitor visitor = new OBMySQLPLRelationFactorVisitor();
+                visitor.visit(ast.getRoot());
+                relationFactorList = visitor.getRelationFactorList();
+            } else {
+                OBMySQLRelationFactorVisitor visitor = new OBMySQLRelationFactorVisitor();
+                visitor.visit(ast.getRoot());
+                relationFactorList = visitor.getRelationFactorList();
+            }
             return relationFactorList.stream()
                     .filter(r -> StringUtils.isBlank(r.getUserVariable()))
                     .map(r -> {
@@ -127,9 +140,15 @@ public class SchemaExtractor {
                     })
                     .filter(Objects::nonNull).collect(Collectors.toSet());
         } else if (dialectType.isOracle()) {
-            OBOracleRelationFactorVisitor visitor = new OBOracleRelationFactorVisitor();
-            visitor.visit(ast.getRoot());
-            List<RelationFactor> relationFactorList = visitor.getRelationFactorList();
+            if (basicResult.isPlDdl()) {
+                OBOraclePLRelationFactorVisitor visitor = new OBOraclePLRelationFactorVisitor();
+                visitor.visit(ast.getRoot());
+                relationFactorList = visitor.getRelationFactorList();
+            } else {
+                OBOracleRelationFactorVisitor visitor = new OBOracleRelationFactorVisitor();
+                visitor.visit(ast.getRoot());
+                relationFactorList = visitor.getRelationFactorList();
+            }
             return relationFactorList.stream()
                     .filter(r -> StringUtils.isBlank(r.getUserVariable()))
                     .map(r -> {
@@ -143,8 +162,9 @@ public class SchemaExtractor {
         return new HashSet<>();
     }
 
+    @Getter
     private static class OBMySQLRelationFactorVisitor extends OBParserBaseVisitor<RelationFactor> {
-        @Getter
+
         private final List<RelationFactor> relationFactorList = new ArrayList<>();
 
         @Override
@@ -185,9 +205,10 @@ public class SchemaExtractor {
         }
     }
 
+    @Getter
     private static class OBOracleRelationFactorVisitor extends
             com.oceanbase.tools.sqlparser.oboracle.OBParserBaseVisitor<RelationFactor> {
-        @Getter
+
         private final List<RelationFactor> relationFactorList = new ArrayList<>();
 
         @Override
@@ -215,6 +236,60 @@ public class SchemaExtractor {
             relationFactorList.add(relationFactor);
             return null;
         }
+    }
+
+
+    @Getter
+    private static class OBMySQLPLRelationFactorVisitor extends PLParserBaseVisitor<RelationFactor> {
+
+        private final List<RelationFactor> relationFactorList = new ArrayList<>();
+
+        @Override
+        public RelationFactor visitSp_name(Sp_nameContext ctx) {
+            List<IdentContext> idents = ctx.ident();
+            if (idents.size() == 1) {
+                relationFactorList.add(new RelationFactor(idents.get(0).getText()));
+            } else if (idents.size() == 2) {
+                RelationFactor relationFactor = new RelationFactor(idents.get(1).getText());
+                relationFactor.setSchema(idents.get(0).getText());
+                relationFactorList.add(relationFactor);
+            }
+            return null;
+        }
+
+    }
+
+    @Getter
+    private static class OBOraclePLRelationFactorVisitor
+            extends com.oceanbase.tools.sqlparser.oboracle.PLParserBaseVisitor<RelationFactor> {
+
+        private final List<RelationFactor> relationFactorList = new ArrayList<>();
+
+        @Override
+        public RelationFactor visitPl_schema_name(Pl_schema_nameContext ctx) {
+            List<IdentifierContext> identifiers = ctx.identifier();
+            if (identifiers.size() == 1) {
+                relationFactorList.add(new RelationFactor(identifiers.get(0).getText()));
+            } else if (identifiers.size() == 2) {
+                RelationFactor relationFactor = new RelationFactor(identifiers.get(1).getText());
+                relationFactor.setSchema(identifiers.get(0).getText());
+                relationFactorList.add(relationFactor);
+            }
+            return null;
+        }
+
+    }
+
+    public static void main(String[] args) {
+        String sql = "CREATE OR REPLACE FUNCTION SCHEMA_NAME.INCREMENT_BY_ONE (INPUT_NUMBER IN NUMBER)\n"
+                + "RETURN NUMBER IS\n"
+                + "BEGIN\n"
+                + "  RETURN INPUT_NUMBER + 1;\n"
+                + "END INCREMENT_BY_ONE;";
+        AbstractSyntaxTreeFactory factory = AbstractSyntaxTreeFactories.getAstFactory(DialectType.OB_ORACLE, 0);
+        AbstractSyntaxTree ast = factory.buildAst(sql);
+        Set<String> schemaNames = listSchemaNames(ast, "schema_name2", DialectType.OB_ORACLE);
+        System.out.println(schemaNames);
     }
 
 }

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/session/util/SchemaExtractor.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/session/util/SchemaExtractor.java
@@ -280,16 +280,4 @@ public class SchemaExtractor {
 
     }
 
-    public static void main(String[] args) {
-        String sql = "CREATE OR REPLACE FUNCTION SCHEMA_NAME.INCREMENT_BY_ONE (INPUT_NUMBER IN NUMBER)\n"
-                + "RETURN NUMBER IS\n"
-                + "BEGIN\n"
-                + "  RETURN INPUT_NUMBER + 1;\n"
-                + "END INCREMENT_BY_ONE;";
-        AbstractSyntaxTreeFactory factory = AbstractSyntaxTreeFactories.getAstFactory(DialectType.OB_ORACLE, 0);
-        AbstractSyntaxTree ast = factory.buildAst(sql);
-        Set<String> schemaNames = listSchemaNames(ast, "schema_name2", DialectType.OB_ORACLE);
-        System.out.println(schemaNames);
-    }
-
 }

--- a/server/odc-service/src/test/java/com/oceanbase/odc/service/session/SchemaExtractorTest.java
+++ b/server/odc-service/src/test/java/com/oceanbase/odc/service/session/SchemaExtractorTest.java
@@ -88,4 +88,52 @@ public class SchemaExtractorTest {
         Assert.assertTrue(actual.isEmpty());
     }
 
+    @Test
+    public void testMySQL_ListSchemaNames_PL_Function() {
+        String sql = "create function `schema_name`.`func` (\n"
+                + "\t`str1` varchar ( 45 ),\n"
+                + "\t`str2` varchar ( 45 )) returns varchar ( 128 ) begin\n"
+                + "return ( select concat( str1, str2 ) from dual );\n"
+                + "end;";
+        Set<String> actual = SchemaExtractor.listSchemaNames(Arrays.asList(sql), DialectType.OB_MYSQL, "default");
+        Set<String> expect = Collections.singleton("schema_name");
+        Assert.assertEquals(expect, actual);
+    }
+
+    @Test
+    public void testMySQL_ListSchemaNames_PL_Function_UseDefaultSchema() {
+        String sql = "CREATE FUNCTION `func` (\n"
+                + "\t`str1` VARCHAR ( 45 ),\n"
+                + "\t`str2` VARCHAR ( 45 )) RETURNS VARCHAR ( 128 ) BEGIN\n"
+                + "RETURN ( SELECT concat( str1, str2 ) FROM DUAL );\n"
+                + "END;";
+        Set<String> actual = SchemaExtractor.listSchemaNames(Arrays.asList(sql), DialectType.OB_MYSQL, "default");
+        Set<String> expect = Collections.singleton("default");
+        Assert.assertEquals(expect, actual);
+    }
+
+    @Test
+    public void testOracle_ListSchemaNames_PL_Function() {
+        String sql = "CREATE OR REPLACE FUNCTION SCHEMA_NAME.INCREMENT_BY_ONE (INPUT_NUMBER IN NUMBER)\n"
+                + "RETURN NUMBER IS\n"
+                + "BEGIN\n"
+                + "  RETURN INPUT_NUMBER + 1;\n"
+                + "END INCREMENT_BY_ONE;";
+        Set<String> actual = SchemaExtractor.listSchemaNames(Arrays.asList(sql), DialectType.OB_ORACLE, "DEFAULT");
+        Set<String> expect = Collections.singleton("SCHEMA_NAME");
+        Assert.assertEquals(expect, actual);
+    }
+
+    @Test
+    public void testOracle_ListSchemaNames_PL_Function_UseDefaultSchema() {
+        String sql = "CREATE OR REPLACE FUNCTION INCREMENT_BY_ONE (INPUT_NUMBER IN NUMBER)\n"
+                + "RETURN NUMBER IS\n"
+                + "BEGIN\n"
+                + "  RETURN INPUT_NUMBER + 1;\n"
+                + "END INCREMENT_BY_ONE;";
+        Set<String> actual = SchemaExtractor.listSchemaNames(Arrays.asList(sql), DialectType.OB_ORACLE, "DEFAULT");
+        Set<String> expect = Collections.singleton("DEFAULT");
+        Assert.assertEquals(expect, actual);
+    }
+
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines.
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request.
3. Ensure you have added or ran the appropriate tests for your PR.
5. If the PR is unfinished, you may add or remove a WIP or [WIP] prefix to your pull request title.
-->

#### What type of PR is this?
type-bug
module-database permission

#### What this PR does / why we need it:
When user has no DB `change` permission, and executing a PL/SQL in SQL  console such as:
```sql
CREATE FUNCTION `gaoda_test_data`.`func2` (
	`str1` VARCHAR ( 45 ),
	`str2` VARCHAR ( 45 )) RETURNS VARCHAR ( 128 ) BEGIN
RETURN ( SELECT concat( str1, str2 ) FROM DUAL );
END;
```
Then the DB permission interceptor will be invalid, the SQL will be executed.

The root cause is that the `SchemaExtractor` does not care about PL/SQL, this PR add these solution and fix this bug.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1581 

#### Special notes for your reviewer:

<!--
This section is used to describe how this PR is implemented. 
If this is a PR that fixes a bug, this section describes how the bug was fixed.
If it's a new feature, this section briefly describes how to implement the new feature.
etc.
-->

#### Additional documentation e.g., usage docs, etc.:
Slef-test passed. 
Note that if the database is accessed from within PL, it may not be detected.

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```