### PR TITLE
Fix issue of online schema change module. when rate limitor is changed, scheduler task save the wrong value of rate limitor, that will cause data process's loop restart which  block the following actions

### DIFF
--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/onlineschemachange/OscService.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/onlineschemachange/OscService.java
@@ -19,6 +19,7 @@ package com.oceanbase.odc.service.onlineschemachange;
 import java.util.Objects;
 import java.util.Optional;
 
+import org.apache.commons.collections4.CollectionUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -178,6 +179,10 @@ public class OscService {
                 "modify task rate limiter is unsupported when task is terminated");
         OnlineSchemaChangeTaskResult taskResult =
                 JsonUtils.fromJson(task.getResultJson(), new TypeReference<OnlineSchemaChangeTaskResult>() {});
+        // Task result may be empty cause task may hasn't been scheduled. Remind user raise this request latter.
+        PreConditions.validArgumentState(null != taskResult && CollectionUtils.isNotEmpty(taskResult.getTasks()),
+            ErrorCodes.BadRequest, new Object[] {req.getFlowInstanceId()},
+            "Task has not been scheduled, please retry update rate limiter latter");
         Long scheduleId = Long.parseLong(taskResult.getTasks().get(0).getJobName());
         ScheduleEntity scheduleEntity = scheduleService.nullSafeGetById(scheduleId);
         OnlineSchemaChangeParameters parameters = JsonUtils.fromJson(

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/onlineschemachange/pipeline/ScheduleCheckOmsProjectValve.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/onlineschemachange/pipeline/ScheduleCheckOmsProjectValve.java
@@ -23,12 +23,14 @@ import org.springframework.stereotype.Component;
 
 import com.google.common.collect.Lists;
 import com.oceanbase.odc.common.json.JsonUtils;
+import com.oceanbase.odc.common.util.StringUtils;
 import com.oceanbase.odc.common.util.tableformat.Table;
 import com.oceanbase.odc.core.shared.constant.ErrorCodes;
 import com.oceanbase.odc.core.shared.constant.TaskStatus;
 import com.oceanbase.odc.metadb.schedule.ScheduleTaskEntity;
 import com.oceanbase.odc.metadb.schedule.ScheduleTaskRepository;
 import com.oceanbase.odc.service.onlineschemachange.configuration.OnlineSchemaChangeProperties;
+import com.oceanbase.odc.service.onlineschemachange.exception.OmsException;
 import com.oceanbase.odc.service.onlineschemachange.exception.OscException;
 import com.oceanbase.odc.service.onlineschemachange.logger.DefaultTableFactory;
 import com.oceanbase.odc.service.onlineschemachange.model.FullVerificationResult;
@@ -102,7 +104,11 @@ public class ScheduleCheckOmsProjectValve extends BaseValve {
                             return null;
                         })
                         .getCheckerResult();
-        updateOmsProjectConfig(scheduleTask.getId(), taskParameter, inputParameters, progress.getStatus());
+        // If config update is in processing, wait until the process done
+        // This behavior may cause process blocked if OMS update failed or resume failed
+        if (updateOmsProjectConfig(scheduleTask.getId(), taskParameter, inputParameters, progress.getStatus())) {
+            return;
+        }
 
         OnlineSchemaChangeScheduleTaskResult result = new OnlineSchemaChangeScheduleTaskResult(taskParameter);
 
@@ -119,11 +125,12 @@ public class ScheduleCheckOmsProjectValve extends BaseValve {
                 context.getParameter().getSwapTableType(), scheduleTask);
     }
 
-    private void updateOmsProjectConfig(Long scheduleTaskId, OnlineSchemaChangeScheduleTaskParameters taskParameters,
+    private boolean updateOmsProjectConfig(Long scheduleTaskId, OnlineSchemaChangeScheduleTaskParameters taskParameters,
             OnlineSchemaChangeParameters inputParameters, OmsProjectStatusEnum omsProjectStatus) {
         // if rate limiter parameters is changed, try to stop and restart project
         if (Objects.equals(inputParameters.getRateLimitConfig(), taskParameters.getRateLimitConfig())) {
-            return;
+            log.info("Rate limiter not changed,rateLimiterConfig = {}, update oms project not required", inputParameters.getRateLimitConfig());
+            return false;
         }
         log.info("Input rate limiter has changed, currentOmsProjectStatus={}, rateLimiterConfig={}, "
                 + "oldRateLimiterConfig={}.",
@@ -153,6 +160,7 @@ public class ScheduleCheckOmsProjectValve extends BaseValve {
                         taskParameters.getOmsProjectId(), scheduleTaskId, e);
             }
         }
+        return true;
     }
 
     private void doUpdateOmsProjectConfig(Long scheduleTaskId, OnlineSchemaChangeScheduleTaskParameters taskParameters,
@@ -173,7 +181,12 @@ public class ScheduleCheckOmsProjectValve extends BaseValve {
 
         log.info("Try to update oms project, omsProjectId={}, scheduleTaskId={},"
                 + " request={}.", taskParameters.getOmsProjectId(), scheduleTaskId, JsonUtils.toJson(request));
-        projectOpenApiService.updateProjectConfig(request);
+        try {
+            projectOpenApiService.updateProjectConfig(request);
+        } catch (OmsException omsException) {
+            throwOrIgnore(omsException);
+        }
+
         log.info("Update oms project completed, Try to resume project, omsProjectId={},"
                 + " scheduleTaskId={}", taskParameters.getOmsProjectId(), scheduleTaskId);
 
@@ -185,6 +198,18 @@ public class ScheduleCheckOmsProjectValve extends BaseValve {
         int rows = scheduleTaskRepository.updateTaskParameters(scheduleTaskId, JsonUtils.toJson(taskParameters));
         if (rows > 0) {
             log.info("Update throttle completed, scheduleTaskId={}", scheduleTaskId);
+        }
+    }
+
+    /**
+     * Lower version OMS may not support updateConfig api
+     * Ignore this exception and continue resume migrate project
+     * @param omsException
+     */
+    private void throwOrIgnore(OmsException omsException) {
+        if (!StringUtils.containsIgnoreCase(omsException.getMessage(),
+            "Unsupported action: UpdateProjectConfig")) {
+            throw omsException;
         }
     }
 


### PR DESCRIPTION
Fix issue of online schema change module. when rate limitor is changed, scheduler task save the wrong value of rate limitor, that will cause data process's loop restart which  block the following actions
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines.
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request.
3. Ensure you have added or ran the appropriate tests for your PR.
5. If the PR is unfinished, you may add or remove a WIP or [WIP] prefix to your pull request title.
-->

#### What type of PR is this?
BugFix

<!--
Add one of the following kinds:
type-bug
type-feature
type-docs
etc.

Optionally add one or more of the following kinds if applicable:
module-resultset
module-sql execution
etc.
-->

#### What this PR does / why we need it:
This PR include two bug fix

1. When online schema change service start, but the async flow task has not scheduled. Request 
 to /api/v2/osc/updateRateLimitConfig may throw NPE.
2. When  /api/v2/osc/updateRateLimitConfig  requested before swap table action. server will loop restart OMS task cause limit config not saved correctly.

Rate limit diff check depends on message stored in schedule_schedule and schedule_task table. The message will not generated until flow task triggered. issue 1 happened before flow task triggered. 

If rate limit resolved different between schedule_schedule and schedule_task, update OMS config operation will triggered. Then schedule_task will assign same rate limit of schedule_schedule. issue 2 save previous rate limit again.


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #


#### Special notes for your reviewer:

<!--
This section is used to describe how this PR is implemented. 
If this is a PR that fixes a bug, this section describes how the bug was fixed.
If it's a new feature, this section briefly describes how to implement the new feature.
etc.
-->

#### Additional documentation e.g., usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```