### PR TITLE
fix(task):  show history log when odc upgrade use same mount path but with a new meta db

### DIFF
--- a/server/odc-server/src/main/resources/log4j2-task.xml
+++ b/server/odc-server/src/main/resources/log4j2-task.xml
@@ -34,6 +34,7 @@
                      filePattern="${LOG_DIRECTORY}/${ctx:taskId}/executor-%d{yyyy-MM-dd}-%i.log">
             <PatternLayout pattern="${LOG_PATTERN}"/>
             <Policies>
+                <OnStartupTriggeringPolicy/>
                 <SizeBasedTriggeringPolicy size="100MB"/>
             </Policies>
             <DefaultRolloverStrategy max="20">
@@ -59,6 +60,7 @@
                             <ThresholdFilter level="INFO" onMatch="ACCEPT" onMismatch="DENY"/>
                         </Filters>
                         <Policies>
+                            <OnStartupTriggeringPolicy/>
                             <TimeBasedTriggeringPolicy interval="6" modulate="true"/>
                             <SizeBasedTriggeringPolicy size="10 MB"/>
                         </Policies>
@@ -81,6 +83,7 @@
                             <ThresholdFilter level="WARN" onMatch="ACCEPT" onMismatch="DENY"/>
                         </Filters>
                         <Policies>
+                            <OnStartupTriggeringPolicy/>
                             <TimeBasedTriggeringPolicy interval="6" modulate="true"/>
                             <SizeBasedTriggeringPolicy size="10 MB"/>
                         </Policies>


### PR DESCRIPTION
What type of PR is this?
type-bug

What this PR does / why we need it:
triggering task log rollover when task start up, and the history log will not show in new task log.

Which issue(s) this PR fixes:
Fixes https://github.com/oceanbase/odc/issues/2203