### PR TITLE
enhancement(data-transfer): upgrade ob-loader-dumper to 2.4.8.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1466,7 +1466,7 @@ limitations under the License.
                 </property>
             </activation>
             <properties>
-                <ob-loader-dumper.version>4.2.8-RELEASE</ob-loader-dumper.version>
+                <ob-loader-dumper.version>4.2.8.1-RELEASE</ob-loader-dumper.version>
             </properties>
         </profile>
     </profiles>

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/flow/task/DataTransferRuntimeFlowableTask.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/flow/task/DataTransferRuntimeFlowableTask.java
@@ -88,6 +88,10 @@ public class DataTransferRuntimeFlowableTask extends BaseODCFlowTaskDelegate<Voi
              */
             odcInternalFileService.getExternalImportFiles(taskEntity, submitter, config.getImportFileName());
         }
+        if (taskEntity.getExecutionExpirationIntervalSeconds() != null) {
+            config.setExecutionTimeoutSeconds(
+                    Integer.toUnsignedLong(taskEntity.getExecutionExpirationIntervalSeconds()));
+        }
         context = dataTransferService.create(taskId + "", config);
         taskService.start(taskId, context.getStatus());
         return null;

--- a/server/plugins/task-plugin-api/src/main/java/com/oceanbase/odc/plugin/task/api/datatransfer/dumper/BinaryFile.java
+++ b/server/plugins/task-plugin-api/src/main/java/com/oceanbase/odc/plugin/task/api/datatransfer/dumper/BinaryFile.java
@@ -16,9 +16,8 @@
 package com.oceanbase.odc.plugin.task.api.datatransfer.dumper;
 
 import java.io.InputStream;
+import java.lang.reflect.Method;
 import java.net.URL;
-
-import com.oceanbase.tools.loaddump.utils.SerializeUtils;
 
 import lombok.Getter;
 import lombok.NonNull;
@@ -45,11 +44,14 @@ public class BinaryFile<T> {
 
     public static <T> BinaryFile<T> newFile(@NonNull URL url) {
         try (InputStream inputStream = url.openStream()) {
-            T value = SerializeUtils.deserializeObjectByKryo(inputStream);
+            Class<?> clazz = Class.forName("com.oceanbase.tools.loaddump.utils.SerializeUtils");
+            Method method = clazz.getDeclaredMethod("deserializeObjectByKryo", InputStream.class);
+            method.setAccessible(true);
+            Object value = method.invoke(null, inputStream);
             if (value == null) {
                 return null;
             }
-            return new BinaryFile<>(value, url);
+            return new BinaryFile<>((T) value, url);
         } catch (Exception e) {
             return null;
         }

--- a/server/plugins/task-plugin-api/src/main/java/com/oceanbase/odc/plugin/task/api/datatransfer/model/DataTransferConfig.java
+++ b/server/plugins/task-plugin-api/src/main/java/com/oceanbase/odc/plugin/task/api/datatransfer/model/DataTransferConfig.java
@@ -90,6 +90,7 @@ public class DataTransferConfig implements TaskParameters, Serializable {
     private int cursorFetchSize;
     @JsonIgnore
     private transient List<DBTableColumn> columns;
+    private Long executionTimeoutSeconds;
 
     public boolean isCompressed() {
         return StringUtils.equalsIgnoreCase("ZIP", fileType);

--- a/server/plugins/task-plugin-ob-mysql/src/main/java/com/oceanbase/odc/plugin/task/obmysql/datatransfer/factory/BaseParameterFactory.java
+++ b/server/plugins/task-plugin-ob-mysql/src/main/java/com/oceanbase/odc/plugin/task/obmysql/datatransfer/factory/BaseParameterFactory.java
@@ -154,6 +154,11 @@ public abstract class BaseParameterFactory<T extends BaseParameter> {
         sessionConfig.setJdbcOption("useCursorFetch", transferConfig.isUsePrepStmts() + "");
         sessionConfig.setJdbcOption("zeroDateTimeBehavior", DEFAULT_ZERO_DATE_TIME_BEHAVIOR);
         sessionConfig.setJdbcOption("sendConnectionAttributes", "false");
+        Long connectTimeout = transferConfig.getExecutionTimeoutSeconds();
+        if (connectTimeout != null) {
+            sessionConfig.setJdbcOption("socketTimeout", connectTimeout * 1000 + "");
+            sessionConfig.setJdbcOption("connectTimeout", connectTimeout * 1000 + "");
+        }
 
         parameter.setSessionConfig(sessionConfig);
     }

--- a/server/plugins/task-plugin-ob-mysql/src/main/java/com/oceanbase/odc/plugin/task/obmysql/datatransfer/factory/BaseParameterFactory.java
+++ b/server/plugins/task-plugin-ob-mysql/src/main/java/com/oceanbase/odc/plugin/task/obmysql/datatransfer/factory/BaseParameterFactory.java
@@ -20,8 +20,6 @@ import static com.oceanbase.odc.core.shared.constant.OdcConstants.DEFAULT_ZERO_D
 
 import java.io.File;
 import java.io.IOException;
-import java.io.InputStream;
-import java.nio.charset.StandardCharsets;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.HashMap;
@@ -148,17 +146,16 @@ public abstract class BaseParameterFactory<T extends BaseParameter> {
     }
 
     private void setInitSqls(BaseParameter parameter) throws IOException {
-        try (InputStream is = getClass().getResourceAsStream(SESSION_CONFIG_FILE_PATH)) {
+        File sessionFile = new File(workingDir, "session.config");
+        IOUtils.copy(getClass().getResource(SESSION_CONFIG_FILE_PATH), sessionFile);
+        SessionConfig sessionConfig = SessionConfig.fromJson(sessionFile);
 
-            SessionConfig sessionConfig = SessionConfig.fromJson(IOUtils.toString(is, StandardCharsets.UTF_8));
+        sessionConfig.setJdbcOption("useServerPrepStmts", transferConfig.isUsePrepStmts() + "");
+        sessionConfig.setJdbcOption("useCursorFetch", transferConfig.isUsePrepStmts() + "");
+        sessionConfig.setJdbcOption("zeroDateTimeBehavior", DEFAULT_ZERO_DATE_TIME_BEHAVIOR);
+        sessionConfig.setJdbcOption("sendConnectionAttributes", "false");
 
-            sessionConfig.setJdbcOption("useServerPrepStmts", transferConfig.isUsePrepStmts() + "");
-            sessionConfig.setJdbcOption("useCursorFetch", transferConfig.isUsePrepStmts() + "");
-            sessionConfig.setJdbcOption("zeroDateTimeBehavior", DEFAULT_ZERO_DATE_TIME_BEHAVIOR);
-            sessionConfig.setJdbcOption("sendConnectionAttributes", "false");
-
-            parameter.setSessionConfig(sessionConfig);
-        }
+        parameter.setSessionConfig(sessionConfig);
     }
 
     private void setCsvInfo(BaseParameter parameter) {

--- a/server/plugins/task-plugin-ob-mysql/src/main/java/com/oceanbase/odc/plugin/task/obmysql/datatransfer/factory/DumpParameterFactory.java
+++ b/server/plugins/task-plugin-ob-mysql/src/main/java/com/oceanbase/odc/plugin/task/obmysql/datatransfer/factory/DumpParameterFactory.java
@@ -220,12 +220,11 @@ public class DumpParameterFactory extends BaseParameterFactory<DumpParameter> {
                 controlDescription.add(function);
                 controlContext.add(controlDescription);
             }
-            // TODO ob-loader-dumper will restore this method in version 4.2.8.1
-            // controlManager.register(entry.getKey().getSchemaName(), entry.getKey().getTableName(),
-            // controlContext);
+            controlManager.register(entry.getKey().getSchemaName(), entry.getKey().getTableName(), controlContext);
         }
         parameter.setControlManager(controlManager);
-        parameter.setUseRuntimeTableName(true);
+        // only when dump data by custom query, this value is true
+        parameter.setUseRuntimeTableName(StringUtils.isEmpty(transferConfig.getQuerySql()));
     }
 
 }

--- a/server/plugins/task-plugin-ob-mysql/src/main/java/com/oceanbase/odc/plugin/task/obmysql/datatransfer/factory/LoadParameterFactory.java
+++ b/server/plugins/task-plugin-ob-mysql/src/main/java/com/oceanbase/odc/plugin/task/obmysql/datatransfer/factory/LoadParameterFactory.java
@@ -17,9 +17,7 @@
 package com.oceanbase.odc.plugin.task.obmysql.datatransfer.factory;
 
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
-import java.io.InputStream;
 import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.LinkedHashMap;
@@ -123,11 +121,14 @@ public class LoadParameterFactory extends BaseParameterFactory<LoadParameter> {
          * only CSV format would save the manifest {@link com.oceanbase.tools.loaddump.client.DumpClient}
          */
         if (manifest.exists() && manifest.isFile()) {
-            try (InputStream inputStream = new FileInputStream(manifest)) {
-                if (SerializeUtils.deserializeObjectByKryo(inputStream) == null) {
+            try {
+                if (SerializeUtils.deserializeObjectByKryo(manifest.getPath()) == null) {
                     log.warn("Failed to deserialize MANIFEST.BIN, please check if different versions of ODC or "
                             + "ob-loader-dumper were used between export and import.");
                 }
+            } catch (Exception e) {
+                log.warn("Failed to deserialize MANIFEST.BIN, please check if different versions of ODC or "
+                        + "ob-loader-dumper were used between export and import.");
             }
         }
 


### PR DESCRIPTION
Upgrade ob-loader-dumper to 2.4.8.1 to fix data masking does not work.

Need to pay attention: ob-loader-dumper modified the `SerializeUtil#deserializeObjectByKryo` method into a private static method, so now it can only be called through reflection. They will revise it back in future versions.