### PR TITLE
fix(partition-plan): failed to view partition plan tables when partition is not active

### DIFF
--- a/server/integration-test/src/test/java/com/oceanbase/odc/service/partitionplan/PartitionPlanScheduleServiceTest.java
+++ b/server/integration-test/src/test/java/com/oceanbase/odc/service/partitionplan/PartitionPlanScheduleServiceTest.java
@@ -50,6 +50,7 @@ import com.oceanbase.odc.plugin.task.api.partitionplan.model.TimeIncreaseGenerat
 import com.oceanbase.odc.service.connection.database.DatabaseService;
 import com.oceanbase.odc.service.connection.database.model.Database;
 import com.oceanbase.odc.service.flow.FlowInstanceService;
+import com.oceanbase.odc.service.flow.model.FlowInstanceDetailResp;
 import com.oceanbase.odc.service.partitionplan.model.PartitionPlanConfig;
 import com.oceanbase.odc.service.partitionplan.model.PartitionPlanKeyConfig;
 import com.oceanbase.odc.service.partitionplan.model.PartitionPlanStrategy;
@@ -276,8 +277,9 @@ public class PartitionPlanScheduleServiceTest extends ServiceTestEnv {
                 .thenReturn(TestRandom.nextObject(ScheduleEntity.class));
         Mockito.doNothing().when(this.scheduleService).enable(Mockito.isA(ScheduleEntity.class));
         this.partitionPlanScheduleService.submit(partitionPlanConfig);
-        Mockito.when(this.flowInstanceService.mapFlowInstance(Mockito.any(), Mockito.any(), Mockito.any()))
-                .thenReturn(partitionPlanConfig.getFlowInstanceId());
+        FlowInstanceDetailResp resp = new FlowInstanceDetailResp();
+        resp.setId(partitionPlanConfig.getFlowInstanceId());
+        Mockito.when(this.flowInstanceService.detail(Mockito.any())).thenReturn(resp);
         PartitionPlanConfig expect = this.partitionPlanScheduleService
                 .getPartitionPlanByFlowInstanceId(partitionPlanConfig.getFlowInstanceId());
         Assert.assertEquals(1, expect.getPartitionTableConfigs().size());
@@ -352,8 +354,9 @@ public class PartitionPlanScheduleServiceTest extends ServiceTestEnv {
                 .thenReturn(TestRandom.nextObject(ScheduleEntity.class));
         Mockito.doNothing().when(this.scheduleService).enable(Mockito.isA(ScheduleEntity.class));
         this.partitionPlanScheduleService.submit(partitionPlanConfig);
-        Mockito.when(this.flowInstanceService.mapFlowInstance(Mockito.any(), Mockito.any(), Mockito.any()))
-                .thenReturn(partitionPlanConfig.getFlowInstanceId());
+        FlowInstanceDetailResp resp = new FlowInstanceDetailResp();
+        resp.setId(partitionPlanConfig.getFlowInstanceId());
+        Mockito.when(this.flowInstanceService.detail(Mockito.any())).thenReturn(resp);
         PartitionPlanConfig cfg = this.partitionPlanScheduleService
                 .getPartitionPlanByFlowInstanceId(partitionPlanConfig.getFlowInstanceId());
         List<PartitionPlanTableConfig> expects = this.partitionPlanScheduleService.getPartitionPlanTables(

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/partitionplan/PartitionPlanScheduleService.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/partitionplan/PartitionPlanScheduleService.java
@@ -33,6 +33,7 @@ import org.springframework.stereotype.Service;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.oceanbase.odc.common.json.JsonUtils;
 import com.oceanbase.odc.core.authority.util.SkipAuthorize;
+import com.oceanbase.odc.core.flow.model.TaskParameters;
 import com.oceanbase.odc.core.shared.constant.FlowStatus;
 import com.oceanbase.odc.core.shared.constant.TaskErrorStrategy;
 import com.oceanbase.odc.metadb.flow.FlowInstanceRepository;
@@ -46,7 +47,7 @@ import com.oceanbase.odc.metadb.schedule.ScheduleEntity;
 import com.oceanbase.odc.service.connection.database.DatabaseService;
 import com.oceanbase.odc.service.connection.database.model.Database;
 import com.oceanbase.odc.service.flow.FlowInstanceService;
-import com.oceanbase.odc.service.flow.instance.FlowInstance;
+import com.oceanbase.odc.service.flow.model.FlowInstanceDetailResp;
 import com.oceanbase.odc.service.iam.auth.AuthenticationFacade;
 import com.oceanbase.odc.service.partitionplan.model.PartitionPlanConfig;
 import com.oceanbase.odc.service.partitionplan.model.PartitionPlanKeyConfig;
@@ -91,9 +92,19 @@ public class PartitionPlanScheduleService {
     private FlowInstanceRepository flowInstanceRepository;
 
     public PartitionPlanConfig getPartitionPlanByFlowInstanceId(@NonNull Long flowInstanceId) {
-        Long fId = this.flowInstanceService.mapFlowInstance(flowInstanceId, FlowInstance::getId, false);
-        Optional<PartitionPlanEntity> optional = this.partitionPlanRepository.findByFlowInstanceId(fId);
-        return optional.map(this::getPartitionPlan).orElse(null);
+        FlowInstanceDetailResp resp = this.flowInstanceService.detail(flowInstanceId);
+        Optional<PartitionPlanEntity> optional = this.partitionPlanRepository.findByFlowInstanceId(resp.getId());
+        if (optional.isPresent()) {
+            return optional.map(this::getPartitionPlan).get();
+        }
+        TaskParameters parameters = resp.getParameters();
+        if (!(parameters instanceof PartitionPlanConfig)) {
+            return null;
+        }
+        PartitionPlanConfig partitionPlanConfig = (PartitionPlanConfig) parameters;
+        partitionPlanConfig.setEnabled(false);
+        partitionPlanConfig.getPartitionTableConfigs().forEach(t -> t.setEnabled(false));
+        return partitionPlanConfig;
     }
 
     public PartitionPlanConfig getPartitionPlanByDatabaseId(@NonNull Long databaseId) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines.
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request.
3. Ensure you have added or ran the appropriate tests for your PR.
5. If the PR is unfinished, you may add or remove a WIP or [WIP] prefix to your pull request title.
-->

#### What type of PR is this?

type-bug
<!--
Add one of the following kinds:
type-bug
type-feature
type-docs
etc.

Optionally add one or more of the following kinds if applicable:
module-resultset
module-sql execution
etc.
-->

#### What this PR does / why we need it:
The partition plan configuration of a specific table cannot be viewed when the partition plan is not in effect. This is because the relevant records have been inserted into the corresponding table when the partition plan is started (usually in the antenna), so they cannot be found.

This PR fixes this problem. When the relevant records cannot be found, they are obtained from the parameters of the task.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #2089 

#### Special notes for your reviewer:

<!--
This section is used to describe how this PR is implemented. 
If this is a PR that fixes a bug, this section describes how the bug was fixed.
If it's a new feature, this section briefly describes how to implement the new feature.
etc.
-->

#### Additional documentation e.g., usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```