### PR TITLE
fix(data-transfer): fix incorrect task result update

### DIFF
--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/flow/task/BaseODCFlowTaskDelegate.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/flow/task/BaseODCFlowTaskDelegate.java
@@ -126,7 +126,9 @@ public abstract class BaseODCFlowTaskDelegate<T> extends BaseRuntimeFlowableDele
         int interval = RuntimeTaskConstants.DEFAULT_TASK_CHECK_INTERVAL_SECONDS;
         scheduleExecutor.scheduleAtFixedRate(() -> {
             try {
-                onProgressUpdate(taskId, taskService);
+                if (taskLatch.getCount() > 0) {
+                    onProgressUpdate(taskId, taskService);
+                }
             } catch (Exception e) {
                 log.warn("Update task progress callback failed, taskId={}", taskId, e);
             }

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/flow/task/FlowTaskCallBackApprovalService.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/flow/task/FlowTaskCallBackApprovalService.java
@@ -103,7 +103,7 @@ public class FlowTaskCallBackApprovalService {
         FlowInstanceEntity flowInstance = getFlowInstance(flowInstanceId);
         FlowableElement flowableElement = getFlowableElementOfUserTask(flowTaskInstanceId);
 
-        Await.await().timeout(60).timeUnit(TimeUnit.SECONDS)
+        Await.await().timeout(60).timeUnit(TimeUnit.SECONDS).period(1).periodTimeUnit(TimeUnit.SECONDS)
                 .until(getFlowableTask(flowInstance, flowableElement.getName())::isPresent).build().start();
         Task task = getFlowableTask(flowInstance, flowableElement.getName()).get();
         doCompleteTask(flowInstanceId, flowTaskInstanceId, flowNodeStatus, approvalVariables, task.getId());


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines.
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request.
3. Ensure you have added or ran the appropriate tests for your PR.
5. If the PR is unfinished, you may add or remove a WIP or [WIP] prefix to your pull request title.
-->

#### What type of PR is this?
type-bug
<!--
Add one of the following kinds:
type-bug
type-feature
type-docs
etc.

Optionally add one or more of the following kinds if applicable:
module-resultset
module-sql execution
etc.
-->

#### What this PR does / why we need it:

In DataTransferRuntimeFlowableTask, we use TaskService#update to upgrade task result, then use TaskService#success to finish task. 
If the `success` is called before `update`, the real result woule be overwriten.