### PR TITLE
fix(notification): lost sign when updating channel

### DIFF
--- a/server/integration-test/src/test/java/com/oceanbase/odc/service/notification/NotificationServiceTest.java
+++ b/server/integration-test/src/test/java/com/oceanbase/odc/service/notification/NotificationServiceTest.java
@@ -126,6 +126,20 @@ public class NotificationServiceTest extends AuthorityTestEnv {
     }
 
     @Test
+    public void test_UpdateChannel_withSign() {
+        Channel channel = getChannel();
+        ((DingTalkChannelConfig) channel.getChannelConfig()).setSign("password");
+        Channel saved = notificationService.createChannel(PROJECT_ID, channel);
+        DingTalkChannelConfig config = new DingTalkChannelConfig();
+        config.setWebhook("https://oapi.dingtalk.com/robot");
+        saved.setChannelConfig(config);
+        Channel updated = notificationService.updateChannel(PROJECT_ID, saved);
+
+        Channel updatedWithConfig = notificationService.detailChannel(PROJECT_ID, updated.getId());
+        Assert.assertEquals("password", ((DingTalkChannelConfig) updatedWithConfig.getChannelConfig()).getSign());
+    }
+
+    @Test
     public void test_DeleteChannel() {
         Channel saved = notificationService.createChannel(PROJECT_ID, getChannel());
         notificationService.deleteChannel(PROJECT_ID, saved.getId());

--- a/server/odc-service/src/main/java/com/oceanbase/odc/metadb/notification/ChannelRepository.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/metadb/notification/ChannelRepository.java
@@ -19,12 +19,15 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
+import javax.transaction.Transactional;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.oceanbase.odc.config.jpa.OdcJpaRepository;
 import com.oceanbase.odc.service.notification.model.QueryChannelParams;
@@ -52,5 +55,12 @@ public interface ChannelRepository extends OdcJpaRepository<ChannelEntity, Long>
                 .and(OdcJpaRepository.in(ChannelEntity_.type, params.getChannelTypes()));
         return findAll(specs, pageable);
     }
+
+    @Modifying
+    @Transactional
+    @Query(value = "update notification_channel set name=:#{#channel.name}, type=:#{#channel.type.name()}, "
+            + "description=:#{#channel.description} where id=:#{#channel.id}",
+            nativeQuery = true)
+    int update(@Param("channel") ChannelEntity channel);
 
 }

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/notification/helper/ChannelMapper.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/notification/helper/ChannelMapper.java
@@ -94,6 +94,10 @@ public class ChannelMapper {
         if (Objects.nonNull(channelConfig)) {
             Map<String, Object> properties =
                     JsonUtils.fromJsonMap(JsonUtils.toJsonIgnoreNull(channelConfig), String.class, Object.class);
+            if (channelConfig instanceof WebhookChannelConfig
+                    && ((WebhookChannelConfig) channelConfig).getSign() != null) {
+                properties.put("sign", ((WebhookChannelConfig) channelConfig).getSign());
+            }
             entity.setProperties(properties.entrySet().stream()
                     .map(entry -> {
                         ChannelPropertyEntity property = new ChannelPropertyEntity();

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/notification/model/WebhookChannelConfig.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/notification/model/WebhookChannelConfig.java
@@ -17,8 +17,9 @@ package com.oceanbase.odc.service.notification.model;
 
 import org.springframework.http.HttpMethod;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonProperty.Access;
 import com.oceanbase.odc.common.json.SensitiveInput;
-import com.oceanbase.odc.common.json.SensitiveOutput;
 
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -34,7 +35,7 @@ public class WebhookChannelConfig extends BaseChannelConfig {
     private String webhook;
 
     @SensitiveInput
-    @SensitiveOutput
+    @JsonProperty(access = Access.WRITE_ONLY)
     private String sign;
 
     private String httpProxy;


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines.
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request.
3. Ensure you have added or ran the appropriate tests for your PR.
5. If the PR is unfinished, you may add or remove a WIP or [WIP] prefix to your pull request title.
-->

#### What type of PR is this?
type-bug
<!--
Add one of the following kinds:
type-bug
type-feature
type-docs
etc.

Optionally add one or more of the following kinds if applicable:
module-resultset
module-sql execution
etc.
-->

#### What this PR does / why we need it:

When user edit and update channel with sign, the sign would be lost after updating.
This is due to the annotation of `@OneToMany`, which caused the new `ChannelPropertyEntity` to overwrite the old ones when editing `ChannelEntity`.
This PR modifies the `save` to the `update` method of `ChannelRepository`. And abandoned the cascading updates of JPA, instead manually deleting ChannelProperty and inserting them again.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #2305 