### PR TITLE
enhancement(connection): print exception stack when test connection failed

### DIFF
--- a/server/plugins/connect-plugin-ob-mysql/src/main/java/com/oceanbase/odc/plugin/connect/obmysql/OBMySQLConnectionExtension.java
+++ b/server/plugins/connect-plugin-ob-mysql/src/main/java/com/oceanbase/odc/plugin/connect/obmysql/OBMySQLConnectionExtension.java
@@ -142,10 +142,11 @@ public class OBMySQLConnectionExtension implements ConnectionExtensionPoint {
         } catch (Exception e) {
             Throwable rootCause = ExceptionUtils.getRootCause(e);
             if (rootCause == null) {
-                log.warn("Failed to get connection, errMsg={}", e.getLocalizedMessage(), e);
+                log.warn("Failed to get connection, errMsg={}", ExceptionUtils.getRootCauseReason(e));
                 return TestResult.unknownError(e);
             }
-            log.warn("Failed to get connection, rooCauseErrMsg={}", rootCause.getLocalizedMessage(), e);
+            log.warn("Failed to get connection, rooCauseErrMsg={}, errMsg={}", rootCause.getLocalizedMessage(),
+                    ExceptionUtils.getRootCauseReason(e));
             String host = hostAddress.getHost();
             Integer port = hostAddress.getPort();
             if (rootCause instanceof ConnectException) {

--- a/server/plugins/connect-plugin-ob-mysql/src/main/java/com/oceanbase/odc/plugin/connect/obmysql/OBMySQLConnectionExtension.java
+++ b/server/plugins/connect-plugin-ob-mysql/src/main/java/com/oceanbase/odc/plugin/connect/obmysql/OBMySQLConnectionExtension.java
@@ -142,10 +142,10 @@ public class OBMySQLConnectionExtension implements ConnectionExtensionPoint {
         } catch (Exception e) {
             Throwable rootCause = ExceptionUtils.getRootCause(e);
             if (rootCause == null) {
-                log.warn("Failed to get connection, errMsg={}", e.getLocalizedMessage());
+                log.warn("Failed to get connection, errMsg={}", e.getLocalizedMessage(), e);
                 return TestResult.unknownError(e);
             }
-            log.warn("Failed to get connection, rooCauseErrMsg={}", rootCause.getLocalizedMessage());
+            log.warn("Failed to get connection, rooCauseErrMsg={}", rootCause.getLocalizedMessage(), e);
             String host = hostAddress.getHost();
             Integer port = hostAddress.getPort();
             if (rootCause instanceof ConnectException) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines.
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request.
3. Ensure you have added or ran the appropriate tests for your PR.
5. If the PR is unfinished, you may add or remove a WIP or [WIP] prefix to your pull request title.
-->

#### What type of PR is this?
type-enhancement
<!--
Add one of the following kinds:
type-bug
type-feature
type-docs
etc.

Optionally add one or more of the following kinds if applicable:
module-resultset
module-sql execution
etc.
-->

#### What this PR does / why we need it:
When user test connection failed, the exceptio would be eaten. Make some modifications here and print the complete exception stack.