### PR TITLE
fix(data-transfer): clean work directory before import

### DIFF
--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/datatransfer/task/DataTransferTask.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/datatransfer/task/DataTransferTask.java
@@ -332,6 +332,8 @@ public class DataTransferTask implements Callable<DataTransferTaskResult> {
             LOGGER.warn("Multiple files for CSV format is invalid, importFileNames={}", fileNames);
             throw new IllegalArgumentException("Multiple files isn't accepted for CSV format");
         }
+        // There maybe some dirty files generated before 4.2.3. We should clean them first.
+        FileUtils.cleanDirectory(destDir);
         LocalFileManager fileManager = SpringContextUtil.getBean(LocalFileManager.class);
         List<URL> inputs = new ArrayList<>();
         for (String fileName : fileNames) {


### PR DESCRIPTION
If ODC was upgraded from versions earlier than 4.2.3, and the metadb files are deleted, we may import some dirty data files. So we should clean the work directory first.

fix #3005 