### PR TITLE
feat(object-search): individual space support global object search

### DIFF
--- a/server/odc-server/src/main/resources/data.sql
+++ b/server/odc-server/src/main/resources/data.sql
@@ -792,8 +792,10 @@ INSERT INTO config_system_configuration(`key`, `value`, `description`) VALUES('o
 ---
 --- v4.3.0
 ---
+INSERT INTO config_system_configuration(`key`, `value`, `description`) VALUES('odc.database.schema.global-search.enabled',
+ 'true', 'enable global searching database schema or not, true by default') ON DUPLICATE KEY UPDATE `id`=`id`;
 INSERT INTO config_system_configuration(`key`, `value`, `description`) VALUES('odc.database.schema.sync.cron-expression',
- '0 0 2 * * ?', 'cron expression for synchronizing full database schema') ON DUPLICATE KEY UPDATE `id`=`id`;
+ '0 0 2 * * ?', 'cron expression for synchronizing global database schema') ON DUPLICATE KEY UPDATE `id`=`id`;
 INSERT INTO config_system_configuration(`key`, `value`, `description`) VALUES('odc.database.schema.sync.executor-thread-count',
  '8', 'thread count for synchronizing database schema') ON DUPLICATE KEY UPDATE `id`=`id`;
 INSERT INTO config_system_configuration(`key`, `value`, `description`) VALUES('odc.database.schema.sync.block-exclusions-when-sync-db-to-project',

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/config/UserConfigKeys.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/config/UserConfigKeys.java
@@ -22,4 +22,5 @@ public class UserConfigKeys {
     public static final String DEFAULT_ORACLE_AUTO_COMMIT_MODE = "odc.sqlexecute.default.oracleAutoCommitMode";
     public static final String DEFAULT_FULL_LINK_TRACE_ENABLED = "odc.sqlexecute.default.fullLinkTraceEnabled";
     public static final String DEFAULT_CONTINUE_EXECUTION_ON_ERROR = "odc.sqlexecute.default.continueExecutionOnError";
+    public static final String DEFAULT_ENABLE_GLOBAL_OBJECT_SEARCH = "odc.database.default.enableGlobalObjectSearch";
 }

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/connection/database/DatabaseSyncManager.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/connection/database/DatabaseSyncManager.java
@@ -29,7 +29,6 @@ import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import com.oceanbase.odc.core.authority.util.SkipAuthorize;
-import com.oceanbase.odc.core.shared.constant.OrganizationType;
 import com.oceanbase.odc.core.shared.exception.BadRequestException;
 import com.oceanbase.odc.metadb.iam.UserEntity;
 import com.oceanbase.odc.service.connection.model.ConnectionConfig;
@@ -79,17 +78,11 @@ public class DatabaseSyncManager {
     public Future<Boolean> submitSyncDataSourceAndDBSchemaTask(@NonNull ConnectionConfig connection) {
         return doExecute(() -> executor.submit(() -> {
             Boolean res = syncDBForDataSource(connection);
-            // only sync db schema for team organization
-            organizationService.get(connection.getOrganizationId()).ifPresent(organization -> {
-                if (organization.getType() == OrganizationType.TEAM) {
-                    try {
-                        dbSchemaSyncTaskManager.submitTaskByDataSource(connection);
-                    } catch (Exception e) {
-                        log.warn("Failed to submit sync database schema task for datasource id={}", connection.getId(),
-                                e);
-                    }
-                }
-            });
+            try {
+                dbSchemaSyncTaskManager.submitTaskByDataSource(connection);
+            } catch (Exception e) {
+                log.warn("Failed to submit sync database schema task for datasource id={}", connection.getId(), e);
+            }
             return res;
         }));
     }

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/db/schema/DBSchemaIndexService.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/db/schema/DBSchemaIndexService.java
@@ -30,8 +30,6 @@ import org.apache.commons.collections4.CollectionUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
-import org.springframework.data.domain.Sort.Direction;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
 import org.springframework.validation.annotation.Validated;
@@ -157,7 +155,7 @@ public class DBSchemaIndexService {
             resp.setDatabases(databases.stream().filter(e -> e.getName().toLowerCase().contains(key))
                     .collect(Collectors.toList()));
         }
-        Pageable pageable = PageRequest.of(0, MAX_SEARCH_SIZE, Sort.by(Direction.DESC, DBColumnEntity_.DATABASE_ID));
+        Pageable pageable = PageRequest.of(0, MAX_SEARCH_SIZE);
         if (CollectionUtils.isEmpty(params.getTypes()) || params.getTypes().contains(DBObjectType.COLUMN)) {
             Specification<DBColumnEntity> columnSpec =
                     SpecificationUtil.columnIn(DBColumnEntity_.DATABASE_ID, queryDatabaseIds);

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/db/schema/DBSchemaIndexService.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/db/schema/DBSchemaIndexService.java
@@ -92,8 +92,8 @@ public class DBSchemaIndexService {
     @Autowired
     private DBSchemaSyncTaskManager dbSchemaSyncTaskManager;
 
-    private static final int MAX_SEARCH_SIZE = 10000;
-    private static final int MAX_RETURN_SIZE_PER_TYPE = 1000;
+    private static final int MAX_SEARCH_SIZE = 5000;
+    private static final int MAX_RETURN_SIZE_PER_TYPE = 200;
 
     public QueryDBObjectResp listDatabaseObjects(@NonNull @Valid QueryDBObjectParams params) {
         QueryDBObjectResp resp = new QueryDBObjectResp();

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/db/schema/DBSchemaSyncTaskManager.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/db/schema/DBSchemaSyncTaskManager.java
@@ -25,6 +25,7 @@ import java.util.stream.Collectors;
 import org.apache.commons.collections4.CollectionUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import org.springframework.stereotype.Component;
@@ -61,8 +62,11 @@ public class DBSchemaSyncTaskManager {
     @Autowired
     private DBSchemaSyncProperties syncProperties;
 
+    @Value("${odc.database.schema.global-search.enabled:true}")
+    private boolean enableGlobalSearch;
+
     public void submitTaskByDatabases(@NonNull Collection<Database> databases) {
-        if (CollectionUtils.isEmpty(databases)) {
+        if (CollectionUtils.isEmpty(databases) || !enableGlobalSearch) {
             return;
         }
         Set<Long> databaseIds = databases.stream().map(Database::getId).collect(Collectors.toSet());

--- a/server/odc-service/src/main/resources/config-meta/user-config-meta.yml
+++ b/server/odc-service/src/main/resources/config-meta/user-config-meta.yml
@@ -171,3 +171,13 @@
   default_value: 'true'
   nullable: false
   description: 'Whether the query is being rewritten in ob-oracle mode and increases the RowId.'
+- id: 18
+  category: 'user'
+  key: 'odc.database.default.enableGlobalObjectSearch'
+  type: 'boolean'
+  max_value: ~
+  min_value: ~
+  allowed_values: [ 'true','false' ]
+  default_value: 'true'
+  nullable: false
+  description: 'Whether enable global database object search.'


### PR DESCRIPTION
#### What type of PR is this?
type-feature
module-global object search

#### What this PR does / why we need it:
This PR add support for global object search:
1. Add system config `odc.database.schema.global-search.enabled` to control the database object sync, the default value  is `true`.
2. Add a user config `odc.database.default.enableGlobalObjectSearch` to control whether open the global object search UI, the default value is `true`.
3. For web mode, if the system config value is `false`, then all sync operation will be ignored; if it is `true`, then we will only sync  databases in team space and these in individual space that the user config is `true`.
4. For desktop mode, if user config is `false`, then sync will be ignored.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #2432 
Fixes #2443 

#### Special notes for your reviewer:
Self-test passed.
<!--
This section is used to describe how this PR is implemented. 
If this is a PR that fixes a bug, this section describes how the bug was fixed.
If it's a new feature, this section briefly describes how to implement the new feature.
etc.
-->

#### Additional documentation e.g., usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```