### PR TITLE
fix(connection): automatically reconnect during the cloud upgrade process

### DIFF
--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/session/ConnectSessionService.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/session/ConnectSessionService.java
@@ -330,7 +330,8 @@ public class ConnectSessionService {
         ConnectionSession session = connectionSessionManager.getSession(sessionId);
         if (session == null) {
             CreateSessionReq req = new DefaultConnectSessionIdGenerator().getKeyFromId(sessionId);
-            if (!autoCreate || !StringUtils.equals(req.getFrom(), stateHostGenerator.getHost())) {
+            if (!autoCreate || (!StringUtils.equals(req.getFrom(), stateHostGenerator.getHost())
+                    && !cloudMetadataClient.supportsCloudMetadata())) {
                 throw new NotFoundException(ResourceType.ODC_SESSION, "ID", sessionId);
             }
             Lock lock = this.sessionId2Lock.computeIfAbsent(sessionId, s -> new ReentrantLock());

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/session/ConnectSessionService.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/session/ConnectSessionService.java
@@ -330,8 +330,8 @@ public class ConnectSessionService {
         ConnectionSession session = connectionSessionManager.getSession(sessionId);
         if (session == null) {
             CreateSessionReq req = new DefaultConnectSessionIdGenerator().getKeyFromId(sessionId);
-            if (!autoCreate || (!StringUtils.equals(req.getFrom(), stateHostGenerator.getHost())
-                    && !cloudMetadataClient.supportsCloudMetadata())) {
+            boolean autoRecreate = cloudMetadataClient.supportsCloudMetadata();
+            if (!autoCreate || (!StringUtils.equals(req.getFrom(), stateHostGenerator.getHost()) && !autoRecreate)) {
                 throw new NotFoundException(ResourceType.ODC_SESSION, "ID", sessionId);
             }
             Lock lock = this.sessionId2Lock.computeIfAbsent(sessionId, s -> new ReentrantLock());


### PR DESCRIPTION
#### What type of PR is this?
type-bug
module-connection
#### What this PR does / why we need it:
Fixed the issue that the connection could not be automatically reconnected during the cloud upgrade process.
The `stateRouteMethods` method has already determined whether the forwarded node is a healthy node before forwarding, so there is no need to change the code logic of `StateRouteAspect`：
<img width="879" alt="image" src="https://github.com/oceanbase/odc/assets/140503120/5483d10e-b44a-4155-9afc-9052197d909b">


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

<!--
This section is used to describe how this PR is implemented. 
If this is a PR that fixes a bug, this section describes how the bug was fixed.
If it's a new feature, this section briefly describes how to implement the new feature.
etc.
-->

#### Additional documentation e.g., usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```