### PR TITLE
fix(session): support auto recreate session when upgrade

### DIFF
--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/session/ConnectSessionService.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/session/ConnectSessionService.java
@@ -276,7 +276,8 @@ public class ConnectSessionService {
         DefaultConnectSessionIdGenerator idGenerator = new DefaultConnectSessionIdGenerator();
         idGenerator.setDatabaseId(req.getDbId());
         idGenerator.setFixRealId(StringUtils.isBlank(req.getRealId()) ? null : req.getRealId());
-        idGenerator.setHost(stateHostGenerator.getHost());
+        String host = cloudMetadataClient.supportsCloudMetadata() ? req.getFrom() : stateHostGenerator.getHost();
+        idGenerator.setHost(host);
         sessionFactory.setIdGenerator(idGenerator);
         long timeoutMillis = TimeUnit.MILLISECONDS.convert(sessionProperties.getTimeoutMins(), TimeUnit.MINUTES);
         timeoutMillis = timeoutMillis + this.connectionSessionManager.getScanIntervalMillis();

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/session/ConnectSessionService.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/session/ConnectSessionService.java
@@ -276,10 +276,12 @@ public class ConnectSessionService {
         DefaultConnectSessionIdGenerator idGenerator = new DefaultConnectSessionIdGenerator();
         idGenerator.setDatabaseId(req.getDbId());
         idGenerator.setFixRealId(StringUtils.isBlank(req.getRealId()) ? null : req.getRealId());
-        String host = cloudMetadataClient.supportsCloudMetadata()
-                && Boolean.FALSE.equals(cloudMetadataClient.supportsCloudParentUid()) ? req.getFrom()
-                        : stateHostGenerator.getHost();
-        idGenerator.setHost(host);
+        if (Objects.nonNull(req.getFrom()) && cloudMetadataClient.supportsCloudMetadata()
+                && Boolean.FALSE.equals(cloudMetadataClient.supportsCloudParentUid())) {
+            idGenerator.setHost(req.getFrom());
+        } else {
+            idGenerator.setHost(stateHostGenerator.getHost());
+        }
         sessionFactory.setIdGenerator(idGenerator);
         long timeoutMillis = TimeUnit.MILLISECONDS.convert(sessionProperties.getTimeoutMins(), TimeUnit.MINUTES);
         timeoutMillis = timeoutMillis + this.connectionSessionManager.getScanIntervalMillis();

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/session/ConnectSessionService.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/session/ConnectSessionService.java
@@ -276,7 +276,9 @@ public class ConnectSessionService {
         DefaultConnectSessionIdGenerator idGenerator = new DefaultConnectSessionIdGenerator();
         idGenerator.setDatabaseId(req.getDbId());
         idGenerator.setFixRealId(StringUtils.isBlank(req.getRealId()) ? null : req.getRealId());
-        String host = cloudMetadataClient.supportsCloudMetadata() ? req.getFrom() : stateHostGenerator.getHost();
+        String host = cloudMetadataClient.supportsCloudMetadata()
+                && Boolean.FALSE.equals(cloudMetadataClient.supportsCloudParentUid()) ? req.getFrom()
+                        : stateHostGenerator.getHost();
         idGenerator.setHost(host);
         sessionFactory.setIdGenerator(idGenerator);
         long timeoutMillis = TimeUnit.MILLISECONDS.convert(sessionProperties.getTimeoutMins(), TimeUnit.MINUTES);
@@ -331,7 +333,8 @@ public class ConnectSessionService {
         ConnectionSession session = connectionSessionManager.getSession(sessionId);
         if (session == null) {
             CreateSessionReq req = new DefaultConnectSessionIdGenerator().getKeyFromId(sessionId);
-            boolean autoRecreate = cloudMetadataClient.supportsCloudMetadata();
+            boolean autoRecreate = cloudMetadataClient.supportsCloudMetadata()
+                    && Boolean.FALSE.equals(cloudMetadataClient.supportsCloudParentUid());
             if (!autoCreate || (!StringUtils.equals(req.getFrom(), stateHostGenerator.getHost()) && !autoRecreate)) {
                 throw new NotFoundException(ResourceType.ODC_SESSION, "ID", sessionId);
             }

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/session/ConnectSessionService.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/session/ConnectSessionService.java
@@ -276,7 +276,7 @@ public class ConnectSessionService {
         DefaultConnectSessionIdGenerator idGenerator = new DefaultConnectSessionIdGenerator();
         idGenerator.setDatabaseId(req.getDbId());
         idGenerator.setFixRealId(StringUtils.isBlank(req.getRealId()) ? null : req.getRealId());
-        if (Objects.nonNull(req.getFrom()) && isOBCLoudEnvironment()) {
+        if (Objects.nonNull(req.getFrom()) && isOBCloudEnvironment()) {
             idGenerator.setHost(req.getFrom());
         } else {
             idGenerator.setHost(stateHostGenerator.getHost());
@@ -335,7 +335,7 @@ public class ConnectSessionService {
         if (session == null) {
             CreateSessionReq req = new DefaultConnectSessionIdGenerator().getKeyFromId(sessionId);
             if (!autoCreate
-                    || (!StringUtils.equals(req.getFrom(), stateHostGenerator.getHost()) && !isOBCLoudEnvironment())) {
+                    || (!StringUtils.equals(req.getFrom(), stateHostGenerator.getHost()) && !isOBCloudEnvironment())) {
                 throw new NotFoundException(ResourceType.ODC_SESSION, "ID", sessionId);
             }
             Lock lock = this.sessionId2Lock.computeIfAbsent(sessionId, s -> new ReentrantLock());
@@ -470,7 +470,7 @@ public class ConnectSessionService {
         }
     }
 
-    private boolean isOBCLoudEnvironment() {
+    private boolean isOBCloudEnvironment() {
         return cloudMetadataClient.supportsCloudMetadata()
                 && Boolean.FALSE.equals(cloudMetadataClient.supportsCloudParentUid());
     }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines.
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request.
3. Ensure you have added or ran the appropriate tests for your PR.
5. If the PR is unfinished, you may add or remove a WIP or [WIP] prefix to your pull request title.
-->

#### What type of PR is this?
type-bug

#### What this PR does / why we need it:
When automatically reconnecting in the cloud upgrade scenario, the host is obtained according to `req.getFrom()`, so that the created sessionId is consistent with the previously not found sessionId
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

<!--
This section is used to describe how this PR is implemented. 
If this is a PR that fixes a bug, this section describes how the bug was fixed.
If it's a new feature, this section briefly describes how to implement the new feature.
etc.
-->

#### Additional documentation e.g., usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```