### PR TITLE
security: upgrade spring-security from 5.1.10 to 5.7.12

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
 
         <!-- dependency version -->
         <springframework.version>5.3.26</springframework.version>
-        <spring-security.version>5.7.10</spring-security.version>
+        <spring-security.version>5.7.12</spring-security.version>
         <spring-security-oauth2-client.version>5.7.5</spring-security-oauth2-client.version>
         <spring-integration.version>5.5.18</spring-integration.version>
         <springboot.version>2.7.12</springboot.version>


### PR DESCRIPTION
security: upgrade spring-security from 5.1.10 to 5.7.12, fix CVE-2024-22257

fix https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-22257
