### PR TITLE
fix(taskframework): daemon job be fired at one time in cluster model

### DIFF
--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/task/caller/ProcessJobCaller.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/task/caller/ProcessJobCaller.java
@@ -17,6 +17,7 @@
 package com.oceanbase.odc.service.task.caller;
 
 import java.text.MessageFormat;
+import java.util.Objects;
 import java.util.Optional;
 
 import com.oceanbase.odc.common.util.SystemUtils;
@@ -73,7 +74,8 @@ public class ProcessJobCaller extends BaseJobCaller {
                     pid, executorName);
         }
 
-        String portString = Optional.ofNullable(SystemUtils.getEnvOrProperty("server.port"))
+        JobConfiguration jobConfiguration = JobConfigurationHolder.getJobConfiguration();
+        String portString = Optional.ofNullable(jobConfiguration.getHostProperties().getPort())
                 .orElse(DefaultExecutorIdentifier.DEFAULT_PORT + "");
         // set process id as namespace
         return DefaultExecutorIdentifier.builder().host(SystemUtils.getLocalIpAddress())
@@ -97,7 +99,10 @@ public class ProcessJobCaller extends BaseJobCaller {
             return;
         }
 
-        if (SystemUtils.getLocalIpAddress().equals(ei.getHost())) {
+        JobConfiguration jobConfiguration = JobConfigurationHolder.getJobConfiguration();
+        String portString = Optional.ofNullable(jobConfiguration.getHostProperties().getPort())
+                .orElse(DefaultExecutorIdentifier.DEFAULT_PORT + "");
+        if (SystemUtils.getLocalIpAddress().equals(ei.getHost()) && Objects.equals(portString, ei.getPort() + "")) {
             updateExecutorDestroyed(ji);
             return;
         }

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/task/config/DefaultJobConfiguration.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/task/config/DefaultJobConfiguration.java
@@ -19,6 +19,7 @@ package com.oceanbase.odc.service.task.config;
 import org.quartz.Scheduler;
 
 import com.oceanbase.odc.common.event.EventPublisher;
+import com.oceanbase.odc.service.common.model.HostProperties;
 import com.oceanbase.odc.service.connection.ConnectionService;
 import com.oceanbase.odc.service.objectstorage.cloud.model.CloudEnvConfigurations;
 import com.oceanbase.odc.service.schedule.ScheduleTaskService;
@@ -78,4 +79,6 @@ public abstract class DefaultJobConfiguration implements JobConfiguration {
     protected TaskFrameworkDisabledHandler taskFrameworkDisabledHandler;
 
     protected JasyptEncryptorConfigProperties jasyptEncryptorConfigProperties;
+
+    protected HostProperties hostProperties;
 }

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/task/config/DefaultSpringJobConfiguration.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/task/config/DefaultSpringJobConfiguration.java
@@ -74,6 +74,7 @@ public class DefaultSpringJobConfiguration extends DefaultJobConfiguration
         initJobRateLimiter();
         setTaskFrameworkDisabledHandler(new DefaultTaskFrameworkDisabledHandler());
         setJasyptEncryptorConfigProperties(ctx.getBean(JasyptEncryptorConfigProperties.class));
+        setHostProperties(ctx.getBean(HostProperties.class));
     }
 
     @Override

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/task/config/JobConfiguration.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/task/config/JobConfiguration.java
@@ -19,6 +19,7 @@ package com.oceanbase.odc.service.task.config;
 import org.quartz.Scheduler;
 
 import com.oceanbase.odc.common.event.EventPublisher;
+import com.oceanbase.odc.service.common.model.HostProperties;
 import com.oceanbase.odc.service.connection.ConnectionService;
 import com.oceanbase.odc.service.objectstorage.cloud.model.CloudEnvConfigurations;
 import com.oceanbase.odc.service.schedule.ScheduleTaskService;
@@ -72,4 +73,6 @@ public interface JobConfiguration {
     TaskFrameworkDisabledHandler getTaskFrameworkDisabledHandler();
 
     JasyptEncryptorConfigProperties getJasyptEncryptorConfigProperties();
+
+    HostProperties getHostProperties();
 }

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/task/config/TaskFrameworkConfiguration.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/task/config/TaskFrameworkConfiguration.java
@@ -75,11 +75,10 @@ public class TaskFrameworkConfiguration {
 
     @Lazy
     @Bean("taskFrameworkSchedulerFactoryBean")
-    public SchedulerFactoryBean taskFrameworkSchedulerFactoryBean(DataSource dataSource,
+    public SchedulerFactoryBean taskFrameworkSchedulerFactoryBean(
             TaskFrameworkProperties taskFrameworkProperties,
             @Qualifier("taskFrameworkMonitorExecutor") ThreadPoolTaskExecutor executor) {
         SchedulerFactoryBean schedulerFactoryBean = new SchedulerFactoryBean();
-        schedulerFactoryBean.setDataSource(dataSource);
         String taskFrameworkSchedulerName = "TASK-FRAMEWORK-SCHEDULER";
         schedulerFactoryBean.setSchedulerName(taskFrameworkSchedulerName);
         schedulerFactoryBean.setStartupDelay(taskFrameworkProperties.getQuartzStartDelaySeconds());

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/task/config/TaskFrameworkConfiguration.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/task/config/TaskFrameworkConfiguration.java
@@ -16,8 +16,6 @@
 
 package com.oceanbase.odc.service.task.config;
 
-import javax.sql.DataSource;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines.
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request.
3. Ensure you have added or ran the appropriate tests for your PR.
5. If the PR is unfinished, you may add or remove a WIP or [WIP] prefix to your pull request title.
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
type-bug
type-feature
type-docs
etc.

Optionally add one or more of the following kinds if applicable:
module-resultset
module-sql execution
etc.
-->
daemon job running be fired at one time in cluster model, so we remove datasource and quartz will use RAMJobStore as non-cluster model

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

<!--
This section is used to describe how this PR is implemented. 
If this is a PR that fixes a bug, this section describes how the bug was fixed.
If it's a new feature, this section briefly describes how to implement the new feature.
etc.
-->

#### Additional documentation e.g., usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```