### PR TITLE
fix(schema): show constraint's on delete rule correctly by parser

### DIFF
--- a/server/plugins/schema-plugin-ob-oracle/src/main/java/com/oceanbase/odc/plugin/schema/oboracle/parser/OBOracleGetDBTableByParser.java
+++ b/server/plugins/schema-plugin-ob-oracle/src/main/java/com/oceanbase/odc/plugin/schema/oboracle/parser/OBOracleGetDBTableByParser.java
@@ -171,7 +171,7 @@ public class OBOracleGetDBTableByParser implements GetDBTableByParser {
                             constraint.setOnDeleteRule(foreignConstraint.getReference().getDeleteOption() != null
                                     ? DBForeignKeyModifyRule
                                             .fromValue(foreignConstraint.getReference().getDeleteOption().toString())
-                                    : DBForeignKeyModifyRule.CASCADE);
+                                    : DBForeignKeyModifyRule.NO_ACTION);
                         } else {
                             if (item.isPrimaryKey()) {
                                 constraint.setType(DBConstraintType.PRIMARY_KEY);
@@ -224,7 +224,7 @@ public class OBOracleGetDBTableByParser implements GetDBTableByParser {
                     constraint.setOnDeleteRule(foreignConstraint.getReference().getDeleteOption() != null
                             ? DBForeignKeyModifyRule
                                     .fromValue(foreignConstraint.getReference().getDeleteOption().toString())
-                            : DBForeignKeyModifyRule.CASCADE);
+                            : DBForeignKeyModifyRule.NO_ACTION);
                 } else {
                     if (outOfLineConstraint.isPrimaryKey()) {
                         constraint.setType(DBConstraintType.PRIMARY_KEY);

--- a/server/plugins/schema-plugin-ob-oracle/src/test/java/com/oceanbase/odc/plugin/schema/oboracle/parser/OBOracleGetDBTableByParserTest.java
+++ b/server/plugins/schema-plugin-ob-oracle/src/test/java/com/oceanbase/odc/plugin/schema/oboracle/parser/OBOracleGetDBTableByParserTest.java
@@ -120,7 +120,7 @@ public class OBOracleGetDBTableByParserTest {
                 Assert.assertEquals(TEST_DATABASE_NAME, cons.getReferenceSchemaName());
                 Assert.assertEquals("CONSTRAINT_PRIMARY_BY_PARSER", cons.getReferenceTableName());
                 Assert.assertEquals("COL1", cons.getReferenceColumnNames().get(0));
-                Assert.assertEquals(DBForeignKeyModifyRule.CASCADE, cons.getOnDeleteRule());
+                Assert.assertEquals(DBForeignKeyModifyRule.NO_ACTION, cons.getOnDeleteRule());
             } else if ("unq33".equals(cons.getName())) {
                 Assert.assertEquals(DBConstraintType.UNIQUE_KEY, cons.getType());
                 Assert.assertEquals("COL2", cons.getColumnNames().get(0));


### PR DESCRIPTION


#### What type of PR is this?
type-bug

#### What this PR does / why we need it:
If the table's DDL does not explicitly show `on delete`, the default rule is ON ACTION:
```
REFERENCES [ schema. ] object [ (column_name [, column_name...]) ] [ON DELETE { CASCADE | SET NULL } ]
```
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #3028 

#### Special notes for your reviewer:

<!--
This section is used to describe how this PR is implemented. 
If this is a PR that fixes a bug, this section describes how the bug was fixed.
If it's a new feature, this section briefly describes how to implement the new feature.
etc.
-->

#### Additional documentation e.g., usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```