### PR TITLE
enhancement(db-browser): return all SchemaIdentities even the schema has no tables or views

### DIFF
--- a/libs/db-browser/src/main/java/com/oceanbase/tools/dbbrowser/schema/mysql/MySQLNoGreaterThan5740SchemaAccessor.java
+++ b/libs/db-browser/src/main/java/com/oceanbase/tools/dbbrowser/schema/mysql/MySQLNoGreaterThan5740SchemaAccessor.java
@@ -214,14 +214,7 @@ public class MySQLNoGreaterThan5740SchemaAccessor implements DBSchemaAccessor {
 
     @Override
     public List<DBObjectIdentity> listTables(String schemaName, String tableNameLike) {
-        List<DBObjectIdentity> results = new ArrayList<>();
-        try {
-            results.addAll(listBaseTables(schemaName, tableNameLike));
-        } catch (Exception e) {
-            log.warn("List base tables failed, reason={}", e.getMessage());
-        }
-
-        return results;
+        return listBaseTables(schemaName, tableNameLike);
     }
 
     protected List<DBObjectIdentity> listBaseTables(String schemaName, String tableNameLike)

--- a/libs/db-browser/src/main/java/com/oceanbase/tools/dbbrowser/schema/mysql/OBMySQLSchemaAccessor.java
+++ b/libs/db-browser/src/main/java/com/oceanbase/tools/dbbrowser/schema/mysql/OBMySQLSchemaAccessor.java
@@ -124,6 +124,9 @@ public class OBMySQLSchemaAccessor extends MySQLNoGreaterThan5740SchemaAccessor 
         } catch (Exception e) {
             log.warn("List system tables from 'oceanbase' failed, reason={}", e.getMessage());
         }
+        String queryMysqlTable = "show full tables from `mysql`";
+        jdbcOperations.query(queryMysqlTable,
+                (rs, num) -> results.add(DBObjectIdentity.of("mysql", DBObjectType.TABLE, rs.getString(1))));
         return results;
     }
 

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/db/DBIdentitiesService.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/db/DBIdentitiesService.java
@@ -47,6 +47,7 @@ public class DBIdentitiesService {
         if (types.contains(DBObjectType.TABLE)) {
             listTables(schemaAccessor, all);
         }
+        schemaAccessor.showDatabases().forEach(db -> all.computeIfAbsent(db, SchemaIdentities::of));
         return new ArrayList<>(all.values());
     }
 


### PR DESCRIPTION


#### What type of PR is this?
type-enhancement
type-bug

#### What this PR does / why we need it:
1. `DBIdentitiesService#list` return all SchemaIdentities even the schema has no tables or views
2. fix `DBSchemaAccessor#listTables` do not return tables in `mysql` schema, because we can not get tables in `mysql` by query `information_schema.tables `in ob mysql mode

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1628 
Fixes #1428 

#### Special notes for your reviewer:

<!--
This section is used to describe how this PR is implemented. 
If this is a PR that fixes a bug, this section describes how the bug was fixed.
If it's a new feature, this section briefly describes how to implement the new feature.
etc.
-->

#### Additional documentation e.g., usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```