### PR TITLE
fix(multiple database): no execution record is generated before or during a multi-database change task 

### DIFF
--- a/server/odc-service/src/main/java/com/oceanbase/odc/metadb/connection/DatabaseRepository.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/metadb/connection/DatabaseRepository.java
@@ -50,8 +50,6 @@ public interface DatabaseRepository extends JpaRepository<DatabaseEntity, Long>,
 
     List<DatabaseEntity> findByNameIn(Collection<String> name);
 
-    long countByIdIn(List<Long> ids);
-
     @Modifying
     @Transactional
     @Query(value = "delete from connect_database t where t.connection_id in (:connectionIds)", nativeQuery = true)

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/databasechange/DatabaseChangeChangingOrderTemplateService.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/databasechange/DatabaseChangeChangingOrderTemplateService.java
@@ -107,7 +107,6 @@ public class DatabaseChangeChangingOrderTemplateService {
                 .findByProjectIdIn(nonArchivedProjectIds).stream()
                 .collect(Collectors.groupingBy(DatabaseEntity::getProjectId));
         disabledTemplateIds.addAll(projectId2TemplateEntityList.entrySet().stream()
-                // 留下未归档的projectId2TemplateEntityList
                 .filter(entry -> nonArchivedProjectIds.contains(entry.getKey()))
                 .flatMap(entry -> {
                     List<DatabaseEntity> databases = projectId2Databases.get(entry.getKey());

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/databasechange/DatabaseChangeChangingOrderTemplateService.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/databasechange/DatabaseChangeChangingOrderTemplateService.java
@@ -191,13 +191,13 @@ public class DatabaseChangeChangingOrderTemplateService {
                 () -> projectRepository.existsById(req.getProjectId()));
         projectPermissionValidator.checkProjectRole(req.getProjectId(), ResourceRoleName.all());
         DatabaseChangeChangingOrderTemplateEntity originEntity =
-                templateRepository.findById(id).orElseThrow(
+                templateRepository.findByIdAndProjectId(id, req.getProjectId()).orElseThrow(
                         () -> new NotFoundException(ResourceType.ODC_DATABASE_CHANGE_ORDER_TEMPLATE, "id", id));
-        Optional<DatabaseChangeChangingOrderTemplateEntity> byNameAndProjectId
-            = templateRepository.findByNameAndProjectId(req.getName(), req.getProjectId());
-        if(byNameAndProjectId.isPresent()){
+        Optional<DatabaseChangeChangingOrderTemplateEntity> byNameAndProjectId =
+                templateRepository.findByNameAndProjectId(req.getName(), req.getProjectId());
+        if (byNameAndProjectId.isPresent()) {
             PreConditions.validNoDuplicated(ResourceType.ODC_DATABASE_CHANGE_ORDER_TEMPLATE, "name", req.getName(),
-                () -> !Objects.equals(byNameAndProjectId.get().getId(), originEntity.getId()));
+                    () -> !Objects.equals(byNameAndProjectId.get().getId(), originEntity.getId()));
         }
         List<List<Long>> orders = req.getOrders();
         List<Long> databaseIds = orders.stream().flatMap(List::stream).collect(Collectors.toList());

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/databasechange/model/DatabaseChangeFlowInstanceDetailResp.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/databasechange/model/DatabaseChangeFlowInstanceDetailResp.java
@@ -33,6 +33,7 @@ public class DatabaseChangeFlowInstanceDetailResp {
     private Date createTime;
     private Date executionTime;
     private Date completeTime;
+    private double progressPercentage;
 
     public DatabaseChangeFlowInstanceDetailResp(FlowInstanceDetailResp flowInstanceDetailResp) {
         if (flowInstanceDetailResp != null) {
@@ -40,6 +41,7 @@ public class DatabaseChangeFlowInstanceDetailResp {
             this.createTime = flowInstanceDetailResp.getCreateTime();
             this.executionTime = flowInstanceDetailResp.getExecutionTime();
             this.completeTime = flowInstanceDetailResp.getCompleteTime();
+            this.progressPercentage = flowInstanceDetailResp.getProgressPercentage();
         }
     }
 }

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/flow/FlowInstanceService.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/flow/FlowInstanceService.java
@@ -919,7 +919,7 @@ public class FlowInstanceService {
         MultipleDatabaseChangeParameters parameters =
                 (MultipleDatabaseChangeParameters) flowInstanceReq.getParameters();
         MultipleDatabaseChangeTaskResult result = new MultipleDatabaseChangeTaskResult();
-        ArrayList<DatabaseChangingRecord> databaseChangingRecords = new ArrayList<>();
+        List<DatabaseChangingRecord> databaseChangingRecords = new ArrayList<>();
         List<DatabaseChangeDatabase> databaseList = parameters.getDatabases();
         for (DatabaseChangeDatabase database : databaseList) {
             DatabaseChangingRecord databaseChangingRecord = new DatabaseChangingRecord();

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/flow/FlowTaskInstanceService.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/flow/FlowTaskInstanceService.java
@@ -232,7 +232,8 @@ public class FlowTaskInstanceService {
 
     public List<? extends FlowTaskResult> getResult(@NotNull Long id) throws IOException {
         TaskEntity task = flowInstanceService.getTaskByFlowInstanceId(id);
-        if (task.getTaskType() == TaskType.ONLINE_SCHEMA_CHANGE || task.getTaskType() == TaskType.EXPORT) {
+        if (task.getTaskType() == TaskType.ONLINE_SCHEMA_CHANGE || task.getTaskType() == TaskType.EXPORT
+                || task.getTaskType() == TaskType.MULTIPLE_ASYNC) {
             return getTaskResultFromEntity(task, true);
         }
         Optional<TaskEntity> taskEntityOptional = getCompleteTaskEntity(id);

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/flow/task/BaseODCFlowTaskDelegate.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/flow/task/BaseODCFlowTaskDelegate.java
@@ -30,6 +30,8 @@ import java.util.concurrent.TimeUnit;
 import org.apache.commons.collections4.CollectionUtils;
 import org.flowable.engine.delegate.DelegateExecution;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
 
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.oceanbase.odc.common.json.JsonUtils;
@@ -116,8 +118,10 @@ public abstract class BaseODCFlowTaskDelegate<T> extends BaseRuntimeFlowableDele
                 .build();
         scheduleExecutor = new ScheduledThreadPoolExecutor(1, threadFactory);
         int interval = RuntimeTaskConstants.DEFAULT_TASK_CHECK_INTERVAL_SECONDS;
+        SecurityContext securityContext = SecurityContextHolder.getContext();
         scheduleExecutor.scheduleAtFixedRate(() -> {
             try {
+                SecurityContextHolder.setContext(securityContext);
                 updateHeartbeatTime();
                 if (taskLatch.getCount() > 0) {
                     onProgressUpdate(taskId, taskService);
@@ -132,6 +136,8 @@ public abstract class BaseODCFlowTaskDelegate<T> extends BaseRuntimeFlowableDele
             } catch (Exception e) {
                 log.warn("Task monitoring thread failed, taskId={}", taskId, e);
                 taskLatch.countDown();
+            } finally {
+                SecurityContextHolder.clearContext();
             }
         }, interval, interval, TimeUnit.SECONDS);
     }

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/flow/task/MultipleDatabaseChangeRuntimeFlowableTask.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/flow/task/MultipleDatabaseChangeRuntimeFlowableTask.java
@@ -63,12 +63,12 @@ public class MultipleDatabaseChangeRuntimeFlowableTask extends BaseODCFlowTaskDe
     private volatile boolean isSuccessful = false;
     private volatile boolean isFailure = false;
     private volatile boolean isFinished = false;
-    private User taskCreator;
-    private Integer batchId;
+    private volatile User taskCreator;
+    private volatile MultipleDatabaseChangeParameters multipleDatabaseChangeParameters;
+    private volatile Integer batchId;
+    private volatile FlowTaskExecutionStrategy flowTaskExecutionStrategy;
     private Integer batchSum;
-    private List<List<Long>> orderedDatabaseIds;
-    private FlowTaskExecutionStrategy flowTaskExecutionStrategy;
-    private MultipleDatabaseChangeParameters multipleDatabaseChangeParameters;
+
     @Autowired
     private FlowInstanceService flowInstanceService;
     @Autowired
@@ -119,7 +119,6 @@ public class MultipleDatabaseChangeRuntimeFlowableTask extends BaseODCFlowTaskDe
             TaskEntity detail = taskService.detail(taskId);
             this.multipleDatabaseChangeParameters = JsonUtils.fromJson(
                     detail.getParametersJson(), MultipleDatabaseChangeParameters.class);
-            this.orderedDatabaseIds = multipleDatabaseChangeParameters.getOrderedDatabaseIds();
             Integer value = multipleDatabaseChangeParameters.getBatchId();
             if (value == null) {
                 this.batchId = 0;
@@ -288,6 +287,9 @@ public class MultipleDatabaseChangeRuntimeFlowableTask extends BaseODCFlowTaskDe
                 .build();
         Page<FlowInstanceDetailResp> page = flowInstanceService.list(Pageable.unpaged(), param);
         List<FlowInstanceDetailResp> flowInstanceDetailRespList = page.getContent();
+        if (flowInstanceDetailRespList.isEmpty()) {
+            return null;
+        }
         // todo At present multi-databases changes do not include databases with the same name
         Map<Long, FlowInstanceDetailResp> databaseId2FlowInstanceDetailResp =
                 flowInstanceDetailRespList.stream().collect(

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/flow/task/MultipleDatabaseChangeRuntimeFlowableTask.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/flow/task/MultipleDatabaseChangeRuntimeFlowableTask.java
@@ -286,7 +286,7 @@ public class MultipleDatabaseChangeRuntimeFlowableTask extends BaseODCFlowTaskDe
                         Collectors.toMap(flowInstanceDetailResp -> flowInstanceDetailResp.getDatabase().getId(),
                                 flowInstanceDetailResp -> flowInstanceDetailResp));
         List<DatabaseChangeDatabase> databases = this.multipleDatabaseChangeParameters.getDatabases();
-        ArrayList<DatabaseChangingRecord> records = new ArrayList<>();
+        List<DatabaseChangingRecord> records = new ArrayList<>();
         for (DatabaseChangeDatabase database : databases) {
             FlowInstanceDetailResp resp = databaseId2FlowInstanceDetailResp.get(database.getId());
             DatabaseChangingRecord record = new DatabaseChangingRecord();


### PR DESCRIPTION
…played in real time

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines.
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request.
3. Ensure you have added or ran the appropriate tests for your PR.
5. If the PR is unfinished, you may add or remove a WIP or [WIP] prefix to your pull request title.
-->

#### What type of PR is this?
type-bug
<!--
Add one of the following kinds:
type-bug
type-feature
type-docs
etc.

Optionally add one or more of the following kinds if applicable:
module-resultset
module-sql execution
etc.
-->

#### What this PR does / why we need it:

1. Previously, the multi-database change ticket would have  execution records only after finishing the first batch. Now it's changed to that there are records of execution displaying once the multi-database change ticket is created.
2. Added the execution progress display.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #2516

#### Special notes for your reviewer:

<!--
This section is used to describe how this PR is implemented. 
If this is a PR that fixes a bug, this section describes how the bug was fixed.
If it's a new feature, this section briefly describes how to implement the new feature.
etc.
-->

#### Additional documentation e.g., usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```