### PR TITLE
fix(data-transfer): export Oracle object ddl without line breaks

### DIFF
--- a/server/plugins/task-plugin-api/src/main/java/com/oceanbase/odc/plugin/task/api/datatransfer/model/DataTransferConfig.java
+++ b/server/plugins/task-plugin-api/src/main/java/com/oceanbase/odc/plugin/task/api/datatransfer/model/DataTransferConfig.java
@@ -63,7 +63,7 @@ public class DataTransferConfig implements TaskParameters, Serializable {
     private EncodingType encoding = EncodingType.UTF_8;
     private CsvConfig csvConfig;
     private List<CsvColumnMapping> csvColumnMappings;
-    private boolean stopWhenError;
+    private boolean stopWhenError = true;
     private String exportFilePath;
     private boolean mergeSchemaFiles;
     private String querySql;

--- a/server/plugins/task-plugin-mysql/src/main/java/com/oceanbase/odc/plugin/task/mysql/datatransfer/common/Constants.java
+++ b/server/plugins/task-plugin-mysql/src/main/java/com/oceanbase/odc/plugin/task/mysql/datatransfer/common/Constants.java
@@ -42,7 +42,7 @@ public class Constants {
 
     public static final String DEFAULT_PL_DELIMITER = "$$" + LINE_BREAKER;
 
-    public static final String PL_DELIMITER_STMT = "DELIMITER " + DEFAULT_PL_DELIMITER;
+    public static final String PL_DELIMITER_STMT = "DELIMITER " + DEFAULT_PL_DELIMITER + LINE_BREAKER;
 
     public static final String COMMIT_STMT = "commit";
 

--- a/server/plugins/task-plugin-mysql/src/main/java/com/oceanbase/odc/plugin/task/mysql/datatransfer/job/datax/DataXTransferJob.java
+++ b/server/plugins/task-plugin-mysql/src/main/java/com/oceanbase/odc/plugin/task/mysql/datatransfer/job/datax/DataXTransferJob.java
@@ -99,7 +99,7 @@ public class DataXTransferJob extends AbstractJob {
             // exit code: 0=success, 1=error
             int exitValue = process.waitFor();
             renameExportFile();
-            if (exitValue == 0 && failed == 0) {
+            if (exitValue == 0 && failed == 0 || isCanceled()) {
                 setStatus(Status.SUCCESS);
             } else {
                 setStatus(Status.FAILURE);

--- a/server/plugins/task-plugin-mysql/src/main/java/com/oceanbase/odc/plugin/task/mysql/datatransfer/job/factory/BaseTransferJobFactory.java
+++ b/server/plugins/task-plugin-mysql/src/main/java/com/oceanbase/odc/plugin/task/mysql/datatransfer/job/factory/BaseTransferJobFactory.java
@@ -95,7 +95,7 @@ public abstract class BaseTransferJobFactory {
         }
         objects.forEach(o -> {
             ObjectResult object = new ObjectResult(transferConfig.getSchemaName(), o.getObjectName(),
-                    o.getDbObjectType().getName());
+                    o.getDbObjectType().name());
             AbstractJob job = generateSchemaExportJob(object, dataSource);
             jobs.add(job);
         });

--- a/server/plugins/task-plugin-oracle/src/main/java/com/oceanbase/odc/plugin/task/oracle/datatransfer/job/OracleSchemaExportJob.java
+++ b/server/plugins/task-plugin-oracle/src/main/java/com/oceanbase/odc/plugin/task/oracle/datatransfer/job/OracleSchemaExportJob.java
@@ -63,7 +63,7 @@ public class OracleSchemaExportJob extends BaseSchemaExportJob {
 
     @Override
     protected String getDropStatement() {
-        return String.format("DROP %s %s", ObjectType.valueOfName(object.getType()).getName(), object.getName());
+        return String.format("DROP %s \"%s\";\n", ObjectType.valueOfName(object.getType()).getName(), object.getName());
     }
 
     @Override


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines.
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request.
3. Ensure you have added or ran the appropriate tests for your PR.
5. If the PR is unfinished, you may add or remove a WIP or [WIP] prefix to your pull request title.
-->

#### What type of PR is this?
type-bug
<!--
Add one of the following kinds:
type-bug
type-feature
type-docs
etc.

Optionally add one or more of the following kinds if applicable:
module-resultset
module-sql execution
etc.
-->

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1742  #1746  . Export Oracle object ddl without line breaks.
Fixes #1671  . When start a export task ,the front-end don't send `stopWhenError` param in request, so it would use false as it's value. If a object failed, the other would continue transfering. 