### PR TITLE
fix(result-set-export): fix export result-set for oracle failed

### DIFF
--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/resultset/DumperResultSetExportTaskManager.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/resultset/DumperResultSetExportTaskManager.java
@@ -85,6 +85,7 @@ public class DumperResultSetExportTaskManager implements ResultSetExportTaskMana
     @Autowired
     private AuthenticationFacade authenticationFacade;
 
+    @Autowired
     private DataTransferAdapter dataTransferAdapter;
 
     @PostConstruct

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/resultset/DumperResultSetExportTaskManager.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/resultset/DumperResultSetExportTaskManager.java
@@ -46,6 +46,7 @@ import com.oceanbase.odc.service.datasecurity.DataMaskingService;
 import com.oceanbase.odc.service.datasecurity.model.MaskingAlgorithm;
 import com.oceanbase.odc.service.datasecurity.model.SensitiveColumn;
 import com.oceanbase.odc.service.datasecurity.util.DataMaskingUtil;
+import com.oceanbase.odc.service.datatransfer.DataTransferAdapter;
 import com.oceanbase.odc.service.datatransfer.model.DataTransferProperties;
 import com.oceanbase.odc.service.iam.auth.AuthenticationFacade;
 import com.oceanbase.odc.service.objectstorage.cloud.CloudObjectStorageService;
@@ -83,6 +84,8 @@ public class DumperResultSetExportTaskManager implements ResultSetExportTaskMana
 
     @Autowired
     private AuthenticationFacade authenticationFacade;
+
+    private DataTransferAdapter dataTransferAdapter;
 
     @PostConstruct
     public void init() {
@@ -130,7 +133,7 @@ public class DumperResultSetExportTaskManager implements ResultSetExportTaskMana
             parameter.setSql(SqlRewriteUtil.addQueryLimit(parameter.getSql(), session, parameter.getMaxRows()));
 
             ResultSetExportTask task = new ResultSetExportTask(workingDir, logDir, parameter, session,
-                    cloudObjectStorageService, dataTransferProperties);
+                    cloudObjectStorageService, dataTransferProperties, dataTransferAdapter.getMaxDumpSizeBytes());
             return new ResultSetExportTaskContext(executor.submit(task), task);
 
         } catch (Exception e) {

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/resultset/ResultSetExportTask.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/resultset/ResultSetExportTask.java
@@ -92,12 +92,13 @@ public class ResultSetExportTask implements Callable<ResultSetExportResult> {
     private final DataTransferConfig transferConfig;
     private final ConnectionSession session;
     private final DataTransferProperties dataTransferProperties;
+    private final Long maxDumpSizeBytes;
     @Getter
     private DataTransferJob job;
 
     public ResultSetExportTask(File workingDir, File logDir, ResultSetExportTaskParameter parameter,
             ConnectionSession session, CloudObjectStorageService cloudObjectStorageService,
-            DataTransferProperties dataTransferProperties) {
+            DataTransferProperties dataTransferProperties, Long maxDumpSizeBytes) {
         PreConditions.notBlank(parameter.getFileName(), "req.fileName");
         this.parameter = parameter;
         this.logDir = logDir;
@@ -107,6 +108,7 @@ public class ResultSetExportTask implements Callable<ResultSetExportResult> {
         this.cloudObjectStorageService = cloudObjectStorageService;
         this.dataTransferProperties = dataTransferProperties;
         this.transferConfig = convertParam2TransferConfig(parameter);
+        this.maxDumpSizeBytes = maxDumpSizeBytes;
     }
 
     @Override
@@ -197,6 +199,7 @@ public class ResultSetExportTask implements Callable<ResultSetExportResult> {
         connectionInfo.setSchema(parameter.getDatabase());
         config.setConnectionInfo(connectionInfo);
 
+        config.setMaxDumpSizeBytes(maxDumpSizeBytes);
 
         config.setQuerySql(parameter.getSql());
         config.setFileType(parameter.getFileFormat().name());

--- a/server/plugins/task-plugin-ob-mysql/src/main/java/com/oceanbase/odc/plugin/task/obmysql/datatransfer/factory/BaseParameterFactory.java
+++ b/server/plugins/task-plugin-ob-mysql/src/main/java/com/oceanbase/odc/plugin/task/obmysql/datatransfer/factory/BaseParameterFactory.java
@@ -160,7 +160,7 @@ public abstract class BaseParameterFactory<T extends BaseParameter> {
                 .ifPresent(timeout -> {
                     sessionConfig.setJdbcOption("socketTimeout", timeout * 1000 + "");
                     sessionConfig.setJdbcOption("connectTimeout", timeout * 1000 + "");
-                    sessionConfig.addInitSql4Both("set ob_query_timeout = " + timeout * 1000000);
+                    sessionConfig.addInitSql4Both("set ob_query_timeout = " + timeout * 1000000L);
                 });
 
         parameter.setSessionConfig(sessionConfig);


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines.
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request.
3. Ensure you have added or ran the appropriate tests for your PR.
5. If the PR is unfinished, you may add or remove a WIP or [WIP] prefix to your pull request title.
-->

#### What type of PR is this?
type-bug
<!--
Add one of the following kinds:
type-bug
type-feature
type-docs
etc.

Optionally add one or more of the following kinds if applicable:
module-resultset
module-sql execution
etc.
-->

#### What this PR does / why we need it:

1. The `fetch first x rows only` syntax is only available on oracle after 12c. So we change it into `where rownum<=x`.
2. When export result-set, the `maxDumpSizeBytes` was not set. Fixed this.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #2017 