### PR TITLE
fix(full-link-trace): enable trace by default on OB 4.x

### DIFF
--- a/server/plugins/connect-plugin-ob-mysql/src/main/java/com/oceanbase/odc/plugin/connect/obmysql/initializer/EnableTraceInitializer.java
+++ b/server/plugins/connect-plugin-ob-mysql/src/main/java/com/oceanbase/odc/plugin/connect/obmysql/initializer/EnableTraceInitializer.java
@@ -38,11 +38,12 @@ public class EnableTraceInitializer implements ConnectionInitializer {
     @Override
     public void init(Connection connection) {
         try {
-            String sql = "set session %s='ON';";
             String version = OBUtils.getObVersion(connection);
             try (Statement statement = connection.createStatement()) {
+                String sql = "set session %s='ON';";
                 if (VersionUtils.isGreaterThanOrEqualsTo(version, "4.0.0")) {
                     statement.execute(String.format(sql, "ob_enable_show_trace"));
+                    statement.execute("CALL DBMS_MONITOR.OB_SESSION_TRACE_ENABLE(null, 1, 1, 'ALL')");
                 } else {
                     statement.execute(String.format(sql, "ob_enable_trace_log"));
                 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines.
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request.
3. Ensure you have added or ran the appropriate tests for your PR.
5. If the PR is unfinished, you may add or remove a WIP or [WIP] prefix to your pull request title.
-->

#### What type of PR is this?
type-bug
<!--
Add one of the following kinds:
type-bug
type-feature
type-docs
etc.

Optionally add one or more of the following kinds if applicable:
module-resultset
module-sql execution
etc.
-->

#### What this PR does / why we need it:

Sometimes, due to performance issues, some tenants may default to disabling full link traces. This will result in the trace function of ODC becoming unavailable.
To avoid this issue, we enabled full link trace by default on version 4. x.
Please note that `DBMS_MONITOR.OB_SESSION_TRACE_ENABLE` called here  is session level and does not affect the overall tenant. Therefore, the impact on tenant performance should be controllable
