### PR TITLE
fix(shadowtable): bad sql grammer when table column's default value is a string type in MySQL

### DIFF
--- a/server/odc-common/pom.xml
+++ b/server/odc-common/pom.xml
@@ -171,5 +171,9 @@
             <groupId>com.auth0</groupId>
             <artifactId>java-jwt</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.oceanbase</groupId>
+            <artifactId>db-browser</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/server/odc-common/src/main/java/com/oceanbase/odc/common/util/StringUtils.java
+++ b/server/odc-common/src/main/java/com/oceanbase/odc/common/util/StringUtils.java
@@ -18,6 +18,7 @@ package com.oceanbase.odc.common.util;
 import java.net.URLDecoder;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
@@ -25,8 +26,12 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.apache.commons.text.StringSubstitutor;
+import org.springframework.util.CollectionUtils;
 
 import com.google.common.primitives.Chars;
+import com.oceanbase.tools.dbbrowser.model.DBTable;
+import com.oceanbase.tools.dbbrowser.model.DBTableColumn;
+import com.oceanbase.tools.dbbrowser.model.datatype.DataTypeUtil;
 
 import lombok.NonNull;
 
@@ -161,6 +166,31 @@ public abstract class StringUtils extends org.apache.commons.lang3.StringUtils {
         }
         String unwrap = unwrap(str, wrapChar);
         return unescapeUseDouble(unwrap, escapeChars);
+    }
+
+    public static void quoteColumnDefaultValues(DBTable table) {
+        if (!CollectionUtils.isEmpty(table.getColumns())) {
+            table.getColumns().forEach(column -> {
+                String defaultValue = column.getDefaultValue();
+                if (StringUtils.isNotEmpty(defaultValue)) {
+                    if (!isDefaultValueBuiltInFunction(column)) {
+                        column.setDefaultValue("'".concat(defaultValue.replace("'", "''")).concat("'"));
+                    }
+                }
+            });
+        }
+    }
+
+    /**
+     * Check whether the data_default contain built in function. Any of the synonyms for
+     * CURRENT_TIMESTAMP have the same meaning as CURRENT_TIMESTAMP. These are CURRENT_TIMESTAMP(),
+     * NOW(), LOCALTIME, LOCALTIME(), LOCALTIMESTAMP, and LOCALTIMESTAMP().
+     */
+    private static boolean isDefaultValueBuiltInFunction(DBTableColumn column) {
+        return com.oceanbase.tools.dbbrowser.util.StringUtils.isEmpty(column.getDefaultValue())
+                || (!DataTypeUtil.isStringType(column.getTypeName())
+                        && column.getDefaultValue().trim().toUpperCase(Locale.getDefault())
+                                .startsWith("CURRENT_TIMESTAMP"));
     }
 
     public static String singleLine(final String str) {

--- a/server/odc-common/src/main/java/com/oceanbase/odc/common/util/StringUtils.java
+++ b/server/odc-common/src/main/java/com/oceanbase/odc/common/util/StringUtils.java
@@ -168,7 +168,7 @@ public abstract class StringUtils extends org.apache.commons.lang3.StringUtils {
         return unescapeUseDouble(unwrap, escapeChars);
     }
 
-    public static void quoteColumnDefaultValues(DBTable table) {
+    public static void quoteColumnDefaultValuesForMySQL(DBTable table) {
         if (!CollectionUtils.isEmpty(table.getColumns())) {
             table.getColumns().forEach(column -> {
                 String defaultValue = column.getDefaultValue();

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/shadowtable/ShadowTableComparingTask.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/shadowtable/ShadowTableComparingTask.java
@@ -105,7 +105,7 @@ public class ShadowTableComparingTask implements Callable<Void> {
                                 .filter(entry -> allRealTableNames.contains(entry.getKey()))
                                 .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
                 if (connectionSession.getDialectType().isMysql()) {
-                    tableName2Tables.values().forEach(StringUtils::quoteColumnDefaultValues);
+                    tableName2Tables.values().forEach(StringUtils::quoteColumnDefaultValuesForMySQL);
                 }
 
             } catch (Exception ex) {

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/structurecompare/DefaultDBStructureComparator.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/structurecompare/DefaultDBStructureComparator.java
@@ -90,8 +90,8 @@ public class DefaultDBStructureComparator implements DBStructureComparator {
         Map<String, DBTable> tgtTableName2Table = tgtAccessor.getTables(tgtConfig.getSchemaName(), null);
 
         if (srcConfig.getConnectType().getDialectType().isMysql()) {
-            srcTableName2Table.values().forEach(StringUtils::quoteColumnDefaultValues);
-            tgtTableName2Table.values().forEach(StringUtils::quoteColumnDefaultValues);
+            srcTableName2Table.values().forEach(StringUtils::quoteColumnDefaultValuesForMySQL);
+            tgtTableName2Table.values().forEach(StringUtils::quoteColumnDefaultValuesForMySQL);
         }
         log.info(
                 "DefaultDBStructureComparator build source and target schema tables success, time consuming={} seconds",

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/structurecompare/DefaultDBStructureComparator.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/structurecompare/DefaultDBStructureComparator.java
@@ -25,6 +25,7 @@ import java.util.Set;
 import javax.sql.DataSource;
 
 import com.oceanbase.odc.common.util.JdbcOperationsUtil;
+import com.oceanbase.odc.common.util.StringUtils;
 import com.oceanbase.odc.core.shared.constant.ConnectType;
 import com.oceanbase.odc.core.shared.constant.DialectType;
 import com.oceanbase.odc.service.db.browser.DBSchemaAccessors;
@@ -87,6 +88,11 @@ public class DefaultDBStructureComparator implements DBStructureComparator {
         long startTimestamp = System.currentTimeMillis();
         Map<String, DBTable> srcTableName2Table = srcAccessor.getTables(srcConfig.getSchemaName(), null);
         Map<String, DBTable> tgtTableName2Table = tgtAccessor.getTables(tgtConfig.getSchemaName(), null);
+
+        if (srcConfig.getConnectType().getDialectType().isMysql()) {
+            srcTableName2Table.values().forEach(StringUtils::quoteColumnDefaultValues);
+            tgtTableName2Table.values().forEach(StringUtils::quoteColumnDefaultValues);
+        }
         log.info(
                 "DefaultDBStructureComparator build source and target schema tables success, time consuming={} seconds",
                 (System.currentTimeMillis() - startTimestamp) / 1000);


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines.
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request.
3. Ensure you have added or ran the appropriate tests for your PR.
5. If the PR is unfinished, you may add or remove a WIP or [WIP] prefix to your pull request title.
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
type-bug
type-feature
type-docs
etc.

Optionally add one or more of the following kinds if applicable:
module-resultset
module-sql execution
etc.
-->
type-bug

#### What this PR does / why we need it:
When the original table column's default is a string type, the generated ddl does not quote the default value which causes to sql execution failed.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #2379 

#### Special notes for your reviewer:

<!--
This section is used to describe how this PR is implemented. 
If this is a PR that fixes a bug, this section describes how the bug was fixed.
If it's a new feature, this section briefly describes how to implement the new feature.
etc.
-->
This issue was introduced by https://github.com/oceanbase/odc/pull/1401

#### Additional documentation e.g., usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```