### PR TITLE
enhancement(notification): support using variables in http header and body

### DIFF
--- a/server/integration-test/src/test/java/com/oceanbase/odc/service/notification/BrokerTest.java
+++ b/server/integration-test/src/test/java/com/oceanbase/odc/service/notification/BrokerTest.java
@@ -143,6 +143,8 @@ public class BrokerTest extends ServiceTestEnv {
     }
 
     private Message getMessage() {
+        Event event = new Event();
+        event.setId(1L);
         return Message.builder()
                 .title("test title")
                 .content("test content")
@@ -153,6 +155,7 @@ public class BrokerTest extends ServiceTestEnv {
                 .organizationId(ORGANIZATION_ID)
                 .projectId(1L)
                 .channel(getChannel())
+                .event(event)
                 .build();
     }
 

--- a/server/integration-test/src/test/java/com/oceanbase/odc/service/notification/JdbcNotificationQueueTest.java
+++ b/server/integration-test/src/test/java/com/oceanbase/odc/service/notification/JdbcNotificationQueueTest.java
@@ -42,6 +42,7 @@ import com.oceanbase.odc.service.notification.helper.ChannelMapper;
 import com.oceanbase.odc.service.notification.helper.EventMapper;
 import com.oceanbase.odc.service.notification.model.Channel;
 import com.oceanbase.odc.service.notification.model.ChannelType;
+import com.oceanbase.odc.service.notification.model.Event;
 import com.oceanbase.odc.service.notification.model.Message;
 import com.oceanbase.odc.service.notification.model.MessageSendingStatus;
 
@@ -142,6 +143,8 @@ public class JdbcNotificationQueueTest extends ServiceTestEnv {
     }
 
     private Message getMessage() {
+        Event event = new Event();
+        event.setId(1L);
         return Message.builder()
                 .title("test title")
                 .content("test content")
@@ -152,6 +155,7 @@ public class JdbcNotificationQueueTest extends ServiceTestEnv {
                 .organizationId(ORGANIZATION_ID)
                 .projectId(1L)
                 .channel(getChannel())
+                .event(event)
                 .build();
     }
 

--- a/server/odc-migrate/src/main/resources/migrate/common/V_4_2_4_12__update_system_config.sql
+++ b/server/odc-migrate/src/main/resources/migrate/common/V_4_2_4_12__update_system_config.sql
@@ -1,0 +1,3 @@
+update config_system_configuration set `value`='true' where `key` = 'odc.task-framework.enabled';
+
+update `config_system_configuration` set `value` = 'true' where `key` = 'odc.notification.enabled';

--- a/server/odc-migrate/src/main/resources/migrate/common/V_4_2_4_12__update_task_framework_enabled.sql
+++ b/server/odc-migrate/src/main/resources/migrate/common/V_4_2_4_12__update_task_framework_enabled.sql
@@ -1,1 +1,0 @@
-update config_system_configuration set `value`='true' where `key` = 'odc.task-framework.enabled';

--- a/server/odc-migrate/src/main/resources/migrate/common/V_4_2_4_16__update_system_config.sql
+++ b/server/odc-migrate/src/main/resources/migrate/common/V_4_2_4_16__update_system_config.sql
@@ -1,1 +1,0 @@
-UPDATE `config_system_configuration` SET `value` = 'true' WHERE `key` = 'odc.notification.enabled';

--- a/server/odc-migrate/src/main/resources/migrate/common/V_4_2_4_16__update_system_config.sql
+++ b/server/odc-migrate/src/main/resources/migrate/common/V_4_2_4_16__update_system_config.sql
@@ -1,0 +1,1 @@
+UPDATE `config_system_configuration` SET `value` = 'true' WHERE `key` = 'odc.notification.enabled';

--- a/server/odc-migrate/src/main/resources/migrate/common/V_4_2_4_2__alter_notification_schema.sql
+++ b/server/odc-migrate/src/main/resources/migrate/common/V_4_2_4_2__alter_notification_schema.sql
@@ -76,6 +76,7 @@ CREATE TABLE IF NOT EXISTS `notification_message` (
   `cc_recipients` varchar(2048) DEFAULT NULL comment 'odc users who will receive this message by copy',
   `error_message` varchar(2048) DEFAULT NULL comment 'reason for message sending failure',
   `last_sent_time` datetime DEFAULT NULL COMMENT 'the last attempt to send current message',
+  `event_id` bigint(20) NOT NULL COMMENT 'event id, reference to notification_event.id',
   CONSTRAINT pk_notification_message_id PRIMARY KEY (`id`),
   KEY `idx_status_retry_times_max_retry_times` (`status`, `retry_times`, `max_retry_times`),
   KEY `idx_notification_message_channel_id` (`channel_id`),

--- a/server/odc-server/src/main/resources/data.sql
+++ b/server/odc-server/src/main/resources/data.sql
@@ -564,7 +564,7 @@ VALUES ('odc.automatic-auth-rule.enabled', 'true', 'odc', 'default', 'master', '
 -- v4.1.3
 --
 insert into `config_system_configuration` (`key`, `value`, `application`, `profile`, `label`, `description`)
-VALUES ('odc.notification.enabled', 'false', 'odc', 'default', 'master', '是否开启消息通知，默认 false，表示不开启') ON DUPLICATE KEY update `id`=`id`;
+VALUES ('odc.notification.enabled', 'true', 'odc', 'default', 'master', '是否开启消息通知，默认 false，表示不开启') ON DUPLICATE KEY update `id`=`id`;
 insert into `config_system_configuration` (`key`, `value`, `application`, `profile`, `label`, `description`)
 VALUES ('odc.notification.event-dequeue-batch-size', '5', 'odc', 'default', 'master', '批量处理事件数量，默认 5') ON DUPLICATE KEY update `id`=`id`;
 insert into `config_system_configuration` (`key`, `value`, `application`, `profile`, `label`, `description`)

--- a/server/odc-service/src/main/java/com/oceanbase/odc/metadb/notification/MessageEntity.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/metadb/notification/MessageEntity.java
@@ -86,4 +86,6 @@ public class MessageEntity {
     private Date lastSentTime;
     @Column(name = "error_message")
     private String errorMessage;
+    @Column(name = "event_id")
+    private Long eventId;
 }

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/notification/Broker.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/notification/Broker.java
@@ -16,6 +16,7 @@
 package com.oceanbase.odc.service.notification;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -23,6 +24,9 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.oceanbase.odc.common.util.ExceptionUtils;
 import com.oceanbase.odc.core.authority.util.SkipAuthorize;
+import com.oceanbase.odc.core.shared.constant.OrganizationType;
+import com.oceanbase.odc.metadb.iam.OrganizationEntity;
+import com.oceanbase.odc.metadb.iam.OrganizationRepository;
 import com.oceanbase.odc.metadb.notification.MessageRepository;
 import com.oceanbase.odc.metadb.notification.MessageSendingHistoryEntity;
 import com.oceanbase.odc.metadb.notification.MessageSendingHistoryRepository;
@@ -66,6 +70,9 @@ public class Broker {
     @Autowired
     private MessageSendingHistoryRepository sendingHistoryRepository;
 
+    @Autowired
+    private OrganizationRepository organizationRepository;
+
     public void dequeueEvent(EventStatus eventStatus) {
         try {
             // 从事件队列中拉取事件
@@ -83,6 +90,10 @@ public class Broker {
 
     @Transactional(rollbackFor = Exception.class)
     public void enqueueEvent(Event event) {
+        Optional<OrganizationEntity> optional = organizationRepository.findById(event.getOrganizationId());
+        if (optional.isPresent() && optional.get().getType() == OrganizationType.INDIVIDUAL) {
+            return;
+        }
         eventQueue.offer(event);
     }
 

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/notification/Converter.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/notification/Converter.java
@@ -124,6 +124,7 @@ public class Converter {
                     message.setRetryTimes(0);
                     message.setProjectId(channel.getProjectId());
                     message.setMaxRetryTimes(notificationProperties.getMaxResendTimes());
+                    message.setEvent(event);
                     messages.add(message);
                 } catch (Exception e) {
                     log.error("failed to convert event with id={}, channel id={}",

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/notification/HttpSender.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/notification/HttpSender.java
@@ -18,11 +18,11 @@ package com.oceanbase.odc.service.notification;
 import java.net.InetSocketAddress;
 import java.net.Proxy;
 import java.net.Proxy.Type;
+import java.util.Locale;
 import java.util.Map;
 
 import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.text.StringSubstitutor;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
@@ -32,10 +32,12 @@ import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestTemplate;
 
-import com.google.common.collect.ImmutableMap;
 import com.oceanbase.odc.common.json.JsonUtils;
 import com.oceanbase.odc.service.notification.helper.MessageResponseValidator;
+import com.oceanbase.odc.service.notification.helper.MessageTemplateProcessor;
 import com.oceanbase.odc.service.notification.model.ChannelType;
+import com.oceanbase.odc.service.notification.model.Event;
+import com.oceanbase.odc.service.notification.model.EventLabels;
 import com.oceanbase.odc.service.notification.model.Message;
 import com.oceanbase.odc.service.notification.model.MessageSendResult;
 import com.oceanbase.odc.service.notification.model.WebhookChannelConfig;
@@ -55,8 +57,7 @@ public class HttpSender implements MessageSender {
     @Override
     public MessageSendResult send(Message message) throws Exception {
         WebhookChannelConfig channelConfig = (WebhookChannelConfig) message.getChannel().getChannelConfig();
-        RestTemplate restTemplate = new RestTemplate();
-        setProxyIfNeed(restTemplate, channelConfig);
+        RestTemplate restTemplate = getRestTemplate(channelConfig);
         HttpMethod httpMethod = channelConfig.getHttpMethod() == null ? HttpMethod.POST : channelConfig.getHttpMethod();
         HttpEntity<String> request = new HttpEntity<>(getBody(message), getHeaders(message));
         ResponseEntity<Map> response =
@@ -71,13 +72,16 @@ public class HttpSender implements MessageSender {
     protected HttpHeaders getHeaders(Message message) {
         WebhookChannelConfig channelConfig = (WebhookChannelConfig) message.getChannel().getChannelConfig();
         HttpHeaders headers = new HttpHeaders();
-        String headersStr = channelConfig.getHeadersTemplate();
-        if (StringUtils.isEmpty(headersStr)) {
+        String headersTemplate = channelConfig.getHeadersTemplate();
+        if (StringUtils.isEmpty(headersTemplate)) {
             return headers;
         }
-        String[] split = headersStr.split(";");
+        String[] split = resolveTemplate(message, headersTemplate).split(";");
         for (String header : split) {
             String[] headerNameAndValue = header.split(":", 2);
+            if (headerNameAndValue.length != 2) {
+                continue;
+            }
             headers.add(headerNameAndValue[0].trim(), headerNameAndValue[1].trim());
         }
         return headers;
@@ -85,9 +89,7 @@ public class HttpSender implements MessageSender {
 
     protected String getBody(Message message) {
         WebhookChannelConfig channelConfig = (WebhookChannelConfig) message.getChannel().getChannelConfig();
-        StringSubstitutor substitutor = new StringSubstitutor(ImmutableMap.of("message", message.getContent()));
-        String bodyTemplate = channelConfig.getBodyTemplate();
-        return substitutor.replace(bodyTemplate);
+        return resolveTemplate(message, channelConfig.getBodyTemplate());
     }
 
     protected MessageSendResult checkResponse(Message message, ResponseEntity<Map> response) {
@@ -108,9 +110,14 @@ public class HttpSender implements MessageSender {
                         responseValidation, content));
     }
 
-    private void setProxyIfNeed(RestTemplate restTemplate, WebhookChannelConfig channelConfig) {
+    private RestTemplate getRestTemplate(WebhookChannelConfig channelConfig) {
+        SimpleClientHttpRequestFactory requestFactory = new SimpleClientHttpRequestFactory();
+        requestFactory.setConnectTimeout(10000);
+        requestFactory.setReadTimeout(10000);
+        RestTemplate restTemplate = new RestTemplate(requestFactory);
+
         if (StringUtils.isEmpty(channelConfig.getHttpProxy())) {
-            return;
+            return restTemplate;
         }
         String httpProxy = channelConfig.getHttpProxy();
         String[] proxyParas = httpProxy.split(":");
@@ -120,10 +127,28 @@ public class HttpSender implements MessageSender {
         String hostName = proxyParas[0].replaceFirst("//", "");
         int port = Integer.parseInt(proxyParas[1]);
         Proxy proxy = new Proxy(Type.HTTP, new InetSocketAddress(hostName, port));
-
-        SimpleClientHttpRequestFactory requestFactory = new SimpleClientHttpRequestFactory();
         requestFactory.setProxy(proxy);
-        restTemplate.setRequestFactory(requestFactory);
+        return restTemplate;
+    }
+
+    private String resolveTemplate(Message message, String template) {
+        Event event = message.getEvent();
+        WebhookChannelConfig channelConfig = (WebhookChannelConfig) message.getChannel().getChannelConfig();
+        Locale locale;
+        try {
+            locale = Locale.forLanguageTag(channelConfig.getLanguage());
+        } catch (Exception e) {
+            locale = Locale.getDefault();
+        }
+        EventLabels labels;
+        if (event == null || event.getLabels() == null) {
+            labels = new EventLabels();
+        } else {
+            labels = event.getLabels();
+        }
+        labels.putIfNonNull("message", message.getContent());
+        labels.putIfNonNull("title", message.getTitle());
+        return MessageTemplateProcessor.replaceVariables(template, locale, labels);
     }
 
 }

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/notification/NotificationScheduleConfiguration.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/notification/NotificationScheduleConfiguration.java
@@ -23,7 +23,6 @@ import java.util.concurrent.Executors;
 import java.util.function.Supplier;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.Trigger;
 import org.springframework.scheduling.annotation.EnableScheduling;
@@ -35,7 +34,6 @@ import com.oceanbase.odc.service.notification.model.MessageSendingStatus;
 
 @EnableScheduling
 @Configuration
-@ConditionalOnProperty(value = "odc.notification.enabled", havingValue = "true")
 public class NotificationScheduleConfiguration implements SchedulingConfigurer {
     @Autowired
     private NotificationProperties notificationProperties;

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/notification/helper/ChannelConfigValidator.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/notification/helper/ChannelConfigValidator.java
@@ -15,8 +15,13 @@
  */
 package com.oceanbase.odc.service.notification.helper;
 
+import java.util.Map;
+
+import org.apache.commons.collections4.MapUtils;
 import org.springframework.stereotype.Component;
 
+import com.oceanbase.odc.common.json.JsonUtils;
+import com.oceanbase.odc.common.util.StringUtils;
 import com.oceanbase.odc.core.shared.Verify;
 import com.oceanbase.odc.core.shared.exception.NotImplementedException;
 import com.oceanbase.odc.service.notification.model.BaseChannelConfig;
@@ -76,6 +81,24 @@ public class ChannelConfigValidator {
 
     private void validateWebhookChannelConfig(WebhookChannelConfig channelConfig) {
         Verify.notEmpty(channelConfig.getWebhook(), "webhook");
+        Verify.verify(channelConfig.getWebhook().startsWith("http://"), "Webhook should start with 'http://'");
+
+        String headersTemplate = channelConfig.getHeadersTemplate();
+        if (StringUtils.isNotEmpty(headersTemplate)) {
+            String[] split = headersTemplate.split(";");
+            for (String header : split) {
+                Verify.verify(2 == header.split(":").length, "Invalid header: " + header);
+            }
+        }
+
+        String responseValidation = channelConfig.getResponseValidation();
+        if (StringUtils.isNotEmpty(responseValidation) && responseValidation.startsWith("{")) {
+            Map map = JsonUtils.fromJson(responseValidation, Map.class);
+            if (MapUtils.isEmpty(map)) {
+                throw new IllegalArgumentException("Please enter a valid Json map for validation");
+            }
+        }
+
     }
 
 }

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/notification/helper/ChannelConfigValidator.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/notification/helper/ChannelConfigValidator.java
@@ -81,7 +81,9 @@ public class ChannelConfigValidator {
 
     private void validateWebhookChannelConfig(WebhookChannelConfig channelConfig) {
         Verify.notEmpty(channelConfig.getWebhook(), "webhook");
-        Verify.verify(channelConfig.getWebhook().startsWith("http://"), "Webhook should start with 'http://'");
+        Verify.verify(
+                channelConfig.getWebhook().startsWith("http://") || channelConfig.getWebhook().startsWith("https://"),
+                "Webhook should start with 'http://' or 'https://'");
 
         String headersTemplate = channelConfig.getHeadersTemplate();
         if (StringUtils.isNotEmpty(headersTemplate)) {

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/notification/model/Message.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/notification/model/Message.java
@@ -51,7 +51,7 @@ public class Message {
     private Date updateTime;
     private Date lastSentTime;
     private Channel channel;
-
+    private Event event;
 
     public MessageEntity toEntity() {
         MessageEntity entity = new MessageEntity();
@@ -70,6 +70,7 @@ public class Message {
         entity.setMaxRetryTimes(this.getMaxRetryTimes());
         entity.setLastSentTime(this.getLastSentTime());
         entity.setErrorMessage(this.getErrorMessage());
+        entity.setEventId(this.getEvent().getId());
         return entity;
     }
 
@@ -93,6 +94,8 @@ public class Message {
         message.setChannel(new Channel());
         message.getChannel().setId(entity.getChannelId());
         message.getChannel().setName(entity.getChannelName());
+        message.setEvent(new Event());
+        message.getEvent().setId(entity.getEventId());
         return message;
     }
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines.
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request.
3. Ensure you have added or ran the appropriate tests for your PR.
5. If the PR is unfinished, you may add or remove a WIP or [WIP] prefix to your pull request title.
-->

#### What type of PR is this?
type-feature
<!--
Add one of the following kinds:
type-bug
type-feature
type-docs
etc.

Optionally add one or more of the following kinds if applicable:
module-resultset
module-sql execution
etc.
-->

#### What this PR does / why we need it:

The notification channel of ODC currently supports custom webhook channel, allowing users to input custom HTTP headers and body. But this template does not support variables, and some users require this feature. So we are increasing this support.
The specific method is to add event_id into the message entity for querying variables in event labels when sending messages. Using these variables to replacing the placeholders in the body and header.