### PR TITLE
refactor(migrate): supports load sql script from custom jar file

### DIFF
--- a/server/odc-common/src/main/java/com/oceanbase/odc/common/util/ResourceUtils.java
+++ b/server/odc-common/src/main/java/com/oceanbase/odc/common/util/ResourceUtils.java
@@ -94,6 +94,9 @@ public class ResourceUtils {
             throw new RuntimeException(
                     String.format("cannot convert url to uri, folder '%s' may not exists", location), e);
         }
+        if (url2uris.isEmpty()) {
+            throw new RuntimeException(String.format("folder '%s' not exists", location));
+        }
         List<ResourceInfo> results = new ArrayList<>();
         for (Pair<URL, URI> url2uri : url2uris) {
             URI uri = url2uri.right;

--- a/server/odc-common/src/main/java/com/oceanbase/odc/common/util/ResourceUtils.java
+++ b/server/odc-common/src/main/java/com/oceanbase/odc/common/util/ResourceUtils.java
@@ -21,7 +21,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.JarURLConnection;
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
@@ -35,6 +34,8 @@ import java.util.jar.JarFile;
 
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.Validate;
+
+import com.oceanbase.odc.common.lang.Pair;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -79,21 +80,30 @@ public class ResourceUtils {
      */
     public static List<ResourceInfo> listResourcesFromDirectory(String location) {
         Validate.notEmpty(location, "parameter location may not be null");
-        URL url = ResourceUtils.class.getClassLoader().getResource(location);
-        if (url == null) {
-            throw new RuntimeException(String.format("folder '%s' not exists", location));
-        }
-        URI uri;
+        List<Pair<URL, URI>> url2uris = new ArrayList<>();
         try {
-            uri = url.toURI();
-        } catch (URISyntaxException e) {
+            Enumeration<URL> urls = ResourceUtils.class.getClassLoader().getResources(location);
+            if (urls == null) {
+                throw new RuntimeException(String.format("folder '%s' not exists", location));
+            }
+            while (urls.hasMoreElements()) {
+                URL url = urls.nextElement();
+                url2uris.add(new Pair<>(url, url.toURI()));
+            }
+        } catch (Exception e) {
             throw new RuntimeException(
                     String.format("cannot convert url to uri, folder '%s' may not exists", location), e);
         }
-        if (uri.getScheme().contains("jar")) {
-            return listResourcesFromJarPackage(url);
+        List<ResourceInfo> results = new ArrayList<>();
+        for (Pair<URL, URI> url2uri : url2uris) {
+            URI uri = url2uri.right;
+            if (uri.getScheme().contains("jar")) {
+                results.addAll(listResourcesFromJarPackage(url2uri.left));
+            } else {
+                results.addAll(listResourcesFromFileSystem(uri));
+            }
         }
-        return listResourcesFromFileSystem(uri);
+        return results;
     }
 
     private static List<ResourceInfo> listResourcesFromFileSystem(URI uri) {

--- a/server/odc-core/src/main/java/com/oceanbase/odc/core/migrate/resource/ResourceManager.java
+++ b/server/odc-core/src/main/java/com/oceanbase/odc/core/migrate/resource/ResourceManager.java
@@ -21,8 +21,10 @@ import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
@@ -37,6 +39,7 @@ import java.util.zip.ZipEntry;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.text.StringSubstitutor;
 
+import com.oceanbase.odc.common.lang.Pair;
 import com.oceanbase.odc.common.util.ListUtils;
 import com.oceanbase.odc.common.util.MapperUtils;
 import com.oceanbase.odc.common.util.TopoOrderComparator;
@@ -183,26 +186,32 @@ public class ResourceManager {
     public static Set<URL> getResourceUrls(List<String> locations) throws IOException {
         Set<URL> targets = new HashSet<>();
         for (String location : locations) {
-            URL url = ResourceManager.class.getClassLoader().getResource(location);
-            if (url == null) {
-                throw new FileNotFoundException("Location is not found " + location);
-            }
-            URI uri;
+            List<Pair<URL, URI>> url2uris = new ArrayList<>();
             try {
-                uri = url.toURI();
+                Enumeration<URL> urls = ResourceManager.class.getClassLoader().getResources(location);
+                if (urls == null) {
+                    throw new FileNotFoundException("Location is not found " + location);
+                }
+                while (urls.hasMoreElements()) {
+                    URL url = urls.nextElement();
+                    url2uris.add(new Pair<>(url, url.toURI()));
+                }
             } catch (URISyntaxException e) {
-                log.warn("Failed to get uri, url={}", url.toString(), e);
+                log.warn("Failed to get uri", e);
                 throw new IllegalStateException(e);
             }
-            String scheme = uri.getScheme();
-            if ("file".equals(scheme)) {
-                LocalFileResourceUrlFactory factory = new LocalFileResourceUrlFactory(url, new YamlFilePredicate());
-                targets.addAll(factory.generateResourceUrls());
-            } else if ("jar".equals(scheme)) {
-                JarFileResourceUrlFactory factory = new JarFileResourceUrlFactory(url, new YamlEntryPredicate());
-                targets.addAll(factory.generateResourceUrls());
-            } else {
-                throw new IllegalArgumentException("UnSupported scheme " + scheme);
+            for (Pair<URL, URI> url2uri : url2uris) {
+                URL url = url2uri.left;
+                String scheme = url2uri.right.getScheme();
+                if ("file".equals(scheme)) {
+                    LocalFileResourceUrlFactory factory = new LocalFileResourceUrlFactory(url, new YamlFilePredicate());
+                    targets.addAll(factory.generateResourceUrls());
+                } else if ("jar".equals(scheme)) {
+                    JarFileResourceUrlFactory factory = new JarFileResourceUrlFactory(url, new YamlEntryPredicate());
+                    targets.addAll(factory.generateResourceUrls());
+                } else {
+                    throw new IllegalArgumentException("UnSupported scheme " + scheme);
+                }
             }
         }
         return targets;

--- a/server/odc-core/src/main/java/com/oceanbase/odc/core/migrate/resource/ResourceManager.java
+++ b/server/odc-core/src/main/java/com/oceanbase/odc/core/migrate/resource/ResourceManager.java
@@ -200,6 +200,9 @@ public class ResourceManager {
                 log.warn("Failed to get uri", e);
                 throw new IllegalStateException(e);
             }
+            if (url2uris.isEmpty()) {
+                throw new FileNotFoundException("Location is not found " + location);
+            }
             for (Pair<URL, URI> url2uri : url2uris) {
                 URL url = url2uri.left;
                 String scheme = url2uri.right.getScheme();


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines.
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request.
3. Ensure you have added or ran the appropriate tests for your PR.
5. If the PR is unfinished, you may add or remove a WIP or [WIP] prefix to your pull request title.
-->

#### What type of PR is this?

type-refactor
<!--
Add one of the following kinds:
type-bug
type-feature
type-docs
etc.

Optionally add one or more of the following kinds if applicable:
module-resultset
module-sql execution
etc.
-->

#### What this PR does / why we need it:

the migrator can only load sql script from its own classpath and this pr change this default behavior

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

<!--
This section is used to describe how this PR is implemented. 
If this is a PR that fixes a bug, this section describes how the bug was fixed.
If it's a new feature, this section briefly describes how to implement the new feature.
etc.
-->

#### Additional documentation e.g., usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```