### PR TITLE
fix(flow): wrong total elements and total pages of flow instances while querying in page

### DIFF
--- a/server/integration-test/src/test/java/com/oceanbase/odc/service/flow/FlowInstanceServiceTest.java
+++ b/server/integration-test/src/test/java/com/oceanbase/odc/service/flow/FlowInstanceServiceTest.java
@@ -283,7 +283,7 @@ public class FlowInstanceServiceTest extends ServiceTestEnv {
     }
 
     @Test
-    public void list_TwoPages_ReturnCorrectTotalElements() {
+    public void list_ThreePages_ReturnCorrectTotalElements() {
 
         for (int i = 0; i < 5; i++) {
             FlowInstance flowInstance = createFlowInstance("test" + i);

--- a/server/odc-service/src/main/java/com/oceanbase/odc/config/jpa/EnhancedJpaRepository.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/config/jpa/EnhancedJpaRepository.java
@@ -50,7 +50,6 @@ import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 
 import com.google.common.base.Preconditions;
-import com.oceanbase.odc.metadb.flow.FlowInstanceViewEntity;
 
 import lombok.SneakyThrows;
 
@@ -128,8 +127,8 @@ public class EnhancedJpaRepository<T, ID extends Serializable> extends SimpleJpa
         Root<S> root = applySpecificationToCriteria(spec, domainClass, query);
 
         /**
-         * if group by, we calculate the count of the group instead of the sum of all group items
-         * this is the only difference with SimpleJpaRepository#getCountQuery
+         * if group by, we calculate the count of the group instead of the sum of all group items this is
+         * the only difference with SimpleJpaRepository#getCountQuery
          */
         if (query.isDistinct() || query.getGroupList().size() > 0) {
             query.select(builder.countDistinct(root));
@@ -146,7 +145,7 @@ public class EnhancedJpaRepository<T, ID extends Serializable> extends SimpleJpa
     private DataSource getDataSource(EntityManager entityManager) {
         SessionFactoryImpl sf = entityManager.getEntityManagerFactory().unwrap(SessionFactoryImpl.class);
         return ((DatasourceConnectionProviderImpl) sf.getServiceRegistry().getService(ConnectionProvider.class))
-            .getDataSource();
+                .getDataSource();
     }
 
     private Long getGeneratedId(ResultSet resultSet) throws SQLException {
@@ -162,7 +161,7 @@ public class EnhancedJpaRepository<T, ID extends Serializable> extends SimpleJpa
 
 
     private <S, U extends T> Root<U> applySpecificationToCriteria(@Nullable Specification<U> spec, Class<U> domainClass,
-        CriteriaQuery<S> query) {
+            CriteriaQuery<S> query) {
 
         Assert.notNull(domainClass, "Domain class must not be null!");
         Assert.notNull(query, "CriteriaQuery must not be null!");

--- a/server/odc-service/src/main/java/com/oceanbase/odc/config/jpa/EnhancedJpaRepository.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/config/jpa/EnhancedJpaRepository.java
@@ -20,6 +20,7 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -29,18 +30,27 @@ import java.util.function.Function;
 import java.util.stream.IntStream;
 
 import javax.persistence.EntityManager;
+import javax.persistence.TypedQuery;
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.Predicate;
+import javax.persistence.criteria.Root;
 import javax.sql.DataSource;
 
 import org.hibernate.engine.jdbc.connections.internal.DatasourceConnectionProviderImpl;
 import org.hibernate.engine.jdbc.connections.spi.ConnectionProvider;
 import org.hibernate.internal.SessionFactoryImpl;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.data.jpa.repository.support.JpaEntityInformation;
 import org.springframework.data.jpa.repository.support.SimpleJpaRepository;
 import org.springframework.jdbc.core.ConnectionCallback;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.lang.Nullable;
+import org.springframework.util.Assert;
 
 import com.google.common.base.Preconditions;
+import com.oceanbase.odc.metadb.flow.FlowInstanceViewEntity;
 
 import lombok.SneakyThrows;
 
@@ -59,10 +69,12 @@ public class EnhancedJpaRepository<T, ID extends Serializable> extends SimpleJpa
         this.namedParameterJdbcTemplate = new NamedParameterJdbcTemplate(getDataSource(entityManager));
     }
 
-    private DataSource getDataSource(EntityManager entityManager) {
-        SessionFactoryImpl sf = entityManager.getEntityManagerFactory().unwrap(SessionFactoryImpl.class);
-        return ((DatasourceConnectionProviderImpl) sf.getServiceRegistry().getService(ConnectionProvider.class))
-                .getDataSource();
+    public JdbcTemplate getJdbcTemplate() {
+        return (JdbcTemplate) namedParameterJdbcTemplate.getJdbcOperations();
+    }
+
+    public NamedParameterJdbcTemplate getNamedParameterJdbcTemplate() {
+        return namedParameterJdbcTemplate;
     }
 
     public EntityManager getEntityManager() {
@@ -107,6 +119,36 @@ public class EnhancedJpaRepository<T, ID extends Serializable> extends SimpleJpa
         return batchCreate(entities, sql, valueGetterMap, idSetter);
     }
 
+
+    @Override
+    protected <S extends T> TypedQuery<Long> getCountQuery(Specification<S> spec, Class<S> domainClass) {
+        CriteriaBuilder builder = entityManager.getCriteriaBuilder();
+        CriteriaQuery<Long> query = builder.createQuery(Long.class);
+
+        Root<S> root = applySpecificationToCriteria(spec, domainClass, query);
+
+        /**
+         * if group by, we calculate the count of the group instead of the sum of all group items
+         * this is the only difference with SimpleJpaRepository#getCountQuery
+         */
+        if (query.isDistinct() || query.getGroupList().size() > 0) {
+            query.select(builder.countDistinct(root));
+        } else {
+            query.select(builder.count(root));
+        }
+
+        // Remove all Orders the Specifications might have applied
+        query.orderBy(Collections.emptyList());
+
+        return entityManager.createQuery(query);
+    }
+
+    private DataSource getDataSource(EntityManager entityManager) {
+        SessionFactoryImpl sf = entityManager.getEntityManagerFactory().unwrap(SessionFactoryImpl.class);
+        return ((DatasourceConnectionProviderImpl) sf.getServiceRegistry().getService(ConnectionProvider.class))
+            .getDataSource();
+    }
+
     private Long getGeneratedId(ResultSet resultSet) throws SQLException {
         if (resultSet.getObject("id") != null) {
             return Long.valueOf(resultSet.getObject("id").toString());
@@ -118,12 +160,27 @@ public class EnhancedJpaRepository<T, ID extends Serializable> extends SimpleJpa
         return null;
     }
 
-    public JdbcTemplate getJdbcTemplate() {
-        return (JdbcTemplate) namedParameterJdbcTemplate.getJdbcOperations();
-    }
 
-    public NamedParameterJdbcTemplate getNamedParameterJdbcTemplate() {
-        return namedParameterJdbcTemplate;
+    private <S, U extends T> Root<U> applySpecificationToCriteria(@Nullable Specification<U> spec, Class<U> domainClass,
+        CriteriaQuery<S> query) {
+
+        Assert.notNull(domainClass, "Domain class must not be null!");
+        Assert.notNull(query, "CriteriaQuery must not be null!");
+
+        Root<U> root = query.from(domainClass);
+
+        if (spec == null) {
+            return root;
+        }
+
+        CriteriaBuilder builder = entityManager.getCriteriaBuilder();
+        Predicate predicate = spec.toPredicate(root, query, builder);
+
+        if (predicate != null) {
+            query.where(predicate);
+        }
+
+        return root;
     }
 
 }

--- a/server/odc-service/src/main/java/com/oceanbase/odc/config/jpa/EnhancedJpaRepository.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/config/jpa/EnhancedJpaRepository.java
@@ -127,10 +127,10 @@ public class EnhancedJpaRepository<T, ID extends Serializable> extends SimpleJpa
         Root<S> root = applySpecificationToCriteria(spec, domainClass, query);
 
         /**
-         * if group by, we calculate the count of the group instead of the sum of all group items this is
-         * the only difference with SimpleJpaRepository#getCountQuery
+         * if group by, we calculate the count of the group instead of the sum of all group items<br/>
+         * this is the only difference with SimpleJpaRepository#getCountQuery
          */
-        if (query.isDistinct() || query.getGroupList().size() > 0) {
+        if (query.isDistinct() || !query.getGroupList().isEmpty()) {
             query.select(builder.countDistinct(root));
         } else {
             query.select(builder.count(root));


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines.
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request.
3. Ensure you have added or ran the appropriate tests for your PR.
5. If the PR is unfinished, you may add or remove a WIP or [WIP] prefix to your pull request title.
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
type-bug
type-feature
type-docs
etc.

Optionally add one or more of the following kinds if applicable:
module-resultset
module-sql execution
etc.
-->
type-bug

#### What this PR does / why we need it:
When querying the flow instances in pages via `flow_instance_view`, it will return the wrong `totalElements` and `pageSize` consequently.

The root cause is that Spring Data JPA gives a wrong SQL to count the total elements when the SQL has a **`GROUP BY`** statement. I assume it's a Spring's issue while they don't think so. Some other developers also encountered this problem. For more discussion, you can see at https://github.com/spring-projects/spring-data-jpa/issues/2361

Here is what happened in Spring Data JPA: When we use `GROUP BY` in our query sql, what we want to obtain is how many rows of the query sql will be returned by the query, but Spring just return the sum of each group's size. For example, let's say we have a table:
```
CREATE TABLE `test` (
  `a` bigint(20) DEFAULT NULL,
  `b` bigint(20) DEFAULT NULL
)
```

And we have such records in the table:
```
a b
1 1
1 2
2 3
```

If we create a query like `select * from test group by a` and we request for a `Page` result, then the Spring will use such sql to calculate the totalElements: `select count(a) from test group by a`, and sum all the result set as the `totalElements`. The result set of the above count sql will be like:
```
count(a)
2
1
```
And Spring will return 3(2 + 1) as the `totalElements` which is wrong. What we expect is 2, because the result set of the original query will be like this(given that we use a `GROUP BY` statement):
```
a b
1 1
2 3
```
The correct answer should be 2 because there are only 2 rows of the result set if we execute the original `GROUP BY` query.

The solution here is that if the query contains a `GROUP BY` statement, we just count distinct which will trickly address the issue. Thanks for the solution by https://github.com/spring-projects/spring-data-jpa/pull/2376