### PR TITLE
fix(structure-compare): alter table remove partitioning sql is not put in comment

### DIFF
--- a/libs/ob-sql-parser/src/main/java/com/oceanbase/tools/sqlparser/adapter/mysql/MySQLAlterTableActionFactory.java
+++ b/libs/ob-sql-parser/src/main/java/com/oceanbase/tools/sqlparser/adapter/mysql/MySQLAlterTableActionFactory.java
@@ -203,6 +203,8 @@ public class MySQLAlterTableActionFactory extends OBParserBaseVisitor<AlterTable
         } else if (ctx.REORGANIZE() != null) {
             alterTableAction.reorganizePartition(getNames(ctx.name_list()),
                     getPartitionElements(ctx.opt_partition_range_or_list()));
+        } else if (ctx.REMOVE() != null && ctx.PARTITIONING() != null) {
+            alterTableAction.setRemovePartitioning(true);
         }
         return alterTableAction;
     }

--- a/libs/ob-sql-parser/src/main/java/com/oceanbase/tools/sqlparser/statement/alter/table/AlterTableAction.java
+++ b/libs/ob-sql-parser/src/main/java/com/oceanbase/tools/sqlparser/statement/alter/table/AlterTableAction.java
@@ -58,6 +58,7 @@ public class AlterTableAction extends BaseStatement {
 
     private TableOptions tableOptions;
     private Boolean moveNoCompress;
+    private Boolean removePartitioning;
     private String moveCompress;
     private List<ColumnDefinition> addColumns;
     private List<ColumnReference> dropColumns;
@@ -402,6 +403,9 @@ public class AlterTableAction extends BaseStatement {
         }
         if (this.refresh) {
             builder.append(" REFRESH");
+        }
+        if (Boolean.TRUE.equals(this.removePartitioning)) {
+            builder.append(" REMOVE PARTITIONING");
         }
         return builder.length() == 0 ? "" : builder.substring(1);
     }

--- a/libs/ob-sql-parser/src/main/resources/obmysql/sql/OBParser.g4
+++ b/libs/ob-sql-parser/src/main/resources/obmysql/sql/OBParser.g4
@@ -3020,6 +3020,7 @@ alter_partition_option
     | modify_partition_info
     | REORGANIZE PARTITION name_list INTO opt_partition_range_or_list
     | TRUNCATE (PARTITION|SUBPARTITION) name_list
+    | REMOVE PARTITIONING
     ;
 
 opt_partition_range_or_list

--- a/libs/ob-sql-parser/src/test/java/com/oceanbase/tools/sqlparser/adapter/MySQLAlterTableActionFactoryTest.java
+++ b/libs/ob-sql-parser/src/test/java/com/oceanbase/tools/sqlparser/adapter/MySQLAlterTableActionFactoryTest.java
@@ -690,6 +690,17 @@ public class MySQLAlterTableActionFactoryTest {
         Assert.assertEquals(expect, actual);
     }
 
+    @Test
+    public void generate_removePartitioning_succeed() {
+        StatementFactory<AlterTableAction> factory = new MySQLAlterTableActionFactory(
+                getActionContext("remove partitioning"));
+        AlterTableAction actual = factory.generate();
+
+        AlterTableAction expect = new AlterTableAction();
+        expect.setRemovePartitioning(true);
+        Assert.assertEquals(expect, actual);
+    }
+
     private Alter_table_actionContext getActionContext(String action) {
         OBLexer lexer = new OBLexer(CharStreams.fromString(action));
         CommonTokenStream tokens = new CommonTokenStream(lexer);

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/structurecompare/model/DBObjectComparisonResult.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/structurecompare/model/DBObjectComparisonResult.java
@@ -156,7 +156,8 @@ public class DBObjectComparisonResult {
         if (stmt instanceof AlterTable) {
             return ((AlterTable) stmt).getAlterTableActions().stream().filter(Objects::nonNull)
                     .anyMatch(action -> !getSafeList(action.getDropPartitionNames()).isEmpty()
-                            || !getSafeList(action.getDropSubPartitionNames()).isEmpty());
+                            || !getSafeList(action.getDropSubPartitionNames()).isEmpty()
+                            || Boolean.TRUE.equals(action.getRemovePartitioning()));
         }
         return false;
     }


### PR DESCRIPTION

#### What type of PR is this?
type-bug
module-structure compare

#### What this PR does / why we need it:
mysql 5.7 support convert partitioned table to non-partitioned table by sql:
`alter table table_name remove partitioning`
In fact, this is also a SQL statement for deleting table attributes which should be placed in comments. 
Add `REMOVE PARTITIONING` to `alter_partition_option` in the obmysql syntax file.


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1666 

#### Special notes for your reviewer:

<!--
This section is used to describe how this PR is implemented. 
If this is a PR that fixes a bug, this section describes how the bug was fixed.
If it's a new feature, this section briefly describes how to implement the new feature.
etc.
-->

#### Additional documentation e.g., usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```