### PR TITLE
fix(database-permission): could not call inside dbms package in SQL console

### DIFF
--- a/server/integration-test/src/test/java/com/oceanbase/odc/service/permission/PermissionCheckWhitelistTest.java
+++ b/server/integration-test/src/test/java/com/oceanbase/odc/service/permission/PermissionCheckWhitelistTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2023 OceanBase.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.oceanbase.odc.service.permission;
+
+import java.util.Set;
+import java.util.TreeSet;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import com.oceanbase.odc.ServiceTestEnv;
+import com.oceanbase.odc.core.shared.constant.DialectType;
+import com.oceanbase.odc.service.permission.common.PermissionCheckWhitelist;
+
+/**
+ * @author gaoda.xy
+ * @date 2024/5/20 15:10
+ */
+public class PermissionCheckWhitelistTest extends ServiceTestEnv {
+
+    @Autowired
+    private PermissionCheckWhitelist permissionCheckWhitelist;
+
+    @Test
+    public void test_checkWhitelist_OBMySQL() {
+        Set<String> whitelist = permissionCheckWhitelist.getDatabaseWhitelist(DialectType.OB_MYSQL);
+        Assert.assertTrue(whitelist instanceof TreeSet);
+        Assert.assertTrue(whitelist.contains("DBMS_STATS"));
+        Assert.assertTrue(whitelist.contains("dbms_stats"));
+    }
+
+    @Test
+    public void test_checkWhitelist_OBOracle() {
+        Set<String> whitelist = permissionCheckWhitelist.getDatabaseWhitelist(DialectType.OB_ORACLE);
+        Assert.assertTrue(whitelist instanceof TreeSet);
+        Assert.assertTrue(whitelist.contains("DBMS_OUTPUT"));
+        Assert.assertTrue(whitelist.contains("dbms_output"));
+    }
+
+    @Test
+    public void test_checkWhitelist_Doris() {
+        Set<String> whitelist = permissionCheckWhitelist.getDatabaseWhitelist(DialectType.DORIS);
+        Assert.assertTrue(whitelist instanceof TreeSet);
+        Assert.assertFalse(whitelist.contains("DBMS_OUTPUT"));
+    }
+
+}

--- a/server/odc-server/src/main/resources/data.sql
+++ b/server/odc-server/src/main/resources/data.sql
@@ -812,6 +812,8 @@ INSERT INTO config_system_configuration(`key`, `value`, `description`) VALUES('o
  'mysql, information_schema, test', 'schema exclusions when synchronizing MySQL database schema') ON DUPLICATE KEY UPDATE `id`=`id`;
 
 INSERT INTO config_system_configuration(`key`, `value`, `description`) VALUES('odc.permission-check.whitelist.database.ob-mysql',
- '', 'Permission check whitelist for database in OB MySQL dialect type') ON DUPLICATE KEY UPDATE `id`=`id`;
+ 'DBMS_RESOURCE_MANAGER, DBMS_STATS, DBMS_UDR, DBMS_XPLAN, DBMS_WORKLOAD_REPOSITORY',
+ 'Permission check whitelist for database in OB MySQL dialect type') ON DUPLICATE KEY UPDATE `id`=`id`;
 INSERT INTO config_system_configuration(`key`, `value`, `description`) VALUES('odc.permission-check.whitelist.database.ob-oracle',
- '', 'Permission check whitelist for database in OB Oracle dialect type') ON DUPLICATE KEY UPDATE `id`=`id`;
+ 'DBMS_APPLICATION_INFO, DBMS_AUDIT_MGMT, DBMS_CRYPTO, DBMS_DEBUG, DBMS_DESCRIBE, DBMS_JOB, DBMS_LOB, DBMS_LOCK, DBMS_METADATA, DBMS_OUTPUT, DBMS_PLAN_CACHE, DBMS_RANDOM, DBMS_RESOURCE_MANAGER, DBMS_SCHEDULER, DBMS_SESSION, DBMS_SQL, DBMS_STATS, DBMS_UDR, DBMS_UTILITY, DBMS_WORKLOAD_REPOSITORY, DBMS_XA, DBMS_XMLGEN, DBMS_XPLAN, ODCIConst, UTL_ENCODE, UTL_FILE, UTL_I18N, UTL_RAW, ANYDATA TYPE, XMLType',
+ 'Permission check whitelist for database in OB Oracle dialect type') ON DUPLICATE KEY UPDATE `id`=`id`;

--- a/server/odc-server/src/main/resources/data.sql
+++ b/server/odc-server/src/main/resources/data.sql
@@ -811,9 +811,22 @@ INSERT INTO config_system_configuration(`key`, `value`, `description`) VALUES('o
 INSERT INTO config_system_configuration(`key`, `value`, `description`) VALUES('odc.database.schema.sync.exclude-schemas.doris',
  'mysql, information_schema, test', 'schema exclusions when synchronizing MySQL database schema') ON DUPLICATE KEY UPDATE `id`=`id`;
 
-INSERT INTO config_system_configuration(`key`, `value`, `description`) VALUES('odc.permission-check.whitelist.database.ob-mysql',
- 'DBMS_RESOURCE_MANAGER, DBMS_STATS, DBMS_UDR, DBMS_XPLAN, DBMS_WORKLOAD_REPOSITORY',
- 'Permission check whitelist for database in OB MySQL dialect type') ON DUPLICATE KEY UPDATE `id`=`id`;
-INSERT INTO config_system_configuration(`key`, `value`, `description`) VALUES('odc.permission-check.whitelist.database.ob-oracle',
- 'DBMS_APPLICATION_INFO, DBMS_AUDIT_MGMT, DBMS_CRYPTO, DBMS_DEBUG, DBMS_DESCRIBE, DBMS_JOB, DBMS_LOB, DBMS_LOCK, DBMS_METADATA, DBMS_OUTPUT, DBMS_PLAN_CACHE, DBMS_RANDOM, DBMS_RESOURCE_MANAGER, DBMS_SCHEDULER, DBMS_SESSION, DBMS_SQL, DBMS_STATS, DBMS_UDR, DBMS_UTILITY, DBMS_WORKLOAD_REPOSITORY, DBMS_XA, DBMS_XMLGEN, DBMS_XPLAN, ODCIConst, UTL_ENCODE, UTL_FILE, UTL_I18N, UTL_RAW, ANYDATA TYPE, XMLType',
- 'Permission check whitelist for database in OB Oracle dialect type') ON DUPLICATE KEY UPDATE `id`=`id`;
+INSERT INTO config_system_configuration(`key`, `value`, `description`)
+VALUES ('odc.permission-check.whitelist.database.ob-mysql',
+        'DBMS_RESOURCE_MANAGER, DBMS_STATS, DBMS_UDR, DBMS_XPLAN, DBMS_WORKLOAD_REPOSITORY',
+        'Permission check whitelist for database in OB MySQL dialect type')
+ON DUPLICATE KEY UPDATE `id`=`id`;
+INSERT INTO config_system_configuration(`key`, `value`, `description`)
+VALUES ('odc.permission-check.whitelist.database.ob-oracle',
+        'DBMS_APPLICATION_INFO, DBMS_APPLICATION_INFO, DBMS_ASH_INTERNAL, DBMS_AUDIT_MGMT, DBMS_CRYPTO, DBMS_DEBUG, '
+            'DBMS_DESCRIBE, DBMS_ERRLOG, DBMS_IJOB, DBMS_ISCHEDULER, DBMS_JOB, DBMS_LOB, DBMS_LOCK, DBMS_METADATA, '
+            'DBMS_MONITOR, DBMS_MONITOR, DBMS_MVIEW, DBMS_MVIEW_STATS, DBMS_OUTPUT, DBMS_PLAN_CACHE, DBMS_PREPROCESSOR, '
+            'DBMS_RANDOM, DBMS_RESOURCE_MANAGER, DBMS_RLS, DBMS_SCHEDULER, DBMS_SESSION, DBMS_SESSION, DBMS_SPM, DBMS_SPM, '
+            'DBMS_SQL, DBMS_STATS, DBMS_SYS_ERROR, DBMS_TYPES, DBMS_UDR, DBMS_UDR, DBMS_UTILITY, DBMS_WARNING, '
+            'DBMS_WORKLOAD_REPOSITORY, DBMS_XA, DBMS_XMLGEN, DBMS_XPLAN, ODCICONST, SA_COMPONENTS, SA_LABEL_ADMIN, '
+            'SA_POLICY_ADMIN, SA_SESSION, SA_SYSDBA, SA_USER_ADMIN, STANDARD, UTL_ENCODE, UTL_FILE, UTL_I18N, UTL_INADDR, '
+            'UTL_RAW, __DBMS_UPGRADE, __DBMS_UPGRADE, dbms_ischeduler, dbms_mview, dbms_mview_stats, '
+            'dbms_ob_limit_calculator, dbms_resource_manager, dbms_scheduler, dbms_stats, '
+            'dbms_trusted_certificate_manager, dbms_workload_repository, dbms_xplan',
+        'Permission check whitelist for database in OB Oracle dialect type')
+ON DUPLICATE KEY UPDATE `id`=`id`;

--- a/server/odc-server/src/main/resources/data.sql
+++ b/server/odc-server/src/main/resources/data.sql
@@ -810,3 +810,8 @@ INSERT INTO config_system_configuration(`key`, `value`, `description`) VALUES('o
  'mysql, information_schema, test', 'schema exclusions when synchronizing MySQL database schema') ON DUPLICATE KEY UPDATE `id`=`id`;
 INSERT INTO config_system_configuration(`key`, `value`, `description`) VALUES('odc.database.schema.sync.exclude-schemas.doris',
  'mysql, information_schema, test', 'schema exclusions when synchronizing MySQL database schema') ON DUPLICATE KEY UPDATE `id`=`id`;
+
+INSERT INTO config_system_configuration(`key`, `value`, `description`) VALUES('odc.permission-check.whitelist.database.ob-mysql',
+ '', 'Permission check whitelist for database in OB MySQL dialect type') ON DUPLICATE KEY UPDATE `id`=`id`;
+INSERT INTO config_system_configuration(`key`, `value`, `description`) VALUES('odc.permission-check.whitelist.database.ob-oracle',
+ '', 'Permission check whitelist for database in OB Oracle dialect type') ON DUPLICATE KEY UPDATE `id`=`id`;

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/connection/database/DatabaseService.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/connection/database/DatabaseService.java
@@ -770,8 +770,7 @@ public class DatabaseService {
         for (Map.Entry<String, Set<DatabasePermissionType>> entry : schemaName2PermissionTypes.entrySet()) {
             String schemaName = entry.getKey();
             Set<DatabasePermissionType> needs = entry.getValue();
-            if (permissionCheckWhitelist.getDatabaseWhitelist(dialectType).contains(schemaName.toLowerCase())
-                    || CollectionUtils.isEmpty(needs)) {
+            if (CollectionUtils.isEmpty(needs) || permissionCheckWhitelist.containsDatabase(schemaName, dialectType)) {
                 continue;
             }
             if (name2Database.containsKey(schemaName)) {

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/connection/database/DatabaseService.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/connection/database/DatabaseService.java
@@ -115,6 +115,7 @@ import com.oceanbase.odc.service.onlineschemachange.ddl.DBUser;
 import com.oceanbase.odc.service.onlineschemachange.ddl.OscDBAccessor;
 import com.oceanbase.odc.service.onlineschemachange.ddl.OscDBAccessorFactory;
 import com.oceanbase.odc.service.onlineschemachange.rename.OscDBUserUtil;
+import com.oceanbase.odc.service.permission.common.PermissionCheckWhitelist;
 import com.oceanbase.odc.service.permission.database.DatabasePermissionHelper;
 import com.oceanbase.odc.service.permission.database.model.DatabasePermissionType;
 import com.oceanbase.odc.service.permission.database.model.UnauthorizedDatabase;
@@ -215,6 +216,9 @@ public class DatabaseService {
 
     @Autowired
     private DBSchemaSyncProperties dbSchemaSyncProperties;
+
+    @Autowired
+    private PermissionCheckWhitelist permissionCheckWhitelist;
 
     @Transactional(rollbackFor = Exception.class)
     @SkipAuthorize("internal authenticated")
@@ -746,6 +750,10 @@ public class DatabaseService {
     public List<UnauthorizedDatabase> filterUnauthorizedDatabases(
             Map<String, Set<DatabasePermissionType>> schemaName2PermissionTypes, @NotNull Long dataSourceId,
             boolean ignoreDataDirectory) {
+        if (authenticationFacade.currentUser() != null
+                && authenticationFacade.currentUser().getOrganizationType() == OrganizationType.INDIVIDUAL) {
+            return Collections.emptyList();
+        }
         if (schemaName2PermissionTypes == null || schemaName2PermissionTypes.isEmpty()) {
             return Collections.emptyList();
         }
@@ -758,10 +766,12 @@ public class DatabaseService {
                 .getPermissions(databases.stream().map(Database::getId).collect(Collectors.toList()));
         List<UnauthorizedDatabase> unauthorizedDatabases = new ArrayList<>();
         Set<Long> involvedProjectIds = projectService.getMemberProjectIds(authenticationFacade.currentUserId());
+        DialectType dialectType = dataSource.getDialectType();
         for (Map.Entry<String, Set<DatabasePermissionType>> entry : schemaName2PermissionTypes.entrySet()) {
             String schemaName = entry.getKey();
             Set<DatabasePermissionType> needs = entry.getValue();
-            if (CollectionUtils.isEmpty(needs)) {
+            if (permissionCheckWhitelist.getDatabaseWhitelist(dialectType).contains(schemaName.toLowerCase())
+                    || CollectionUtils.isEmpty(needs)) {
                 continue;
             }
             if (name2Database.containsKey(schemaName)) {
@@ -786,7 +796,6 @@ public class DatabaseService {
             }
         }
         if (ignoreDataDirectory) {
-            DialectType dialectType = dataSource.getDialectType();
             if (dialectType != null) {
                 if (dialectType.isOracle()) {
                     unauthorizedDatabases =

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/permission/common/PermissionCheckWhitelist.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/permission/common/PermissionCheckWhitelist.java
@@ -23,6 +23,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.cloud.context.config.annotation.RefreshScope;
 import org.springframework.context.annotation.Configuration;
 
+import com.oceanbase.odc.common.util.StringUtils;
 import com.oceanbase.odc.core.shared.constant.DialectType;
 
 import lombok.Data;
@@ -46,6 +47,16 @@ public class PermissionCheckWhitelist {
         }
         String key = dialect.name().toLowerCase().replace("_", "-");
         return database.getOrDefault(key, Collections.emptyList());
+    }
+
+    public boolean containsDatabase(@NonNull String database, @NonNull DialectType dialect) {
+        List<String> whitelist = getDatabaseWhitelist(dialect);
+        for (String item : whitelist) {
+            if (StringUtils.equalsIgnoreCase(item, database)) {
+                return true;
+            }
+        }
+        return false;
     }
 
 }

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/permission/common/PermissionCheckWhitelist.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/permission/common/PermissionCheckWhitelist.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2023 OceanBase.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.oceanbase.odc.service.permission.common;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.cloud.context.config.annotation.RefreshScope;
+import org.springframework.context.annotation.Configuration;
+
+import com.oceanbase.odc.core.shared.constant.DialectType;
+
+import lombok.Data;
+import lombok.NonNull;
+
+/**
+ * @author gaoda.xy
+ * @date 2024/5/16 15:38
+ */
+@Data
+@RefreshScope
+@Configuration
+@ConfigurationProperties(prefix = "odc.permission-check.whitelist")
+public class PermissionCheckWhitelist {
+
+    private Map<String, List<String>> database;
+
+    public List<String> getDatabaseWhitelist(@NonNull DialectType dialect) {
+        if (database == null || database.isEmpty()) {
+            return Collections.emptyList();
+        }
+        String key = dialect.name().toLowerCase().replace("_", "-");
+        return database.getOrDefault(key, Collections.emptyList());
+    }
+
+}


### PR DESCRIPTION
#### What type of PR is this?
type-bug
module-database permission

#### What this PR does / why we need it:
When execute:
```sql
call DBMS_OUTPUT.putline('aaaa');
```
We cannot judge `DBMS_OUTPUT` is name of a database or a package. Now we will recognize them as database name, but the "database" is not exist, so the SQL will be intercepted during permission check.
This PR fix it by add a whitelist, the default vaule is all OB inside system packages. User can add items by config metaDB. If a new dialect type is supported, we no need to change codes, but add config key as `odc.permission-check.whitelist.database.[dialect-type]`.

#### Which issue(s) this PR fixes:
Fixes #2391 

#### Special notes for your reviewer:
Self-test passed.

#### Additional documentation e.g., usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```