### PR TITLE
fix(db-browser):failed to get table when column has default value in oracle11g mode

### DIFF
--- a/libs/db-browser/src/main/java/com/oceanbase/tools/dbbrowser/schema/oracle/OracleSchemaAccessor.java
+++ b/libs/db-browser/src/main/java/com/oceanbase/tools/dbbrowser/schema/oracle/OracleSchemaAccessor.java
@@ -755,6 +755,11 @@ public class OracleSchemaAccessor implements DBSchemaAccessor {
         final int[] hiddenColumnOrdinaryPosition = {-1};
         return (rs, rowNum) -> {
             DBTableColumn tableColumn = new DBTableColumn();
+            /**
+             * All LONG or LONG RAW columns have to be retrieved from the ResultSet prior to all the other
+             * columns or oracle jdbc will throw “Stream has already been closed” Exception
+             */
+            String defaultValue = rs.getString(OracleConstants.COL_DATA_DEFAULT);
             tableColumn.setSchemaName(rs.getString(OracleConstants.CONS_OWNER));
             tableColumn.setTableName(rs.getString(OracleConstants.COL_TABLE_NAME));
             tableColumn.setName(rs.getString(OracleConstants.COL_COLUMN_NAME));
@@ -790,8 +795,7 @@ public class OracleSchemaAccessor implements DBSchemaAccessor {
                 hiddenColumnOrdinaryPosition[0]--;
             }
             tableColumn.setVirtual("YES".equalsIgnoreCase(rs.getString(OracleConstants.COL_VIRTUAL_COLUMN)));
-            tableColumn.setDefaultValue("NULL".equals(rs.getString(OracleConstants.COL_DATA_DEFAULT)) ? null
-                    : rs.getString(OracleConstants.COL_DATA_DEFAULT));
+            tableColumn.setDefaultValue("NULL".equals(defaultValue) ? null : defaultValue);
             if (tableColumn.getVirtual()) {
                 tableColumn.setGenExpression(rs.getString(OracleConstants.COL_DATA_DEFAULT));
             }


### PR DESCRIPTION


#### What type of PR is this?
type-bug


#### What this PR does / why we need it:
All LONG or LONG RAW columns have to be retrieved from the ResultSet prior to all the other columns or oracle jdbc will throw “Stream has already been closed” Exception.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1727

#### Special notes for your reviewer:

<!--
This section is used to describe how this PR is implemented. 
If this is a PR that fixes a bug, this section describes how the bug was fixed.
If it's a new feature, this section briefly describes how to implement the new feature.
etc.
-->

#### Additional documentation e.g., usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```