### PR TITLE
fix(client-mode): ODC fail to start in client mode

### DIFF
--- a/server/starters/desktop-starter/src/main/java/com/oceanbase/odc/migrate/DesktopResourceHandle.java
+++ b/server/starters/desktop-starter/src/main/java/com/oceanbase/odc/migrate/DesktopResourceHandle.java
@@ -30,11 +30,20 @@ import com.oceanbase.odc.service.common.migrate.IgnoreResourceIdHandle;
 import com.oceanbase.odc.service.common.util.SpringContextUtil;
 
 public class DesktopResourceHandle implements Function<ResourceSpec, ResourceSpec> {
+    private static final Set<String> RESERVE_RESOURCE_ID_TABLES = new HashSet<>();
+
+    static {
+        RESERVE_RESOURCE_ID_TABLES.add("iam_organization");
+    }
 
     @Override
     public ResourceSpec apply(ResourceSpec entity) {
         Set<String> profiles = new HashSet<>(Arrays.asList(SpringContextUtil.getProfiles()));
         if (!profiles.contains("test")) {
+            if (entity.getTemplates().stream()
+                    .anyMatch(t -> RESERVE_RESOURCE_ID_TABLES.contains(t.getMetadata().getTable()))) {
+                return entity;
+            }
             return new IgnoreResourceIdHandle().apply(entity);
         }
         /**


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines.
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request.
3. Ensure you have added or ran the appropriate tests for your PR.
5. If the PR is unfinished, you may add or remove a WIP or [WIP] prefix to your pull request title.
-->

#### What type of PR is this?
type-bug
<!--
Add one of the following kinds:
type-bug
type-feature
type-docs
etc.

Optionally add one or more of the following kinds if applicable:
module-resultset
module-sql execution
etc.
-->

#### What this PR does / why we need it:

ODC added `IgnoreResourceIdHandle` for client  mode in 4.3.0 version. This results in a default organization ID of 10000 in the iam_organization table. But due to the organization ID that other tables depend on being hardcode to 1, the correct organization cannot be found.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #2760 