### PR TITLE
fix(db-browser): listTables correctly returns the table under the specified schema

### DIFF
--- a/libs/db-browser/src/main/java/com/oceanbase/tools/dbbrowser/schema/mysql/OBMySQLSchemaAccessor.java
+++ b/libs/db-browser/src/main/java/com/oceanbase/tools/dbbrowser/schema/mysql/OBMySQLSchemaAccessor.java
@@ -117,16 +117,30 @@ public class OBMySQLSchemaAccessor extends MySQLNoGreaterThan5740SchemaAccessor 
     public List<DBObjectIdentity> listTables(String schemaName, String tableNameLike) {
         List<DBObjectIdentity> results = super.listTables(schemaName, tableNameLike);
 
-        String querySystemTable = "show full tables from oceanbase where Table_type='BASE TABLE'";
-        try {
-            List<String> tables = jdbcOperations.query(querySystemTable, (rs, rowNum) -> rs.getString(1));
-            tables.forEach(name -> results.add(DBObjectIdentity.of("oceanbase", DBObjectType.TABLE, name)));
-        } catch (Exception e) {
-            log.warn("List system tables from 'oceanbase' failed, reason={}", e.getMessage());
+        if (StringUtils.isBlank(schemaName) || "oceanbase".equals(schemaName)) {
+            MySQLSqlBuilder querySystemTable = new MySQLSqlBuilder();
+            querySystemTable.append("show full tables from oceanbase where Table_type='BASE TABLE'");
+            if (StringUtils.isNotBlank(tableNameLike)) {
+                querySystemTable.append(" and tables_in_oceanbase like ").value("%" + tableNameLike + "%");
+            }
+            try {
+                List<String> tables =
+                        jdbcOperations.query(querySystemTable.toString(), (rs, rowNum) -> rs.getString(1));
+                tables.forEach(name -> results.add(DBObjectIdentity.of("oceanbase", DBObjectType.TABLE, name)));
+            } catch (Exception e) {
+                log.warn("List system tables from 'oceanbase' failed, reason={}", e.getMessage());
+            }
         }
-        String queryMysqlTable = "show full tables from `mysql`";
-        jdbcOperations.query(queryMysqlTable,
-                (rs, num) -> results.add(DBObjectIdentity.of("mysql", DBObjectType.TABLE, rs.getString(1))));
+
+        if (StringUtils.isBlank(schemaName) || "mysql".equals(schemaName)) {
+            MySQLSqlBuilder queryMysqlTable = new MySQLSqlBuilder();
+            queryMysqlTable.append("show full tables from `mysql` where Table_type='BASE TABLE'");
+            if (StringUtils.isNotBlank(tableNameLike)) {
+                queryMysqlTable.append(" and tables_in_mysql like ").value("%" + tableNameLike + "%");
+            }
+            jdbcOperations.query(queryMysqlTable.toString(),
+                    (rs, num) -> results.add(DBObjectIdentity.of("mysql", DBObjectType.TABLE, rs.getString(1))));
+        }
         return results;
     }
 

--- a/libs/db-browser/src/test/java/com/oceanbase/tools/dbbrowser/schema/OBMySQLSchemaAccessorTest.java
+++ b/libs/db-browser/src/test/java/com/oceanbase/tools/dbbrowser/schema/OBMySQLSchemaAccessorTest.java
@@ -269,8 +269,20 @@ public class OBMySQLSchemaAccessorTest extends BaseTestEnv {
     }
 
     @Test
-    public void showTablelike_Success() {
+    public void listTables_Success() {
         List<DBObjectIdentity> tables = accessor.listTables(getOBMySQLDataBaseName(), null);
+        Assert.assertTrue(tables != null && tables.size() > 0);
+    }
+
+    @Test
+    public void listTables_inOceanbaseSchema_Success() {
+        List<DBObjectIdentity> tables = accessor.listTables("oceanbase", "job");
+        Assert.assertTrue(tables != null && tables.size() > 0);
+    }
+
+    @Test
+    public void listTables_inMySQLSchema_Success() {
+        List<DBObjectIdentity> tables = accessor.listTables("mysql", "time");
         Assert.assertTrue(tables != null && tables.size() > 0);
     }
 


### PR DESCRIPTION


#### What type of PR is this?
type-bug

#### What this PR does / why we need it:
`OBMySQLSchemaAccessor#listTables` correctly returns the table under the specified schema
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

<!--
This section is used to describe how this PR is implemented. 
If this is a PR that fixes a bug, this section describes how the bug was fixed.
If it's a new feature, this section briefly describes how to implement the new feature.
etc.
-->

#### Additional documentation e.g., usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```