### PR TITLE
fix(obclient): remove unexpected characters to avoid obclient display incorrectly

### DIFF
--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/websocket/OBClientReadThread.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/websocket/OBClientReadThread.java
@@ -18,6 +18,7 @@ package com.oceanbase.odc.service.websocket;
 import java.io.InputStream;
 import java.util.Arrays;
 import java.util.function.Consumer;
+import java.util.regex.Pattern;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -28,6 +29,8 @@ import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 public class OBClientReadThread extends Thread {
+    private static final Pattern UNEXPECTED_SEQUENCE_PATTERN = Pattern.compile(" \\r");
+
     private Consumer<String> messageConsumer;
     private InputStream inputStream;
     private volatile Boolean stop = false;
@@ -63,7 +66,7 @@ public class OBClientReadThread extends Thread {
                     // ref: https://www.fileformat.info/info/unicode/char/fffd/index.htm
                     String result = new String(builder);
                     if (!result.endsWith("\uFFFD")) {
-                        messageConsumer.accept(result);
+                        messageConsumer.accept(UNEXPECTED_SEQUENCE_PATTERN.matcher(result).replaceAll(""));
                         builder = new byte[1024];
                         total = 0;
                     }

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/websocket/OBClientReadThread.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/websocket/OBClientReadThread.java
@@ -29,6 +29,8 @@ import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 public class OBClientReadThread extends Thread {
+    // when client sends a row of data that exceeds a certain length, a ' \r' will be added, causing
+    // errors in the ODC front-end display. This charsequence should be filtered.
     private static final Pattern UNEXPECTED_SEQUENCE_PATTERN = Pattern.compile(" \\r");
 
     private Consumer<String> messageConsumer;


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines.
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request.
3. Ensure you have added or ran the appropriate tests for your PR.
5. If the PR is unfinished, you may add or remove a WIP or [WIP] prefix to your pull request title.
-->

#### What type of PR is this?
type-bug
<!--
Add one of the following kinds:
type-bug
type-feature
type-docs
etc.

Optionally add one or more of the following kinds if applicable:
module-resultset
module-sql execution
etc.
-->

#### What this PR does / why we need it:

When input a long sequence in obclient, it would return a sequence with ` \r` in it. And it would cause the cursor going back to head of the line . 
So we replace these unexpected characters manually.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #2301