### PR TITLE
security: disable LogicalDatabaseController 

### DIFF
--- a/libs/db-browser/pom.xml
+++ b/libs/db-browser/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.oceanbase</groupId>
     <artifactId>db-browser</artifactId>
-    <version>1.1.4</version>
+    <version>1.1.3</version>
     <name>db-browser</name>
     <url>https://github.com/oceanbase/odc/tree/main/libs/db-browser</url>
 

--- a/libs/db-browser/src/main/java/com/oceanbase/tools/dbbrowser/model/DBObjectType.java
+++ b/libs/db-browser/src/main/java/com/oceanbase/tools/dbbrowser/model/DBObjectType.java
@@ -24,7 +24,7 @@ public enum DBObjectType {
      */
     SCHEMA("SCHEMA"),
     TABLE("TABLE"),
-    LOGICAL_TABLE("LOGICAL TABLE"),
+    // LOGICAL_TABLE("LOGICAL TABLE"),
     COLUMN("COLUMN"),
     INDEX("INDEX"),
     CONSTRAINT("CONSTRAINT"),

--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,7 @@
         <alipay.sdk.version>4.20.19.ALL</alipay.sdk.version>
         <bucket4j-core.version>4.10.0</bucket4j-core.version>
         <springfox-swagger-ui.version>2.10.0</springfox-swagger-ui.version>
-        <db-browser.version>1.1.4</db-browser.version>
+        <db-browser.version>1.1.3</db-browser.version>
         <ob-sql-parser.version>1.3.0</ob-sql-parser.version>
         <pf4j.version>3.10.0</pf4j.version>
         <bcpkix-jdk15on.version>1.64</bcpkix-jdk15on.version>

--- a/server/odc-server/src/main/java/com/oceanbase/odc/server/web/controller/v2/LogicalDatabaseController.java
+++ b/server/odc-server/src/main/java/com/oceanbase/odc/server/web/controller/v2/LogicalDatabaseController.java
@@ -20,7 +20,6 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
-import org.springframework.web.bind.annotation.RestController;
 
 import com.oceanbase.odc.service.common.response.Responses;
 import com.oceanbase.odc.service.common.response.SuccessResponse;
@@ -34,7 +33,6 @@ import com.oceanbase.odc.service.connection.logicaldatabase.model.DetailLogicalD
  * @Date: 2024/5/7 15:07
  * @Description: []
  */
-@RestController
 @RequestMapping("/api/v2/connect/logicaldatabase")
 public class LogicalDatabaseController {
     @Autowired


### PR DESCRIPTION
ODC 4.3.1 does not currently support logical database management. 
1. Disable `LogicDatabaseController`.
2. Return the db-browser's version to 1.1.3.