### PR TITLE
fix(integration): garbled code exists when using Chinese in request body

### DIFF
--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/integration/HttpOperationService.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/integration/HttpOperationService.java
@@ -16,19 +16,19 @@
 package com.oceanbase.odc.service.integration;
 
 import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
 
-import org.apache.http.HttpEntity;
 import org.apache.http.NameValuePair;
 import org.apache.http.client.config.RequestConfig;
-import org.apache.http.client.entity.EntityBuilder;
 import org.apache.http.client.entity.UrlEncodedFormEntity;
 import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.client.methods.RequestBuilder;
+import org.apache.http.entity.StringEntity;
 import org.apache.http.message.BasicNameValuePair;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -105,8 +105,8 @@ public class HttpOperationService {
             if (type == BodyType.RAW) {
                 String json = variables.process((String) body.getContent());
                 String encryptedBody = EncryptionUtil.encrypt(json, encryption);
-                HttpEntity entity = EntityBuilder.create().setText(encryptedBody).build();
-                builder.setEntity(entity);
+                StringEntity stringEntity = new StringEntity(encryptedBody, StandardCharsets.UTF_8);
+                builder.setEntity(stringEntity);
             } else if (type == BodyType.FORM_DATA) {
                 Map<String, Object> formData = (Map<String, Object>) body.getContent();
                 List<NameValuePair> paramList = new ArrayList<>();


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines.
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request.
3. Ensure you have added or ran the appropriate tests for your PR.
5. If the PR is unfinished, you may add or remove a WIP or [WIP] prefix to your pull request title.
-->

#### What type of PR is this?
type-bug
type-external integration

#### What this PR does / why we need it:
There is a bug: Garbled code exists when using Chinese in request body of external integration configuration.

Root cause: When the content-type is RAW, then we build HTTP request entity through `EntityBuilder.create().setText(encryptedBody).build()`. Then the default charset is `ISO_8859_1` rather than `UTF_8` causing garbled code for Chinese.

This PR fix it by using `StringEntity(bodyString, StandardCharsets.UTF_8)`.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1624 

#### Special notes for your reviewer:
Self-test Passed.
<!--
This section is used to describe how this PR is implemented. 
If this is a PR that fixes a bug, this section describes how the bug was fixed.
If it's a new feature, this section briefly describes how to implement the new feature.
etc.
-->

#### Additional documentation e.g., usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```