### PR TITLE
fix(db-object): exception occurred when open oracle table in GBK encoding

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1128,6 +1128,11 @@
                 <version>${oracle.jdbc.version}</version>
             </dependency>
             <dependency>
+                <groupId>com.oracle.database.nls</groupId>
+                <artifactId>orai18n</artifactId>
+                <version>${oracle.jdbc.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>io.kubernetes</groupId>
                 <artifactId>client-java</artifactId>
                 <version>${kubernetes-client.version}</version>

--- a/server/odc-service/pom.xml
+++ b/server/odc-service/pom.xml
@@ -259,6 +259,10 @@
             <artifactId>ojdbc8</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.oracle.database.nls</groupId>
+            <artifactId>orai18n</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.codehaus.groovy</groupId>
             <artifactId>groovy-all</artifactId>
         </dependency>

--- a/server/plugins/connect-plugin-oracle/pom.xml
+++ b/server/plugins/connect-plugin-oracle/pom.xml
@@ -44,6 +44,11 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>com.oracle.database.nls</groupId>
+            <artifactId>orai18n</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>com.oceanbase</groupId>
             <artifactId>connect-plugin-ob-oracle</artifactId>
         </dependency>


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines.
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request.
3. Ensure you have added or ran the appropriate tests for your PR.
5. If the PR is unfinished, you may add or remove a WIP or [WIP] prefix to your pull request title.
-->

#### What type of PR is this?
type-bug
<!--
Add one of the following kinds:
type-bug
type-feature
type-docs
etc.

Optionally add one or more of the following kinds if applicable:
module-resultset
module-sql execution
etc.
-->

#### What this PR does / why we need it:

When Oracle character set is ZHS16GBK, ODC cannot open the table structure.
According to https://stackoverflow.com/questions/36775398/java-sql-sqlexception-non-supported-character-set-oracle-character-set-178 , it's because we lack i18n dependency.
Add this dependency should fix this.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #2262