### PR TITLE
fix(manual execution):manual execution button should not be displayed after clicking manual execution

### DIFF
--- a/server/odc-core/src/main/java/com/oceanbase/odc/core/shared/constant/FlowStatus.java
+++ b/server/odc-core/src/main/java/com/oceanbase/odc/core/shared/constant/FlowStatus.java
@@ -46,12 +46,6 @@ public enum FlowStatus {
     WAIT_FOR_EXECUTION_EXPIRED,
 
     WAIT_FOR_CONFIRM,
-
-    /**
-     * The ticket status is between manual {@code WAIT_FOR_EXECUTION} and {@code EXECUTING}
-     */
-    PRE_EXECUTION,
-
     /**
      * {@code FlowInstance} is executing
      */

--- a/server/odc-core/src/main/java/com/oceanbase/odc/core/shared/constant/FlowStatus.java
+++ b/server/odc-core/src/main/java/com/oceanbase/odc/core/shared/constant/FlowStatus.java
@@ -46,6 +46,12 @@ public enum FlowStatus {
     WAIT_FOR_EXECUTION_EXPIRED,
 
     WAIT_FOR_CONFIRM,
+
+    /**
+     * The ticket status is between manual {@code WAIT_FOR_EXECUTION} and {@code EXECUTING}
+     */
+    PRE_EXECUTION,
+
     /**
      * {@code FlowInstance} is executing
      */

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/flow/FlowTaskInstanceService.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/flow/FlowTaskInstanceService.java
@@ -192,10 +192,10 @@ public class FlowTaskInstanceService {
             return response.getContentByType(new TypeReference<SuccessResponse<FlowInstanceDetailResp>>() {}).getData();
         }
         taskInstance.confirmExecute();
-        flowInstanceRepository.updateStatusById(id, FlowStatus.PRE_EXECUTION);
+        flowInstanceRepository.updateStatusById(id, FlowStatus.EXECUTING);
         FlowInstanceDetailResp flowInstanceDetailResp = FlowInstanceDetailResp.withIdAndType(id,
                 taskInstance.getTaskType());
-        flowInstanceDetailResp.setStatus(FlowStatus.PRE_EXECUTION);
+        flowInstanceDetailResp.setStatus(FlowStatus.EXECUTING);
         return flowInstanceDetailResp;
     }
 

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/flow/FlowTaskInstanceService.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/flow/FlowTaskInstanceService.java
@@ -43,6 +43,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.google.common.base.Charsets;
@@ -53,6 +54,7 @@ import com.oceanbase.odc.core.flow.model.FlowTaskResult;
 import com.oceanbase.odc.core.shared.PreConditions;
 import com.oceanbase.odc.core.shared.Verify;
 import com.oceanbase.odc.core.shared.constant.ErrorCodes;
+import com.oceanbase.odc.core.shared.constant.FlowStatus;
 import com.oceanbase.odc.core.shared.constant.ResourceType;
 import com.oceanbase.odc.core.shared.constant.TaskType;
 import com.oceanbase.odc.core.shared.exception.AccessDeniedException;
@@ -170,6 +172,7 @@ public class FlowTaskInstanceService {
 
     private final Set<String> supportedBucketName = new HashSet<>(Arrays.asList("async", "structure-comparison"));
 
+    @Transactional(rollbackFor = Exception.class)
     public FlowInstanceDetailResp executeTask(@NotNull Long id) throws IOException {
         List<FlowTaskInstance> instances =
                 filterTaskInstance(id, instance -> instance.getStatus() == FlowNodeStatus.PENDING, false);
@@ -189,7 +192,11 @@ public class FlowTaskInstanceService {
             return response.getContentByType(new TypeReference<SuccessResponse<FlowInstanceDetailResp>>() {}).getData();
         }
         taskInstance.confirmExecute();
-        return FlowInstanceDetailResp.withIdAndType(id, taskInstance.getTaskType());
+        flowInstanceRepository.updateStatusById(id, FlowStatus.EXECUTING);
+        FlowInstanceDetailResp flowInstanceDetailResp = FlowInstanceDetailResp.withIdAndType(id,
+                taskInstance.getTaskType());
+        flowInstanceDetailResp.setStatus(FlowStatus.EXECUTING);
+        return flowInstanceDetailResp;
     }
 
     public String getLog(@NotNull Long flowInstanceId, OdcTaskLogLevel level, boolean skipAuth) throws IOException {

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/flow/FlowTaskInstanceService.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/flow/FlowTaskInstanceService.java
@@ -192,10 +192,10 @@ public class FlowTaskInstanceService {
             return response.getContentByType(new TypeReference<SuccessResponse<FlowInstanceDetailResp>>() {}).getData();
         }
         taskInstance.confirmExecute();
-        flowInstanceRepository.updateStatusById(id, FlowStatus.EXECUTING);
+        flowInstanceRepository.updateStatusById(id, FlowStatus.PRE_EXECUTION);
         FlowInstanceDetailResp flowInstanceDetailResp = FlowInstanceDetailResp.withIdAndType(id,
                 taskInstance.getTaskType());
-        flowInstanceDetailResp.setStatus(FlowStatus.EXECUTING);
+        flowInstanceDetailResp.setStatus(FlowStatus.PRE_EXECUTION);
         return flowInstanceDetailResp;
     }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines.
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request.
3. Ensure you have added or ran the appropriate tests for your PR.
5. If the PR is unfinished, you may add or remove a WIP or [WIP] prefix to your pull request title.
-->

#### What type of PR is this?
type-bug
<!--
Add one of the following kinds:
type-bug
type-feature
type-docs
etc.

Optionally add one or more of the following kinds if applicable:
module-resultset
module-sql execution
etc.
-->

#### What this PR does / why we need it:
At present, after clicking manual execution button on the ticket, the status of ticket in the database will remain in wait_for_execution for a period of time, and the front end displays the execution button according to this status. Therefore, after clicking manual execution, the execution button will appear for a period of time, and an error will be reported when the user clicks execution button again.
The improvement is to change the status of the ticket to not ‘wait_for_execution’ immediately after clicking Manual execution button
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

<!--
This section is used to describe how this PR is implemented. 
If this is a PR that fixes a bug, this section describes how the bug was fixed.
If it's a new feature, this section briefly describes how to implement the new feature.
etc.
-->

#### Additional documentation e.g., usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```