### PR TITLE
fix(resultset-export): the exported file is empty if use lower table name for oracle mode

### DIFF
--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/resultset/ResultSetExportTask.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/resultset/ResultSetExportTask.java
@@ -302,7 +302,7 @@ public class ResultSetExportTask implements Callable<ResultSetExportResult> {
 
     private String getFileName(String extension) {
         return (transferConfig.getConnectionInfo().getConnectType().getDialectType().isMysql()
-                ? parameter.getTableName()
+                ? parameter.getTableName().toLowerCase()
                 : parameter.getTableName().toUpperCase()) + extension;
     }
 

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/resultset/ResultSetExportTask.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/resultset/ResultSetExportTask.java
@@ -134,6 +134,7 @@ public class ResultSetExportTask implements Callable<ResultSetExportResult> {
              */
             File origin = new File(localResultSetFilePath);
             if (!origin.exists()) {
+                LOGGER.warn("There is no file generated, create an empty file instead.");
                 FileUtils.touch(origin);
             }
 
@@ -141,7 +142,7 @@ public class ResultSetExportTask implements Callable<ResultSetExportResult> {
              * OBDumper 不支持 excel 导出，需要先生成 csv, 然后使用工具类转换成 xlsx
              */
             if (DataTransferFormat.EXCEL == parameter.getFileFormat()) {
-                String excelFilePath = getDumpFileDirectory() + getFileName(DataTransferFormat.EXCEL.getExtension());
+                String excelFilePath = getDumpFileDirectory() + fileName;
                 try {
                     FileConvertUtils.convertCsvToXls(localResultSetFilePath, excelFilePath,
                             parameter.isSaveSql() ? Collections.singletonList(parameter.getSql()) : null);
@@ -295,15 +296,11 @@ public class ResultSetExportTask implements Callable<ResultSetExportResult> {
     private String getDumpFilePath(DataTransferTaskResult result, String extension) throws Exception {
         List<URL> exportPaths = result.getDataObjectsInfo().get(0).getExportPaths();
         if (CollectionUtils.isEmpty(exportPaths)) {
-            return Paths.get(getDumpFileDirectory(), getFileName(extension)).toString();
+            File[] files = new File(getDumpFileDirectory()).listFiles();
+            Verify.verify(files != null && files.length == 1, "");
+            return files[0].getPath();
         }
         return exportPaths.get(0).toURI().getPath();
-    }
-
-    private String getFileName(String extension) {
-        return (transferConfig.getConnectionInfo().getConnectType().getDialectType().isMysql()
-                ? parameter.getTableName().toLowerCase()
-                : parameter.getTableName().toUpperCase()) + extension;
     }
 
     private String getDumpFileDirectory() throws IOException {

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/resultset/ResultSetExportTask.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/resultset/ResultSetExportTask.java
@@ -301,8 +301,9 @@ public class ResultSetExportTask implements Callable<ResultSetExportResult> {
     }
 
     private String getFileName(String extension) {
-        return transferConfig.getConnectionInfo().getConnectType().getDialectType().isMysql() ? parameter.getTableName()
-                : parameter.getTableName().toUpperCase() + extension;
+        return (transferConfig.getConnectionInfo().getConnectType().getDialectType().isMysql()
+                ? parameter.getTableName()
+                : parameter.getTableName().toUpperCase()) + extension;
     }
 
     private String getDumpFileDirectory() throws IOException {

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/resultset/ResultSetExportTask.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/resultset/ResultSetExportTask.java
@@ -301,7 +301,8 @@ public class ResultSetExportTask implements Callable<ResultSetExportResult> {
     }
 
     private String getFileName(String extension) {
-        return parameter.getTableName() + extension;
+        return transferConfig.getConnectionInfo().getConnectType().getDialectType().isMysql() ? parameter.getTableName()
+                : parameter.getTableName().toUpperCase() + extension;
     }
 
     private String getDumpFileDirectory() throws IOException {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines.
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request.
3. Ensure you have added or ran the appropriate tests for your PR.
5. If the PR is unfinished, you may add or remove a WIP or [WIP] prefix to your pull request title.
-->

#### What type of PR is this?
type-bug
<!--
Add one of the following kinds:
type-bug
type-feature
type-docs
etc.

Optionally add one or more of the following kinds if applicable:
module-resultset
module-sql execution
etc.
-->

#### What this PR does / why we need it:
when exporting result set in oracle mode  and using a lower case table name , the exported file would be empty.
It's because obdumper would always generate a file with upper case name.