### PR TITLE
fix(sql-execute): anonymous block execution module adapted to oracle11g

### DIFF
--- a/libs/db-browser/src/main/java/com/oceanbase/tools/dbbrowser/schema/oracle/OracleSchemaAccessor.java
+++ b/libs/db-browser/src/main/java/com/oceanbase/tools/dbbrowser/schema/oracle/OracleSchemaAccessor.java
@@ -1483,16 +1483,18 @@ public class OracleSchemaAccessor implements DBSchemaAccessor {
         });
         parsePackageDDL(packageHead);
 
-        OracleSqlBuilder packageBodyDDL = new OracleSqlBuilder();
-        packageBodyDDL.append("SELECT dbms_metadata.get_ddl('PACKAGE_BODY', ")
-                .value(packageName)
-                .append(", ")
-                .value(schemaName)
-                .append(") as DDL from dual");
-        jdbcOperations.query(packageBodyDDL.toString(), rs -> {
-            packageBodyBasicInfo.setDdl(rs.getString(1));
-        });
-        parsePackageDDL(packageBody);
+        if (Objects.nonNull(packageBodyBasicInfo.getDefiner())) {
+            OracleSqlBuilder packageBodyDDL = new OracleSqlBuilder();
+            packageBodyDDL.append("SELECT dbms_metadata.get_ddl('PACKAGE_BODY', ")
+                    .value(packageName)
+                    .append(", ")
+                    .value(schemaName)
+                    .append(") as DDL from dual");
+            jdbcOperations.query(packageBodyDDL.toString(), rs -> {
+                packageBodyBasicInfo.setDdl(rs.getString(1));
+            });
+            parsePackageDDL(packageBody);
+        }
 
         if (StringUtils.containsIgnoreCase(dbPackage.getStatus(), PLConstants.PL_OBJECT_STATUS_INVALID)) {
             dbPackage.setErrorMessage(PLObjectErrMsgUtils.getOraclePLObjErrMsg(jdbcOperations,

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/db/DBPLService.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/db/DBPLService.java
@@ -217,13 +217,14 @@ public class DBPLService {
 
     public DBPLObjectIdentity parsePLNameType(@NonNull ConnectionSession session, @NonNull String ddl) {
         DBPLObjectIdentity plObject = new DBPLObjectIdentity();
+        Validate.notNull(session.getDialectType(), "Dialect type can not be null");
         List<String> sqls = SqlCommentProcessor.removeSqlComments(ddl + "$$", "$$",
                 session.getDialectType(), true).stream().map(OffsetString::getStr).collect(Collectors.toList());
         if (!sqls.isEmpty()) {
             ddl = sqls.get(0);
         }
         ParsePLResult result;
-        if (DialectType.OB_ORACLE == session.getDialectType()) {
+        if (session.getDialectType().isOracle()) {
             result = PLParser.parseOracle(ddl);
         } else if (session.getDialectType().isMysql()) {
             result = PLParser.parseObMysql(ddl);

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/session/OdcStatementCallBack.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/session/OdcStatementCallBack.java
@@ -206,7 +206,7 @@ public class OdcStatementCallBack implements StatementCallback<List<JdbcGeneralR
             if (this.autoCommit ^ currentAutoCommit) {
                 statement.getConnection().setAutoCommit(currentAutoCommit);
             }
-            if (DialectType.OB_ORACLE.equals(this.dialectType)) {
+            if (this.dialectType.isOracle()) {
                 String dbmsInfo = queryDBMSOutput(statement);
                 if (dbmsInfo != null) {
                     log.info("Clear dbms_output cache, dbmsInfo={}", dbmsInfo);
@@ -296,7 +296,7 @@ public class OdcStatementCallBack implements StatementCallback<List<JdbcGeneralR
             executeResults.add(executeResult);
         }
         // get pl log，not support for mysql mode
-        if (DialectType.OB_ORACLE.equals(this.dialectType)) {
+        if (this.dialectType.isOracle()) {
             try (TraceStage s = traceWatch.start(SqlExecuteStages.QUERY_DBMS_OUTPUT)) {
                 executeResults.forEach(jdbcResult -> jdbcResult.setDbmsOutput(queryDBMSOutput(statement)));
             }

--- a/server/plugins/connect-plugin-ob-oracle/src/main/java/com/oceanbase/odc/plugin/connect/oboracle/OBOracleConnectionExtension.java
+++ b/server/plugins/connect-plugin-ob-oracle/src/main/java/com/oceanbase/odc/plugin/connect/oboracle/OBOracleConnectionExtension.java
@@ -23,7 +23,7 @@ import org.pf4j.Extension;
 import com.oceanbase.odc.core.datasource.ConnectionInitializer;
 import com.oceanbase.odc.plugin.connect.obmysql.OBMySQLConnectionExtension;
 import com.oceanbase.odc.plugin.connect.obmysql.initializer.EnableTraceInitializer;
-import com.oceanbase.odc.plugin.connect.oboracle.initializer.OBOracleDBMSOutputInitializer;
+import com.oceanbase.odc.plugin.connect.oboracle.initializer.OracleDBMSOutputInitializer;
 
 /**
  * @author yaobin
@@ -37,7 +37,7 @@ public class OBOracleConnectionExtension extends OBMySQLConnectionExtension {
     public List<ConnectionInitializer> getConnectionInitializers() {
         List<ConnectionInitializer> initializers = new ArrayList<>();
         initializers.add(new EnableTraceInitializer());
-        initializers.add(new OBOracleDBMSOutputInitializer());
+        initializers.add(new OracleDBMSOutputInitializer());
         return initializers;
     }
 

--- a/server/plugins/connect-plugin-ob-oracle/src/main/java/com/oceanbase/odc/plugin/connect/oboracle/initializer/OracleDBMSOutputInitializer.java
+++ b/server/plugins/connect-plugin-ob-oracle/src/main/java/com/oceanbase/odc/plugin/connect/oboracle/initializer/OracleDBMSOutputInitializer.java
@@ -32,7 +32,7 @@ import lombok.extern.slf4j.Slf4j;
  * @since ODC_release_3.2.2
  */
 @Slf4j
-public class OBOracleDBMSOutputInitializer implements ConnectionInitializer {
+public class OracleDBMSOutputInitializer implements ConnectionInitializer {
 
     private static final int PL_LOG_CACHE_SIZE = 1000000;
 

--- a/server/plugins/connect-plugin-oracle/src/main/java/com/oceanbase/odc/plugin/connect/oracle/OracleConnectionExtension.java
+++ b/server/plugins/connect-plugin-oracle/src/main/java/com/oceanbase/odc/plugin/connect/oracle/OracleConnectionExtension.java
@@ -38,6 +38,7 @@ import com.oceanbase.odc.core.shared.jdbc.JdbcUrlParser;
 import com.oceanbase.odc.plugin.connect.api.TestResult;
 import com.oceanbase.odc.plugin.connect.model.JdbcUrlProperty;
 import com.oceanbase.odc.plugin.connect.obmysql.OBMySQLConnectionExtension;
+import com.oceanbase.odc.plugin.connect.oboracle.initializer.OracleDBMSOutputInitializer;
 
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
@@ -87,7 +88,7 @@ public class OracleConnectionExtension extends OBMySQLConnectionExtension {
 
     @Override
     public List<ConnectionInitializer> getConnectionInitializers() {
-        return Collections.emptyList();
+        return Collections.singletonList(new OracleDBMSOutputInitializer());
     }
 
     @Override


### PR DESCRIPTION
#### What type of PR is this?
type-bug
module-sql-execution
module-db-browser

#### What this PR does / why we need it:
1. Anonymous block execution module adapted to oracle11g
- rename `OBOracleDBMSOutputInitializer` to `OracleDBMSOutputInitializer`
2. Fixed the problem of error reporting when viewing packages without package body

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1729 
Fixes #1754 

#### Special notes for your reviewer:

<!--
This section is used to describe how this PR is implemented. 
If this is a PR that fixes a bug, this section describes how the bug was fixed.
If it's a new feature, this section briefly describes how to implement the new feature.
etc.
-->

#### Additional documentation e.g., usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```