### PR TITLE
fix(connection):modify DruidDataSource MaxWait timeout

### DIFF
--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/session/factory/DruidDataSourceFactory.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/session/factory/DruidDataSourceFactory.java
@@ -82,7 +82,7 @@ public class DruidDataSourceFactory extends OBConsoleDataSourceFactory {
         dataSource.setMaxActive(5);
         dataSource.setInitialSize(2);
         // wait for get available connection from connection pool
-        dataSource.setMaxWait(10_000L);
+        dataSource.setMaxWait(5000L);
         /**
          * {@link DruidDataSource#init()} will set these two properties to
          * {@link com.alibaba.druid.pool.DruidAbstractDataSource#DEFAULT_TIME_SOCKET_TIMEOUT_MILLIS} if we


### PR DESCRIPTION
#### What type of PR is this?
type-bug

#### What this PR does / why we need it:
The durid connection pool will try again when it is not full, and the previously waiting time for getting connection is 10s, so the total waiting time is 20s. we just modify the max wait time to 5s.
`com.alibaba.druid.pool.DruidDataSource#getConnectionDirect`:
```
public DruidPooledConnection getConnectionDirect(long maxWaitMillis) throws SQLException {
        int notFullTimeoutRetryCnt = 0;

        DruidPooledConnection poolableConnection;
        while(true) {
            while(true) {
                try {
                    poolableConnection = this.getConnectionInternal(maxWaitMillis);
                    break;
                } catch (GetConnectionTimeoutException var23) {
                    if (notFullTimeoutRetryCnt > this.notFullTimeoutRetryCount || this.isFull()) {
                        throw var23;
                    }

                    ++notFullTimeoutRetryCnt;
                    if (LOG.isWarnEnabled()) {
                        LOG.warn("get connection timeout retry : " + notFullTimeoutRetryCnt);
                    }
                }
            }
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #2008

#### Special notes for your reviewer:

<!--
This section is used to describe how this PR is implemented. 
If this is a PR that fixes a bug, this section describes how the bug was fixed.
If it's a new feature, this section briefly describes how to implement the new feature.
etc.
-->

#### Additional documentation e.g., usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```