### PR TITLE
fix(multiple database): no execution record is generated before or during a multi-database change task 

### DIFF
--- a/server/odc-service/src/main/java/com/oceanbase/odc/metadb/connection/DatabaseRepository.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/metadb/connection/DatabaseRepository.java
@@ -50,8 +50,6 @@ public interface DatabaseRepository extends JpaRepository<DatabaseEntity, Long>,
 
     List<DatabaseEntity> findByNameIn(Collection<String> name);
 
-    long countByIdIn(List<Long> ids);
-
     @Modifying
     @Transactional
     @Query(value = "delete from connect_database t where t.connection_id in (:connectionIds)", nativeQuery = true)

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/databasechange/DatabaseChangeChangingOrderTemplateService.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/databasechange/DatabaseChangeChangingOrderTemplateService.java
@@ -50,7 +50,6 @@ import com.oceanbase.odc.metadb.connection.DatabaseRepository;
 import com.oceanbase.odc.metadb.databasechange.DatabaseChangeChangingOrderTemplateEntity;
 import com.oceanbase.odc.metadb.databasechange.DatabaseChangeChangingOrderTemplateRepository;
 import com.oceanbase.odc.metadb.databasechange.DatabaseChangeChangingOrderTemplateSpecs;
-import com.oceanbase.odc.service.connection.database.DatabaseService;
 import com.oceanbase.odc.service.databasechange.model.CreateDatabaseChangeChangingOrderTemplateReq;
 import com.oceanbase.odc.service.databasechange.model.DatabaseChangeChangingOrderTemplateResp;
 import com.oceanbase.odc.service.databasechange.model.DatabaseChangeDatabase;
@@ -75,8 +74,6 @@ public class DatabaseChangeChangingOrderTemplateService {
 
     @Autowired
     private ProjectRepository projectRepository;
-    @Autowired
-    private DatabaseService databaseService;
 
     @Autowired
     private ProjectPermissionValidator projectPermissionValidator;
@@ -107,7 +104,6 @@ public class DatabaseChangeChangingOrderTemplateService {
                 .findByProjectIdIn(nonArchivedProjectIds).stream()
                 .collect(Collectors.groupingBy(DatabaseEntity::getProjectId));
         disabledTemplateIds.addAll(projectId2TemplateEntityList.entrySet().stream()
-                // 留下未归档的projectId2TemplateEntityList
                 .filter(entry -> nonArchivedProjectIds.contains(entry.getKey()))
                 .flatMap(entry -> {
                     List<DatabaseEntity> databases = projectId2Databases.get(entry.getKey());

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/databasechange/model/DatabaseChangeFlowInstanceDetailResp.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/databasechange/model/DatabaseChangeFlowInstanceDetailResp.java
@@ -33,6 +33,7 @@ public class DatabaseChangeFlowInstanceDetailResp {
     private Date createTime;
     private Date executionTime;
     private Date completeTime;
+    private double progressPercentage;
 
     public DatabaseChangeFlowInstanceDetailResp(FlowInstanceDetailResp flowInstanceDetailResp) {
         if (flowInstanceDetailResp != null) {
@@ -40,6 +41,7 @@ public class DatabaseChangeFlowInstanceDetailResp {
             this.createTime = flowInstanceDetailResp.getCreateTime();
             this.executionTime = flowInstanceDetailResp.getExecutionTime();
             this.completeTime = flowInstanceDetailResp.getCompleteTime();
+            this.progressPercentage = flowInstanceDetailResp.getProgressPercentage();
         }
     }
 }

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/flow/task/model/MultipleDatabaseChangeTaskResult.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/flow/task/model/MultipleDatabaseChangeTaskResult.java
@@ -30,5 +30,6 @@ import lombok.Setter;
 @Getter
 @Setter
 public class MultipleDatabaseChangeTaskResult implements FlowTaskResult {
+    private Long flowInstanceId;
     private List<DatabaseChangingRecord> databaseChangingRecordList;
 }

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/task/TaskService.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/task/TaskService.java
@@ -288,11 +288,30 @@ public class TaskService {
     }
 
     @Transactional(rollbackFor = Exception.class)
+    public void succeed(Long id) {
+        TaskEntity taskEntity = nullSafeFindById(id);
+        taskEntity.setStatus(TaskStatus.DONE);
+        taskEntity.setProgressPercentage(100);
+        taskRepository.save(taskEntity);
+        log.info("Task ended: taskId={}", id);
+    }
+
+    @Transactional(rollbackFor = Exception.class)
     public void fail(Long id, double percentage, Object taskResult) {
         TaskEntity taskEntity = nullSafeFindById(id);
         taskEntity.setStatus(TaskStatus.FAILED);
         taskEntity.setProgressPercentage(percentage);
         taskEntity.setResultJson(JsonUtils.toJson(taskResult));
+        taskRepository.save(taskEntity);
+        log.info("Task ended: taskId={}", id);
+    }
+
+
+    @Transactional(rollbackFor = Exception.class)
+    public void fail(Long id, double percentage) {
+        TaskEntity taskEntity = nullSafeFindById(id);
+        taskEntity.setStatus(TaskStatus.FAILED);
+        taskEntity.setProgressPercentage(percentage);
         taskRepository.save(taskEntity);
         log.info("Task ended: taskId={}", id);
     }


### PR DESCRIPTION
…played in real time

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines.
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request.
3. Ensure you have added or ran the appropriate tests for your PR.
5. If the PR is unfinished, you may add or remove a WIP or [WIP] prefix to your pull request title.
-->

#### What type of PR is this?
type-bug
<!--
Add one of the following kinds:
type-bug
type-feature
type-docs
etc.

Optionally add one or more of the following kinds if applicable:
module-resultset
module-sql execution
etc.
-->

#### What this PR does / why we need it:

1. Previously, the multi-database change ticket would have  execution records only after finishing the first batch. Now it's changed to that there are records of execution displaying once the multi-database change ticket is created.
2. Added the execution progress display.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #2516

#### Special notes for your reviewer:

<!--
This section is used to describe how this PR is implemented. 
If this is a PR that fixes a bug, this section describes how the bug was fixed.
If it's a new feature, this section briefly describes how to implement the new feature.
etc.
-->

#### Additional documentation e.g., usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```