### PR TITLE
fix(stateful): max pool size may less than core pool size and cause error

### DIFF
--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/state/StateRouteAspect.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/state/StateRouteAspect.java
@@ -81,7 +81,7 @@ public class StateRouteAspect {
     private HttpRequestProvider requestProvider;
 
     @Autowired
-    private ThreadPoolExecutor stetefullRouteThreadPoolExecutor;
+    private ThreadPoolExecutor statefulRouteThreadPoolExecutor;
 
     @Pointcut("@annotation(com.oceanbase.odc.service.state.model.StatefulRoute)")
     public void stateRouteMethods() {}
@@ -135,7 +135,7 @@ public class StateRouteAspect {
             final HttpServletRequest request = requestProvider.getRequest();
             final ByteArrayOutputStream requestBody = requestProvider.getRequestBody();
             List<Pair<RouteInfo, Future<DispatchResponse>>> routeResponse = otherNodeRoute.stream().map(r -> {
-                Future<DispatchResponse> future = stetefullRouteThreadPoolExecutor.submit(
+                Future<DispatchResponse> future = statefulRouteThreadPoolExecutor.submit(
                         () -> requestDispatcher.forward(r.getHostName(), r.getPort(), request, requestBody));
                 return new Pair<>(r, future);
             }).collect(Collectors.toList());

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/state/StatefulRouteConfiguration.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/state/StatefulRouteConfiguration.java
@@ -39,11 +39,12 @@ public class StatefulRouteConfiguration {
     private Integer capacity;
 
     @Bean
-    public ThreadPoolExecutor stetefullRouteThreadPoolExecutor() {
+    public ThreadPoolExecutor statefulRouteThreadPoolExecutor() {
         int core = Math.max(SystemUtils.availableProcessors() * 2, coolPoolSize);
+        int max = Math.max(maxPoolSize, core);
         return new ThreadPoolExecutor(
                 core,
-                maxPoolSize,
+                max,
                 60L,
                 TimeUnit.SECONDS,
                 new LinkedBlockingQueue<>(capacity),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines.
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request.
3. Ensure you have added or ran the appropriate tests for your PR.
5. If the PR is unfinished, you may add or remove a WIP or [WIP] prefix to your pull request title.
-->

#### What type of PR is this?
fix maxPoolSize may less than core

<!--
Add one of the following kinds:
type-bug
type-feature
type-docs
etc.

Optionally add one or more of the following kinds if applicable:
module-resultset
module-sql execution
etc.
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

<!--
This section is used to describe how this PR is implemented. 
If this is a PR that fixes a bug, this section describes how the bug was fixed.
If it's a new feature, this section briefly describes how to implement the new feature.
etc.
-->

#### Additional documentation e.g., usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```