### PR TITLE
fix(structure-compare): failed to run structure compare task without update connection permission

### DIFF
--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/flow/task/DBStructureComparisonFlowableTask.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/flow/task/DBStructureComparisonFlowableTask.java
@@ -146,7 +146,8 @@ public class DBStructureComparisonFlowableTask extends BaseODCFlowTaskDelegate<V
         DBStructureComparisonConfig srcConfig = new DBStructureComparisonConfig();
 
         Database database = databaseService.detail((parameters.getSourceDatabaseId()));
-        ConnectionConfig connectionConfig = connectionService.getForConnect(database.getDataSource().getId());
+        ConnectionConfig connectionConfig =
+                connectionService.getForConnectionSkipPermissionCheck(database.getDataSource().getId());
 
         srcConfig.setSchemaName(database.getName());
         srcConfig.setConnectType(connectionConfig.getType());
@@ -165,7 +166,8 @@ public class DBStructureComparisonFlowableTask extends BaseODCFlowTaskDelegate<V
         DBStructureComparisonConfig tgtConfig = new DBStructureComparisonConfig();
 
         Database database = databaseService.detail(parameters.getTargetDatabaseId());
-        ConnectionConfig connectionConfig = connectionService.getForConnect(database.getDataSource().getId());
+        ConnectionConfig connectionConfig =
+                connectionService.getForConnectionSkipPermissionCheck(database.getDataSource().getId());
         tgtConfig.setSchemaName(database.getName());
         tgtConfig.setConnectType(connectionConfig.getType());
         tgtConfig.setDataSource(new DruidDataSourceFactory(connectionConfig).getDataSource());


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines.
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request.
3. Ensure you have added or ran the appropriate tests for your PR.
5. If the PR is unfinished, you may add or remove a WIP or [WIP] prefix to your pull request title.
-->

#### What type of PR is this?
type-bug

#### What this PR does / why we need it:
`ConnectionService.getForConnect` need update connection permission, use `ConnectionService.getForConnectionSkipPermissionCheck` instead
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #2003

#### Special notes for your reviewer:

<!--
This section is used to describe how this PR is implemented. 
If this is a PR that fixes a bug, this section describes how the bug was fixed.
If it's a new feature, this section briefly describes how to implement the new feature.
etc.
-->

#### Additional documentation e.g., usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```