### PR TITLE
fix(data-transfer): obloader fail to load MANIFEST.bin

### DIFF
--- a/server/plugins/task-plugin-api/src/main/java/com/oceanbase/odc/plugin/task/api/datatransfer/dumper/ExportOutput.java
+++ b/server/plugins/task-plugin-api/src/main/java/com/oceanbase/odc/plugin/task/api/datatransfer/dumper/ExportOutput.java
@@ -116,12 +116,11 @@ public class ExportOutput {
             }
         }
         for (DumpDBObject dumpDbObject : dumpDbObjects) {
-            String dirName = dumpDbObject.getObjectType().getName();
-            FileUtils.forceMkdir(new File(parent + dirName));
+            File dir = Paths.get(parent, "data", dumpDbObject.getObjectType().getName()).toFile();
+            FileUtils.forceMkdir(dir);
             for (AbstractOutputFile outputFile : dumpDbObject.getOutputFiles()) {
-                String name = parent + dirName + File.separator + outputFile.getFileName();
                 try (InputStream inputStream = outputFile.getUrl().openStream();
-                        OutputStream outputStream = new FileOutputStream(name)) {
+                        OutputStream outputStream = new FileOutputStream(new File(dir, outputFile.getFileName()))) {
                     IOUtils.copy(inputStream, outputStream);
                 }
             }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines.
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request.
3. Ensure you have added or ran the appropriate tests for your PR.
5. If the PR is unfinished, you may add or remove a WIP or [WIP] prefix to your pull request title.
-->

#### What type of PR is this?
type-bug
<!--
Add one of the following kinds:
type-bug
type-feature
type-docs
etc.

Optionally add one or more of the following kinds if applicable:
module-resultset
module-sql execution
etc.
-->

#### What this PR does / why we need it:

In the earlier version, ob-loader-dumper would save binary files like `MANIFEST.bin` in data directory. 
But in obloader-2.4.8.2, it has changed the file path into root directory. So ODC has adapted this feature.

FROM
```
root
└── data
    ├── TABLE
    │      └── xxx.sql
    └── MANIFEST.bin
```
TO
```
root
├── data
│     └── TABLE
│          └── xxx.sql
└── MANIFEST.bin
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #2176 