### PR TITLE
feat(database-change): support retry execute in database change task

### DIFF
--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/flow/task/model/DatabaseChangeParameters.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/flow/task/model/DatabaseChangeParameters.java
@@ -50,6 +50,7 @@ public class DatabaseChangeParameters implements Serializable, TaskParameters {
     private boolean modifyTimeoutIfTimeConsumingSqlExists = true;
     // internal usage for notification
     private JobType parentJobType;
+    private Integer retryTimes = 0;
 
     public void setErrorStrategy(String errorStrategy) {
         this.errorStrategy = TaskErrorStrategy.valueOf(errorStrategy);

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/flow/task/model/DatabaseChangeParameters.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/flow/task/model/DatabaseChangeParameters.java
@@ -51,6 +51,7 @@ public class DatabaseChangeParameters implements Serializable, TaskParameters {
     // internal usage for notification
     private JobType parentJobType;
     private Integer retryTimes = 0;
+    private Long retryIntervalMillis = 180000L;
 
     public void setErrorStrategy(String errorStrategy) {
         this.errorStrategy = TaskErrorStrategy.valueOf(errorStrategy);


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines.
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request.
3. Ensure you have added or ran the appropriate tests for your PR.
5. If the PR is unfinished, you may add or remove a WIP or [WIP] prefix to your pull request title.
-->

#### What type of PR is this?
type-feature
<!--
Add one of the following kinds:
type-bug
type-feature
type-docs
etc.

Optionally add one or more of the following kinds if applicable:
module-resultset
module-sql execution
etc.
-->

#### What this PR does / why we need it:

Currently, if a database change task fails due to external factors, it terminates. There is a need to add a retry mechanism that allows users to attempt to retry the failed task.

So we add retry capabilities to the product functionality.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1802 
