### PR TITLE
fix(data-transfer): oracle mode import with incorrect splitted sqls

### DIFF
--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/datatransfer/task/DataTransferTask.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/datatransfer/task/DataTransferTask.java
@@ -319,6 +319,8 @@ public class DataTransferTask implements Callable<DataTransferTaskResult> {
                 .collect(Collectors.toList());
         if (CollectionUtils.isNotEmpty(failedObjects)) {
             LOGGER.warn("Data transfer task completed with unfinished objects! Details : {}", failedObjects);
+            throw new IllegalStateException(
+                    "Data transfer task completed with unfinished objects! Details :" + failedObjects);
         }
     }
 

--- a/server/plugins/task-plugin-mysql/src/main/java/com/oceanbase/odc/plugin/task/mysql/datatransfer/MySQLDataTransferJob.java
+++ b/server/plugins/task-plugin-mysql/src/main/java/com/oceanbase/odc/plugin/task/mysql/datatransfer/MySQLDataTransferJob.java
@@ -32,13 +32,10 @@ import java.util.Objects;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
-
-import javax.sql.DataSource;
 
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.Predicate;
@@ -87,13 +84,10 @@ public class MySQLDataTransferJob implements DataTransferJob {
     protected final File workingDir;
     protected final File logDir;
     protected final List<URL> inputs;
-    private final AtomicInteger finishedJobNum = new AtomicInteger(0);
     private final List<AbstractJob> schemaJobs = new LinkedList<>();
     private final List<AbstractJob> dataJobs = new LinkedList<>();
     private final AtomicReference<TaskStatus> status = new AtomicReference<>();
     private final LocalEventPublisher publisher = new LocalEventPublisher();
-
-    private int transferJobNum = 0;
 
     public MySQLDataTransferJob(@NonNull DataTransferConfig config, @NonNull File workingDir, @NonNull File logDir,
             @NonNull List<URL> inputs) {
@@ -115,10 +109,13 @@ public class MySQLDataTransferJob implements DataTransferJob {
 
     @Override
     public double getProgress() {
-        if (transferJobNum == 0) {
-            return 0.0;
-        }
-        return finishedJobNum.get() * 100D / transferJobNum;
+        int base = (baseConfig.isTransferData() ? 1 : 0) + (baseConfig.isTransferDDL() ? 1 : 0);
+
+        double schemaProgress = CollectionUtils.isEmpty(schemaJobs) ? 0
+                : schemaJobs.stream().filter(AbstractJob::isDone).count() * 1D / schemaJobs.size();
+        double dataProgress = CollectionUtils.isEmpty(dataJobs) ? 0
+                : dataJobs.stream().filter(AbstractJob::isDone).count() * 1D / dataJobs.size();
+        return (schemaProgress + dataProgress) / base;
     }
 
     @Override
@@ -138,16 +135,23 @@ public class MySQLDataTransferJob implements DataTransferJob {
     public DataTransferTaskResult call() throws Exception {
         try (HikariDataSource dataSource = getDataSource()) {
 
-            initTransferJobs(dataSource, dataSource.getJdbcUrl());
+            BaseTransferJobFactory factory = getJobFactory();
 
-            if (CollectionUtils.isNotEmpty(schemaJobs)) {
+            if (baseConfig.isTransferDDL() && !isCanceled()) {
+                List<AbstractJob> jobs = factory.generateSchemaTransferJobs(dataSource, dataSource.getJdbcUrl());
+                LOGGER.info("Found {} schema jobs for database {}.", jobs.size(), baseConfig.getSchemaName());
+                schemaJobs.addAll(jobs);
                 try {
                     runSchemaJobs();
                 } finally {
                     logSummary(schemaJobs, "SCHEMA");
                 }
             }
-            if (CollectionUtils.isNotEmpty(dataJobs)) {
+
+            if (baseConfig.isTransferData() && !isCanceled()) {
+                List<AbstractJob> jobs = factory.generateDataTransferJobs(dataSource, dataSource.getJdbcUrl());
+                LOGGER.info("Found {} data jobs for database {}.", jobs.size(), baseConfig.getSchemaName());
+                dataJobs.addAll(jobs);
                 ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor(
                         new ThreadFactoryBuilder().setNameFormat("datatransfer-schedule-%d").build());
                 try {
@@ -209,30 +213,6 @@ public class MySQLDataTransferJob implements DataTransferJob {
                 : Constants.TXT_FILE_WRITER;
     }
 
-    private void initTransferJobs(DataSource dataSource, String jdbcUrl) {
-        BaseTransferJobFactory factory = getJobFactory();
-        try {
-            if (baseConfig.isTransferDDL()) {
-                List<AbstractJob> jobs = factory.generateSchemaTransferJobs(dataSource, jdbcUrl);
-                if (CollectionUtils.isNotEmpty(jobs)) {
-                    schemaJobs.addAll(jobs);
-                    transferJobNum += jobs.size();
-                }
-                LOGGER.info("Found {} schema jobs for database {}.", jobs.size(), baseConfig.getSchemaName());
-            }
-            if (baseConfig.isTransferData()) {
-                List<AbstractJob> jobs = factory.generateDataTransferJobs(dataSource, jdbcUrl);
-                if (CollectionUtils.isNotEmpty(jobs)) {
-                    dataJobs.addAll(jobs);
-                    transferJobNum += jobs.size();
-                }
-                LOGGER.info("Found {} data jobs for database {}.", jobs.size(), baseConfig.getSchemaName());
-            }
-        } catch (Exception e) {
-            throw new RuntimeException("Failed to init transfer jobs.", e);
-        }
-    }
-
     private void runSchemaJobs() {
         if (CollectionUtils.isEmpty(schemaJobs)) {
             return;
@@ -244,8 +224,6 @@ public class MySQLDataTransferJob implements DataTransferJob {
             try {
                 LOGGER.info("Begin to transfer schema for {}.", job);
                 job.run();
-
-                finishedJobNum.getAndIncrement();
                 LOGGER.info("Successfully finished transferring schema for {}.", job);
             } catch (Exception e) {
                 LOGGER.warn("Object {} failed.", job, e);
@@ -271,8 +249,6 @@ public class MySQLDataTransferJob implements DataTransferJob {
                 LOGGER.info("Begin to transfer data for {}.", job);
                 publisher.publishEvent(new ObjectStartEvent(job, ""));
                 job.run();
-
-                finishedJobNum.getAndIncrement();
                 LOGGER.info("Successfully finished transferring data for {} .", job);
             } catch (Exception e) {
                 LOGGER.warn("Object {} failed.", job, e);

--- a/server/plugins/task-plugin-mysql/src/main/java/com/oceanbase/odc/plugin/task/mysql/datatransfer/job/MySQLSqlScriptImportJob.java
+++ b/server/plugins/task-plugin-mysql/src/main/java/com/oceanbase/odc/plugin/task/mysql/datatransfer/job/MySQLSqlScriptImportJob.java
@@ -94,12 +94,12 @@ public class MySQLSqlScriptImportJob extends BaseSqlScriptImportJob {
     }
 
     @Override
-    protected List<String> getPreSqlsForSchema() {
+    protected List<String> getPreSqlsForSchema() throws SQLException {
         List<String> preSqls = new LinkedList<>();
         if (StringUtils.equalsIgnoreCase(object.getType(), "TABLE")) {
             preSqls.add(Constants.DISABLE_FK);
         }
-        if (transferConfig.isReplaceSchemaWhenExists()) {
+        if (transferConfig.isReplaceSchemaWhenExists() && isObjectExists()) {
             preSqls.add(String.format(Constants.DROP_OBJECT_FORMAT, object.getType(),
                     StringUtils.quoteMysqlIdentifier(object.getName())));
             LOGGER.info("{} will be dropped.", object.getSummary());
@@ -132,6 +132,11 @@ public class MySQLSqlScriptImportJob extends BaseSqlScriptImportJob {
         if (StringUtils.equalsIgnoreCase(object.getType(), "TABLE")) {
             return Collections.singletonList(Constants.ENABLE_FK);
         }
+        return null;
+    }
+
+    @Override
+    protected List<String> getPreSqlsForExternal() {
         return null;
     }
 

--- a/server/plugins/task-plugin-mysql/src/main/java/com/oceanbase/odc/plugin/task/mysql/datatransfer/job/datax/DataXTransferJob.java
+++ b/server/plugins/task-plugin-mysql/src/main/java/com/oceanbase/odc/plugin/task/mysql/datatransfer/job/datax/DataXTransferJob.java
@@ -172,7 +172,7 @@ public class DataXTransferJob extends AbstractJob {
                 }
                 matcher = LOG_DIRTY_RECORD_PATTERN.matcher(line);
                 if (matcher.matches()) {
-                    LOGGER.warn("Dirty record: {}", line);
+                    LOGGER.warn("Dirty record: {}", line.substring(0, Math.min(line.length(), 1024)));
                 }
             }
         } finally {

--- a/server/plugins/task-plugin-oracle/src/main/java/com/oceanbase/odc/plugin/task/oracle/datatransfer/job/OracleSqlScriptImportJob.java
+++ b/server/plugins/task-plugin-oracle/src/main/java/com/oceanbase/odc/plugin/task/oracle/datatransfer/job/OracleSqlScriptImportJob.java
@@ -27,7 +27,11 @@ import java.util.stream.Collectors;
 import javax.sql.DataSource;
 
 import org.apache.commons.collections4.CollectionUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import com.google.common.collect.Lists;
+import com.oceanbase.odc.common.util.StringUtils;
 import com.oceanbase.odc.core.sql.split.SqlSplitter;
 import com.oceanbase.odc.core.sql.split.SqlStatementIterator;
 import com.oceanbase.odc.plugin.schema.oracle.OracleFunctionExtension;
@@ -52,6 +56,7 @@ import com.oceanbase.tools.loaddump.common.enums.ObjectType;
  * @date 2024/2/1
  */
 public class OracleSqlScriptImportJob extends BaseSqlScriptImportJob {
+    private static final Logger LOGGER = LoggerFactory.getLogger("DataTransferLogger");
 
     public OracleSqlScriptImportJob(ObjectResult object, DataTransferConfig transferConfig, URL input,
             DataSource dataSource) {
@@ -125,8 +130,15 @@ public class OracleSqlScriptImportJob extends BaseSqlScriptImportJob {
     }
 
     @Override
-    protected List<String> getPreSqlsForSchema() {
-        return Collections.singletonList("alter session set CURRENT_SCHEMA=" + transferConfig.getSchemaName());
+    protected List<String> getPreSqlsForSchema() throws SQLException {
+        List<String> sqls = Lists.newArrayList(
+                "alter session set CURRENT_SCHEMA=" + transferConfig.getSchemaName());
+        if (transferConfig.isReplaceSchemaWhenExists() && isObjectExists()) {
+            sqls.add(String.format("DROP %s %s", ObjectType.valueOfName(object.getType()).getName(),
+                    StringUtils.quoteOracleIdentifier(object.getName())));
+            LOGGER.info("{} will be dropped.", object.getSummary());
+        }
+        return sqls;
     }
 
     @Override
@@ -142,5 +154,10 @@ public class OracleSqlScriptImportJob extends BaseSqlScriptImportJob {
     @Override
     protected List<String> getPostSqlsForData() {
         return Collections.emptyList();
+    }
+
+    @Override
+    protected List<String> getPreSqlsForExternal() {
+        return Collections.singletonList("alter session set CURRENT_SCHEMA=" + transferConfig.getSchemaName());
     }
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines.
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request.
3. Ensure you have added or ran the appropriate tests for your PR.
5. If the PR is unfinished, you may add or remove a WIP or [WIP] prefix to your pull request title.
-->

#### What type of PR is this?
type-bug
<!--
Add one of the following kinds:
type-bug
type-feature
type-docs
etc.

Optionally add one or more of the following kinds if applicable:
module-resultset
module-sql execution
etc.
-->

#### What this PR does / why we need it:

Fixed:
1. When import sql scripts for orarcle mode, we used `SqlCommentProcessor` to split sql. But it should use `SqlSplittter` instead. 
2. In MySQLDataTransferJob, schema jobs and data jobs will be initialized first before task transfer. Actually, this is incorrect because when creating a data job, table information will be queried. If the table has not been imported yet, an error will occur.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1761 #1773 