### PR TITLE
fix(sqlcheck): affected rows for the native MySQL INSERT statement cannot take effect

### DIFF
--- a/server/odc-core/src/main/resources/i18n/BusinessMessages.properties
+++ b/server/odc-core/src/main/resources/i18n/BusinessMessages.properties
@@ -527,6 +527,10 @@ com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.restrict-sql-affect
 com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.restrict-sql-affected-rows.allowed-max-sql-affected-count=Maximum Allowed SQL Affected Rows
 com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.restrict-sql-affected-rows.allowed-max-sql-affected-count.description=Maximum Allowed SQL Affected Rows
 
+com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.estimate-sql-affected-rows-failed.message=The number of rows affected by this SQL cannot be determined or failed to be determined.
+com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.estimate-sql-affected-rows-failed.name=Unable to determine or failed to determine the number of lines affected by the statement
+com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.estimate-sql-affected-rows-failed.description=SQL affected rows determination failed.
+
 com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.too-many-table-join.message=Too many table objects JOIN may lead to an unoptimized execution plan. It is recommended not to exceed {0}, the actual is {1}
 com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.too-many-table-join.name=Too many table objects JOIN
 com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.too-many-table-join.description=Too many table objects JOIN may lead to an unoptimized execution plan

--- a/server/odc-core/src/main/resources/i18n/BusinessMessages.properties
+++ b/server/odc-core/src/main/resources/i18n/BusinessMessages.properties
@@ -527,9 +527,9 @@ com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.restrict-sql-affect
 com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.restrict-sql-affected-rows.allowed-max-sql-affected-count=Maximum Allowed SQL Affected Rows
 com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.restrict-sql-affected-rows.allowed-max-sql-affected-count.description=Maximum Allowed SQL Affected Rows
 
-com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.estimate-sql-affected-rows-failed.message=The number of rows affected by this SQL cannot be determined or failed to be determined.
-com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.estimate-sql-affected-rows-failed.name=Unable to determine or failed to determine the number of lines affected by the statement
-com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.estimate-sql-affected-rows-failed.description=SQL affected rows determination failed.
+com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.estimate-sql-affected-rows-failed.message=The number of rows affected by this SQL statement cannot be determined or failed to be determined.
+com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.estimate-sql-affected-rows-failed.name=Unable to determine or failed to determine the number of rows affected by the SQL statement.
+com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.estimate-sql-affected-rows-failed.description=Unable to determine or failed to determine the number of rows affected by the SQL statement.
 
 com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.too-many-table-join.message=Too many table objects JOIN may lead to an unoptimized execution plan. It is recommended not to exceed {0}, the actual is {1}
 com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.too-many-table-join.name=Too many table objects JOIN

--- a/server/odc-core/src/main/resources/i18n/BusinessMessages_zh_CN.properties
+++ b/server/odc-core/src/main/resources/i18n/BusinessMessages_zh_CN.properties
@@ -510,6 +510,9 @@ com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.restrict-sql-affect
 com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.restrict-sql-affected-rows.description=SQL 影响行数不能超限
 com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.restrict-sql-affected-rows.allowed-max-sql-affected-count=最大 SQL 影响行数
 com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.restrict-sql-affected-rows.allowed-max-sql-affected-count.description=最大 SQL 影响行数
+com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.estimate-sql-affected-rows-failed.message=本条 SQL 影响行数无法判断或判断失败
+com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.estimate-sql-affected-rows-failed.name=无法判断或判断失败语句影响行数
+com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.estimate-sql-affected-rows-failed.description=SQL 影响行数无法判断或判断失败
 com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.too-many-table-join.message=过多的表对象 JOIN，可能导致执行计划无法最优，推荐不超过 {0} 个，实际 {1} 个表联结
 com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.too-many-table-join.name=过多的表对象 JOIN
 com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.too-many-table-join.description=过多的表对象 JOIN，可能导致执行计划无法最优

--- a/server/odc-core/src/main/resources/i18n/BusinessMessages_zh_TW.properties
+++ b/server/odc-core/src/main/resources/i18n/BusinessMessages_zh_TW.properties
@@ -532,6 +532,10 @@ com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.restrict-sql-affect
 com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.restrict-sql-affected-rows.allowed-max-sql-affected-count=最大 SQL 影響行數
 com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.restrict-sql-affected-rows.allowed-max-sql-affected-count.description=最大 SQL 影響行數
 
+com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.estimate-sql-affected-rows-failed.message=本條 SQL 影響行數無法判斷或判斷失敗
+com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.estimate-sql-affected-rows-failed.name=無法判斷或判斷失敗陳述會影響列數
+com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.estimate-sql-affected-rows-failed.description=SQL 影響行數無法判斷或判斷失敗
+
 com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.too-many-table-join.message=過多的表對象 JOIN，可能導致執行計劃無法最優，推薦不超過 {0} 個，實際 {1} 個表聯結
 com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.too-many-table-join.name=過多的表對象 JOIN
 com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.too-many-table-join.description=過多的表對象 JOIN，可能導致執行計劃無法最優

--- a/server/odc-migrate/src/main/resources/init-config/init/regulation-rule-applying.yaml
+++ b/server/odc-migrate/src/main/resources/init-config/init/regulation-rule-applying.yaml
@@ -457,7 +457,7 @@
   appliedDialectTypes:
     - 'OB_MYSQL'
     - 'MYSQL'
-  propertiesJson: '{"${com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.estimate-sql-affected-rows-failed.unable-to-estimate-sql-affected-count}":-1}'
+  propertiesJson: '{}'
 - enabled: 1
   level: 0
   rulesetName: ${com.oceanbase.odc.builtin-resource.regulation.ruleset.default-sit-ruleset.name}
@@ -1459,7 +1459,7 @@
   appliedDialectTypes:
     - 'OB_MYSQL'
     - 'MYSQL'
-  propertiesJson: '{"${com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.estimate-sql-affected-rows-failed.unable-to-estimate-sql-affected-count}":-1}'
+  propertiesJson: '{}'
 - enabled: 1
   level: 1
   rulesetName: ${com.oceanbase.odc.builtin-resource.regulation.ruleset.default-prod-ruleset.name}
@@ -1950,7 +1950,7 @@
   appliedDialectTypes:
     - 'OB_MYSQL'
     - 'MYSQL'
-  propertiesJson: '{"${com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.estimate-sql-affected-rows-failed.unable-to-estimate-sql-affected-count}":-1}'
+  propertiesJson: '{}'
 - enabled: 1
   level: 1
   rulesetName: ${com.oceanbase.odc.builtin-resource.regulation.ruleset.default-default-ruleset.name}

--- a/server/odc-migrate/src/main/resources/init-config/init/regulation-rule-applying.yaml
+++ b/server/odc-migrate/src/main/resources/init-config/init/regulation-rule-applying.yaml
@@ -453,6 +453,14 @@
 - enabled: 1
   level: 0
   rulesetName: ${com.oceanbase.odc.builtin-resource.regulation.ruleset.default-sit-ruleset.name}
+  ruleName: ${com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.estimate-sql-affected-rows-failed.name}
+  appliedDialectTypes:
+    - 'OB_MYSQL'
+    - 'MYSQL'
+  propertiesJson: '{"${com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.estimate-sql-affected-rows-failed.unable-to-estimate-sql-affected-count}":-1}'
+- enabled: 1
+  level: 0
+  rulesetName: ${com.oceanbase.odc.builtin-resource.regulation.ruleset.default-sit-ruleset.name}
   ruleName: ${com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.too-many-table-join.name}
   appliedDialectTypes:
       - 'OB_MYSQL'
@@ -946,6 +954,14 @@
 - enabled: 1
   level: 0
   rulesetName: ${com.oceanbase.odc.builtin-resource.regulation.ruleset.default-dev-ruleset.name}
+  ruleName: ${com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.estimate-sql-affected-rows-failed.name}
+  appliedDialectTypes:
+    - 'OB_MYSQL'
+    - 'MYSQL'
+  propertiesJson: '{"${com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.estimate-sql-affected-rows-failed.unable-to-estimate-sql-affected-count}":-1}'
+- enabled: 1
+  level: 0
+  rulesetName: ${com.oceanbase.odc.builtin-resource.regulation.ruleset.default-dev-ruleset.name}
   ruleName: ${com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.too-many-table-join.name}
   appliedDialectTypes:
       - 'OB_MYSQL'
@@ -1439,6 +1455,14 @@
 - enabled: 1
   level: 1
   rulesetName: ${com.oceanbase.odc.builtin-resource.regulation.ruleset.default-prod-ruleset.name}
+  ruleName: ${com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.estimate-sql-affected-rows-failed.name}
+  appliedDialectTypes:
+    - 'OB_MYSQL'
+    - 'MYSQL'
+  propertiesJson: '{"${com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.estimate-sql-affected-rows-failed.unable-to-estimate-sql-affected-count}":-1}'
+- enabled: 1
+  level: 1
+  rulesetName: ${com.oceanbase.odc.builtin-resource.regulation.ruleset.default-prod-ruleset.name}
   ruleName: ${com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.too-many-table-join.name}
   appliedDialectTypes:
       - 'OB_MYSQL'
@@ -1919,6 +1943,14 @@
     - 'OB_MYSQL'
     - 'MYSQL'
   propertiesJson: '{"${com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.restrict-sql-affected-rows.allowed-max-sql-affected-count}":1000}'
+- enabled: 1
+  level: 1
+  rulesetName: ${com.oceanbase.odc.builtin-resource.regulation.ruleset.default-default-ruleset.name}
+  ruleName: ${com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.estimate-sql-affected-rows-failed.name}
+  appliedDialectTypes:
+    - 'OB_MYSQL'
+    - 'MYSQL'
+  propertiesJson: '{"${com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.estimate-sql-affected-rows-failed.unable-to-estimate-sql-affected-count}":-1}'
 - enabled: 1
   level: 1
   rulesetName: ${com.oceanbase.odc.builtin-resource.regulation.ruleset.default-default-ruleset.name}

--- a/server/odc-migrate/src/main/resources/init-config/init/regulation-rule-applying.yaml
+++ b/server/odc-migrate/src/main/resources/init-config/init/regulation-rule-applying.yaml
@@ -958,7 +958,7 @@
   appliedDialectTypes:
     - 'OB_MYSQL'
     - 'MYSQL'
-  propertiesJson: '{"${com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.estimate-sql-affected-rows-failed.unable-to-estimate-sql-affected-count}":-1}'
+  propertiesJson: '{}'
 - enabled: 1
   level: 0
   rulesetName: ${com.oceanbase.odc.builtin-resource.regulation.ruleset.default-dev-ruleset.name}

--- a/server/odc-migrate/src/main/resources/init-config/init/regulation-rule-metadata.yaml
+++ b/server/odc-migrate/src/main/resources/init-config/init/regulation-rule-metadata.yaml
@@ -1441,10 +1441,3 @@
       value: OB_MYSQL
     - label: SUPPORTED_DIALECT_TYPE
       value: MYSQL
-  propertyMetadatas:
-    - name: ${com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.estimate-sql-affected-rows-failed.unable-to-estimate-sql-affected-count}
-      description: ${com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.estimate-sql-affected-rows-failed.unable-to-estimate-sql-affected-count.description}
-      type: INTEGER
-      componentType: INPUT_NUMBER
-      defaultValues:
-        - !!int -1

--- a/server/odc-migrate/src/main/resources/init-config/init/regulation-rule-metadata.yaml
+++ b/server/odc-migrate/src/main/resources/init-config/init/regulation-rule-metadata.yaml
@@ -1423,3 +1423,28 @@
       componentType: INPUT_NUMBER
       defaultValues:
         - !!int 1000
+- id: 60
+  name: ${com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.estimate-sql-affected-rows-failed.name}
+  description: ${com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.estimate-sql-affected-rows-failed.description}
+  type: SQL_CHECK
+  builtIn: 1
+  labels:
+    - label: SUB_TYPE
+      value: DML
+    - label: SUB_TYPE
+      value: UPDATE
+    - label: SUB_TYPE
+      value: DELETE
+    - label: SUB_TYPE
+      value: INSERT
+    - label: SUPPORTED_DIALECT_TYPE
+      value: OB_MYSQL
+    - label: SUPPORTED_DIALECT_TYPE
+      value: MYSQL
+  propertyMetadatas:
+    - name: ${com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.estimate-sql-affected-rows-failed.unable-to-estimate-sql-affected-count}
+      description: ${com.oceanbase.odc.builtin-resource.regulation.rule.sql-check.estimate-sql-affected-rows-failed.unable-to-estimate-sql-affected-count.description}
+      type: INTEGER
+      componentType: INPUT_NUMBER
+      defaultValues:
+        - !!int -1

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/sqlcheck/factory/Unable2JudgeAffectedRowsFactory.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/sqlcheck/factory/Unable2JudgeAffectedRowsFactory.java
@@ -23,6 +23,7 @@ import com.oceanbase.odc.core.shared.constant.DialectType;
 import com.oceanbase.odc.service.sqlcheck.SqlCheckRule;
 import com.oceanbase.odc.service.sqlcheck.SqlCheckRuleFactory;
 import com.oceanbase.odc.service.sqlcheck.model.SqlCheckRuleType;
+import com.oceanbase.odc.service.sqlcheck.rule.MySQLAffectedRowsExceedLimit;
 import com.oceanbase.odc.service.sqlcheck.rule.Unable2JudgeAffectedRows;
 
 import lombok.NonNull;
@@ -37,15 +38,14 @@ public class Unable2JudgeAffectedRowsFactory implements SqlCheckRuleFactory {
 
     @Override
     public SqlCheckRuleType getSupportsType() {
-        return SqlCheckRuleType.ESTIMATE_SQL_AFFECTED_ROWS;
+        return SqlCheckRuleType.ESTIMATE_SQL_AFFECTED_ROWS_FAILED;
     }
 
     @Override
     public SqlCheckRule generate(@NonNull DialectType dialectType, Map<String, Object> parameters) {
-        String key = getParameterNameKey("allowed-max-sql-affected-count");
-        if (parameters == null || parameters.isEmpty() || parameters.get(key) == null) {
-            return new Unable2JudgeAffectedRows(1000L, dialectType, jdbc);
-        }
-        return new Unable2JudgeAffectedRows(Long.valueOf(parameters.get(key).toString()), dialectType, jdbc);
+        SqlAffectedRowsFactory sqlAffectedRowsFactory = new SqlAffectedRowsFactory(this.jdbc);
+        MySQLAffectedRowsExceedLimit targetRule = (MySQLAffectedRowsExceedLimit) sqlAffectedRowsFactory
+                .generate(dialectType, parameters);
+        return new Unable2JudgeAffectedRows(targetRule);
     }
 }

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/sqlcheck/factory/Unable2JudgeAffectedRowsFactory.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/sqlcheck/factory/Unable2JudgeAffectedRowsFactory.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2023 OceanBase.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.oceanbase.odc.service.sqlcheck.factory;
+
+import java.util.Map;
+
+import org.springframework.jdbc.core.JdbcOperations;
+
+import com.oceanbase.odc.core.shared.constant.DialectType;
+import com.oceanbase.odc.service.sqlcheck.SqlCheckRule;
+import com.oceanbase.odc.service.sqlcheck.SqlCheckRuleFactory;
+import com.oceanbase.odc.service.sqlcheck.model.SqlCheckRuleType;
+import com.oceanbase.odc.service.sqlcheck.rule.Unable2JudgeAffectedRows;
+
+import lombok.NonNull;
+
+public class Unable2JudgeAffectedRowsFactory implements SqlCheckRuleFactory {
+
+    private final JdbcOperations jdbc;
+
+    public Unable2JudgeAffectedRowsFactory(JdbcOperations jdbc) {
+        this.jdbc = jdbc;
+    }
+
+    @Override
+    public SqlCheckRuleType getSupportsType() {
+        return SqlCheckRuleType.ESTIMATE_SQL_AFFECTED_ROWS;
+    }
+
+    @Override
+    public SqlCheckRule generate(@NonNull DialectType dialectType, Map<String, Object> parameters) {
+        String key = getParameterNameKey("allowed-max-sql-affected-count");
+        if (parameters == null || parameters.isEmpty() || parameters.get(key) == null) {
+            return new Unable2JudgeAffectedRows(1000L, dialectType, jdbc);
+        }
+        return new Unable2JudgeAffectedRows(Long.valueOf(parameters.get(key).toString()), dialectType, jdbc);
+    }
+}

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/sqlcheck/factory/Unable2JudgeAffectedRowsFactory.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/sqlcheck/factory/Unable2JudgeAffectedRowsFactory.java
@@ -24,7 +24,7 @@ import com.oceanbase.odc.service.sqlcheck.SqlCheckRule;
 import com.oceanbase.odc.service.sqlcheck.SqlCheckRuleFactory;
 import com.oceanbase.odc.service.sqlcheck.model.SqlCheckRuleType;
 import com.oceanbase.odc.service.sqlcheck.rule.MySQLAffectedRowsExceedLimit;
-import com.oceanbase.odc.service.sqlcheck.rule.Unable2JudgeAffectedRows;
+import com.oceanbase.odc.service.sqlcheck.rule.MySQLUnable2JudgeAffectedRows;
 
 import lombok.NonNull;
 
@@ -46,6 +46,6 @@ public class Unable2JudgeAffectedRowsFactory implements SqlCheckRuleFactory {
         SqlAffectedRowsFactory sqlAffectedRowsFactory = new SqlAffectedRowsFactory(this.jdbc);
         MySQLAffectedRowsExceedLimit targetRule = (MySQLAffectedRowsExceedLimit) sqlAffectedRowsFactory
                 .generate(dialectType, parameters);
-        return new Unable2JudgeAffectedRows(targetRule);
+        return new MySQLUnable2JudgeAffectedRows(targetRule);
     }
 }

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/sqlcheck/factory/Unable2JudgeAffectedRowsFactory.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/sqlcheck/factory/Unable2JudgeAffectedRowsFactory.java
@@ -24,7 +24,7 @@ import com.oceanbase.odc.service.sqlcheck.SqlCheckRule;
 import com.oceanbase.odc.service.sqlcheck.SqlCheckRuleFactory;
 import com.oceanbase.odc.service.sqlcheck.model.SqlCheckRuleType;
 import com.oceanbase.odc.service.sqlcheck.rule.MySQLAffectedRowsExceedLimit;
-import com.oceanbase.odc.service.sqlcheck.rule.MySQLUnable2JudgeAffectedRows;
+import com.oceanbase.odc.service.sqlcheck.rule.Unable2JudgeAffectedRows;
 
 import lombok.NonNull;
 
@@ -46,6 +46,6 @@ public class Unable2JudgeAffectedRowsFactory implements SqlCheckRuleFactory {
         SqlAffectedRowsFactory sqlAffectedRowsFactory = new SqlAffectedRowsFactory(this.jdbc);
         MySQLAffectedRowsExceedLimit targetRule = (MySQLAffectedRowsExceedLimit) sqlAffectedRowsFactory
                 .generate(dialectType, parameters);
-        return new MySQLUnable2JudgeAffectedRows(targetRule);
+        return new Unable2JudgeAffectedRows(targetRule);
     }
 }

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/sqlcheck/model/SqlCheckRuleType.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/sqlcheck/model/SqlCheckRuleType.java
@@ -251,7 +251,7 @@ public enum SqlCheckRuleType implements Translatable {
     /**
      * Unable to judge restrict the number of lines affected by SQL
      */
-    ESTIMATE_SQL_AFFECTED_ROWS("estimate-sql-affected-rows-failed");
+    ESTIMATE_SQL_AFFECTED_ROWS_FAILED("estimate-sql-affected-rows-failed");
 
     private final String name;
     private static final String NAME_CODE = "name";

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/sqlcheck/model/SqlCheckRuleType.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/sqlcheck/model/SqlCheckRuleType.java
@@ -247,7 +247,11 @@ public enum SqlCheckRuleType implements Translatable {
     /**
      * Restrict the number of lines affected by SQL
      */
-    RESTRICT_SQL_AFFECTED_ROWS("restrict-sql-affected-rows");
+    RESTRICT_SQL_AFFECTED_ROWS("restrict-sql-affected-rows"),
+    /**
+     * Unable to judge restrict the number of lines affected by SQL
+     */
+    ESTIMATE_SQL_AFFECTED_ROWS("estimate-sql-affected-rows-failed");
 
     private final String name;
     private static final String NAME_CODE = "name";

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/sqlcheck/rule/BaseAffectedRowsExceedLimit.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/sqlcheck/rule/BaseAffectedRowsExceedLimit.java
@@ -18,9 +18,6 @@ package com.oceanbase.odc.service.sqlcheck.rule;
 import java.util.Collections;
 import java.util.List;
 
-import org.springframework.jdbc.core.JdbcOperations;
-
-import com.oceanbase.odc.core.shared.constant.DialectType;
 import com.oceanbase.odc.service.sqlcheck.SqlCheckContext;
 import com.oceanbase.odc.service.sqlcheck.SqlCheckRule;
 import com.oceanbase.odc.service.sqlcheck.SqlCheckUtil;
@@ -28,20 +25,13 @@ import com.oceanbase.odc.service.sqlcheck.model.CheckViolation;
 import com.oceanbase.odc.service.sqlcheck.model.SqlCheckRuleType;
 import com.oceanbase.tools.sqlparser.statement.Statement;
 
-import lombok.Getter;
 import lombok.NonNull;
 
-@Getter
 public abstract class BaseAffectedRowsExceedLimit implements SqlCheckRule {
 
     private final Long maxSqlAffectedRows;
-    private final JdbcOperations jdbcOperations;
-    private final DialectType dialectType;
 
-    public BaseAffectedRowsExceedLimit(@NonNull Long maxSqlAffectedRows, DialectType dialectType,
-            JdbcOperations jdbcOperations) {
-        this.dialectType = dialectType;
-        this.jdbcOperations = jdbcOperations;
+    public BaseAffectedRowsExceedLimit(@NonNull Long maxSqlAffectedRows) {
         this.maxSqlAffectedRows = maxSqlAffectedRows < 0 ? Long.MAX_VALUE : maxSqlAffectedRows;
     }
 
@@ -59,7 +49,7 @@ public abstract class BaseAffectedRowsExceedLimit implements SqlCheckRule {
     @Override
     public List<CheckViolation> check(@NonNull Statement statement, @NonNull SqlCheckContext context) {
         try {
-            long affectedRows = getStatementAffectedRows(statement, this.jdbcOperations, this.maxSqlAffectedRows);
+            long affectedRows = getStatementAffectedRows(statement);
             if (affectedRows >= 0) {
                 if (affectedRows > maxSqlAffectedRows) {
                     return Collections.singletonList(SqlCheckUtil.buildViolation(statement.getText(),
@@ -73,7 +63,6 @@ public abstract class BaseAffectedRowsExceedLimit implements SqlCheckRule {
         return Collections.emptyList();
     }
 
-    public abstract long getStatementAffectedRows(Statement statement,
-            JdbcOperations jdbcOperations, Long maxSqlAffectedRows) throws Exception;
+    public abstract long getStatementAffectedRows(Statement statement) throws Exception;
 
 }

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/sqlcheck/rule/BaseAffectedRowsExceedLimit.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/sqlcheck/rule/BaseAffectedRowsExceedLimit.java
@@ -28,20 +28,21 @@ import com.oceanbase.odc.service.sqlcheck.model.CheckViolation;
 import com.oceanbase.odc.service.sqlcheck.model.SqlCheckRuleType;
 import com.oceanbase.tools.sqlparser.statement.Statement;
 
+import lombok.Getter;
 import lombok.NonNull;
-import lombok.extern.slf4j.Slf4j;
 
-@Slf4j
-public class Unable2JudgeAffectedRows implements SqlCheckRule {
+@Getter
+public abstract class BaseAffectedRowsExceedLimit implements SqlCheckRule {
 
-    private final BaseAffectedRowsExceedLimit targetRule;
-    private final JdbcOperations jdbcOperations;
     private final Long maxSqlAffectedRows;
+    private final JdbcOperations jdbcOperations;
+    private final DialectType dialectType;
 
-    public Unable2JudgeAffectedRows(@NonNull BaseAffectedRowsExceedLimit targetRule) {
-        this.jdbcOperations = targetRule.getJdbcOperations();
-        this.maxSqlAffectedRows = targetRule.getMaxSqlAffectedRows();
-        this.targetRule = targetRule;
+    public BaseAffectedRowsExceedLimit(@NonNull Long maxSqlAffectedRows, DialectType dialectType,
+            JdbcOperations jdbcOperations) {
+        this.dialectType = dialectType;
+        this.jdbcOperations = jdbcOperations;
+        this.maxSqlAffectedRows = maxSqlAffectedRows < 0 ? Long.MAX_VALUE : maxSqlAffectedRows;
     }
 
     /**
@@ -49,12 +50,7 @@ public class Unable2JudgeAffectedRows implements SqlCheckRule {
      */
     @Override
     public SqlCheckRuleType getType() {
-        return SqlCheckRuleType.ESTIMATE_SQL_AFFECTED_ROWS_FAILED;
-    }
-
-    @Override
-    public List<DialectType> getSupportsDialectTypes() {
-        return this.targetRule.getSupportsDialectTypes();
+        return SqlCheckRuleType.RESTRICT_SQL_AFFECTED_ROWS;
     }
 
     /**
@@ -63,16 +59,21 @@ public class Unable2JudgeAffectedRows implements SqlCheckRule {
     @Override
     public List<CheckViolation> check(@NonNull Statement statement, @NonNull SqlCheckContext context) {
         try {
-            long affectedRows = this.targetRule.getStatementAffectedRows(statement, jdbcOperations, maxSqlAffectedRows);
-            if (affectedRows < 0) {
-                return Collections.singletonList(SqlCheckUtil
-                        .buildViolation(statement.getText(), statement, getType(), new Object[] {}));
+            long affectedRows = getStatementAffectedRows(statement, this.jdbcOperations, this.maxSqlAffectedRows);
+            if (affectedRows >= 0) {
+                if (affectedRows > maxSqlAffectedRows) {
+                    return Collections.singletonList(SqlCheckUtil.buildViolation(statement.getText(),
+                            statement, getType(), new Object[] {maxSqlAffectedRows, affectedRows}));
+                }
+                return Collections.emptyList();
             }
         } catch (Exception e) {
-            log.warn("Unable to get affected rows, sql={}", statement.getText(), e);
-            return Collections.singletonList(SqlCheckUtil
-                    .buildViolation(statement.getText(), statement, getType(), new Object[] {}));
+            // eat the exception
         }
         return Collections.emptyList();
     }
+
+    public abstract long getStatementAffectedRows(Statement statement,
+            JdbcOperations jdbcOperations, Long maxSqlAffectedRows) throws Exception;
+
 }

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/sqlcheck/rule/MySQLAffectedRowsExceedLimit.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/sqlcheck/rule/MySQLAffectedRowsExceedLimit.java
@@ -144,7 +144,7 @@ public class MySQLAffectedRowsExceedLimit implements SqlCheckRule {
         Matcher selectMatcher = selectPattern.matcher(sql);
 
         if (valuesMatcher.find()) {
-            String [] valueList = sql.split(valuesRegex);
+            String[] valueList = sql.split(valuesRegex);
             Pattern pattern = Pattern.compile("\\(.*?\\)");
             Matcher matcher = pattern.matcher("(" + valueList[1]);
             int count = 0;

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/sqlcheck/rule/MySQLAffectedRowsExceedLimit.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/sqlcheck/rule/MySQLAffectedRowsExceedLimit.java
@@ -133,13 +133,13 @@ public class MySQLAffectedRowsExceedLimit implements SqlCheckRule {
      */
     private long getMySqlAffectedRowsByCount(Insert insertStatement) {
 
-        List<Expression> insertClass = insertStatement.getTableInsert().get(0)
-                .getValues().get(0);
-        String expressionType = insertClass.get(0)
+        List<List<Expression>> insertList = insertStatement.getTableInsert().get(0)
+                .getValues();
+        String expressionType = insertList.get(0).get(0)
                 .getClass().getSimpleName();
         // case1: For INSERT INTO ... VALUES(...)
         if ("ConstExpression".equals(expressionType)) {
-            return insertClass.size();
+            return insertList.size();
         }
         // case2: For INSERT INTO ... SELECT ...
         if ("Select".equals(expressionType)) {

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/sqlcheck/rule/MySQLAffectedRowsExceedLimit.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/sqlcheck/rule/MySQLAffectedRowsExceedLimit.java
@@ -88,7 +88,7 @@ public class MySQLAffectedRowsExceedLimit implements SqlCheckRule {
                     switch (dialectType) {
                         case MYSQL:
                             affectedRows = (statement instanceof Insert)
-                                    ? getMySqlAffectedRowsByCount((Insert)statement)
+                                    ? getMySqlAffectedRowsByCount((Insert) statement)
                                     : getMySqlAffectedRowsByExplain(explainSql, jdbcOperations);
                             break;
                         case OB_MYSQL:
@@ -134,9 +134,9 @@ public class MySQLAffectedRowsExceedLimit implements SqlCheckRule {
     private long getMySqlAffectedRowsByCount(Insert insertStatement) {
 
         List<Expression> insertClass = insertStatement.getTableInsert().get(0)
-            .getValues().get(0);
+                .getValues().get(0);
         String expressionType = insertClass.get(0)
-            .getClass().getSimpleName();
+                .getClass().getSimpleName();
         // case1: For INSERT INTO ... VALUES(...)
         if ("ConstExpression".equals(expressionType)) {
             return insertClass.size();

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/sqlcheck/rule/MySQLAffectedRowsExceedLimit.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/sqlcheck/rule/MySQLAffectedRowsExceedLimit.java
@@ -134,16 +134,11 @@ public class MySQLAffectedRowsExceedLimit implements SqlCheckRule {
 
         explainSql = explainSql.toLowerCase();
 
-        if (explainSql.contains("value")) {
-            String valueList = extractValueList(explainSql);
-            return valueList.isEmpty() ? 0 : Arrays.stream(valueList.split("\\),")).count();
-        }
-
         if (explainSql.contains("select")) {
             return getMySqlAffectedRowsByExplain(explainSql, jdbc);
+        } else {
+            return explainSql.split("\\),").length;
         }
-
-        return 0;
     }
 
     /**
@@ -238,19 +233,4 @@ public class MySQLAffectedRowsExceedLimit implements SqlCheckRule {
         return 0;
     }
 
-    /**
-     * parse explain result set
-     *
-     * @param explainSql row
-     * @return value list
-     */
-    private String extractValueList(String explainSql) {
-        // Match "value" or "values"
-        String[] list = explainSql.split("value(s)?");
-        if (list.length > 1) {
-            String valuesPart = list[1].split(";")[0];
-            return valuesPart.trim();
-        }
-        return "";
-    }
 }

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/sqlcheck/rule/MySQLAffectedRowsExceedLimit.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/sqlcheck/rule/MySQLAffectedRowsExceedLimit.java
@@ -54,10 +54,11 @@ import lombok.extern.slf4j.Slf4j;
  */
 @Slf4j
 public class MySQLAffectedRowsExceedLimit implements SqlCheckRule {
+
     @Getter
-    protected final Long maxSqlAffectedRows;
-    protected final JdbcOperations jdbcOperations;
-    protected final DialectType dialectType;
+    private final Long maxSqlAffectedRows;
+    private final JdbcOperations jdbcOperations;
+    private final DialectType dialectType;
 
     public MySQLAffectedRowsExceedLimit(@NonNull Long maxSqlAffectedRows, DialectType dialectType,
             JdbcOperations jdbcOperations) {

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/sqlcheck/rule/MySQLAffectedRowsExceedLimit.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/sqlcheck/rule/MySQLAffectedRowsExceedLimit.java
@@ -41,6 +41,7 @@ import com.oceanbase.tools.sqlparser.statement.select.Select;
 import com.oceanbase.tools.sqlparser.statement.select.SelectBody;
 import com.oceanbase.tools.sqlparser.statement.update.Update;
 
+import lombok.Getter;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 
@@ -53,11 +54,9 @@ import lombok.extern.slf4j.Slf4j;
  */
 @Slf4j
 public class MySQLAffectedRowsExceedLimit implements SqlCheckRule {
-
+    @Getter
     protected final Long maxSqlAffectedRows;
-
     protected final JdbcOperations jdbcOperations;
-
     protected final DialectType dialectType;
 
     public MySQLAffectedRowsExceedLimit(@NonNull Long maxSqlAffectedRows, DialectType dialectType,
@@ -80,7 +79,6 @@ public class MySQLAffectedRowsExceedLimit implements SqlCheckRule {
      */
     @Override
     public List<CheckViolation> check(@NonNull Statement statement, @NonNull SqlCheckContext context) {
-
         long affectedRows = getAffectedRows(statement);
         if (affectedRows >= 0) {
             if (affectedRows > maxSqlAffectedRows) {
@@ -103,7 +101,6 @@ public class MySQLAffectedRowsExceedLimit implements SqlCheckRule {
     }
 
     protected long getAffectedRows(@NonNull Statement statement) {
-
         long affectedRows = 0;
         if (statement instanceof Update || statement instanceof Delete || statement instanceof Insert) {
             String explainSql = "EXPLAIN " + statement.getText();
@@ -142,8 +139,7 @@ public class MySQLAffectedRowsExceedLimit implements SqlCheckRule {
      * @param insertStatement target sql
      * @return affected rows
      */
-    protected long getMySqlAffectedRowsByCount(Insert insertStatement) {
-
+    private long getMySqlAffectedRowsByCount(Insert insertStatement) {
         List<InsertTable> insertTableList = insertStatement.getTableInsert();
         if (insertTableList.isEmpty()) {
             log.warn("InsertTableList is empty, please check your sql");
@@ -179,8 +175,7 @@ public class MySQLAffectedRowsExceedLimit implements SqlCheckRule {
      * @param jdbc jdbc Object
      * @return affected rows
      */
-    protected long getMySqlAffectedRowsByExplain(String explainSql, JdbcOperations jdbc) {
-
+    private long getMySqlAffectedRowsByExplain(String explainSql, JdbcOperations jdbc) {
         try {
             List<Long> resultSet = jdbc.query(explainSql,
                     (rs, rowNum) -> rs.getLong("rows"));
@@ -205,8 +200,7 @@ public class MySQLAffectedRowsExceedLimit implements SqlCheckRule {
      * @param jdbc jdbc Object
      * @return affected rows
      */
-    protected long getOBMySqlAffectedRows(String explainSql, JdbcOperations jdbc) {
-
+    private long getOBMySqlAffectedRows(String explainSql, JdbcOperations jdbc) {
         /**
          * <pre>
          *
@@ -257,7 +251,7 @@ public class MySQLAffectedRowsExceedLimit implements SqlCheckRule {
      * @param singleRow row
      * @return affected rows
      */
-    protected long getEstRowsValue(String singleRow) {
+    private long getEstRowsValue(String singleRow) {
         String[] parts = singleRow.split("\\|");
         if (parts.length > 4) {
             String value = parts[4].trim();

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/sqlcheck/rule/MySQLAffectedRowsExceedLimit.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/sqlcheck/rule/MySQLAffectedRowsExceedLimit.java
@@ -86,7 +86,9 @@ public class MySQLAffectedRowsExceedLimit implements SqlCheckRule {
                 } else {
                     switch (dialectType) {
                         case MYSQL:
-                            affectedRows = getMySqlAffectedRows(explainSql, jdbcOperations);
+                            affectedRows = (statement instanceof Insert)
+                                    ? getMySqlAffectedRowsByCount(explainSql, jdbcOperations)
+                                    : getMySqlAffectedRowsByExplain(explainSql, jdbcOperations);
                             break;
                         case OB_MYSQL:
                             affectedRows = getOBMySqlAffectedRows(explainSql, jdbcOperations);
@@ -121,13 +123,37 @@ public class MySQLAffectedRowsExceedLimit implements SqlCheckRule {
     }
 
     /**
+     * MySQL checks the count of value list. Process mode: case1: For INSERT INTO ... VALUES(...)
+     * statements, ODC checks the count of value list. case2: For INSERT INTO ... SELECT ... statements,
+     * ODC runs EXPLAIN statements to get affected rows.
+     *
+     * @param explainSql target sql
+     * @return affected rows
+     */
+    private long getMySqlAffectedRowsByCount(String explainSql, JdbcOperations jdbc) {
+
+        explainSql = explainSql.toLowerCase();
+
+        if (explainSql.contains("value")) {
+            String valueList = extractValueList(explainSql);
+            return valueList.isEmpty() ? 0 : Arrays.stream(valueList.split("\\),")).count();
+        }
+
+        if (explainSql.contains("select")) {
+            return getMySqlAffectedRowsByExplain(explainSql, jdbc);
+        }
+
+        return 0;
+    }
+
+    /**
      * MySQL execute 'explain' statement
      *
      * @param explainSql target sql
      * @param jdbc jdbc Object
      * @return affected rows
      */
-    private long getMySqlAffectedRows(String explainSql, JdbcOperations jdbc) {
+    private long getMySqlAffectedRowsByExplain(String explainSql, JdbcOperations jdbc) {
 
         try {
             List<Long> resultSet = jdbc.query(explainSql,
@@ -210,5 +236,21 @@ public class MySQLAffectedRowsExceedLimit implements SqlCheckRule {
             return Long.parseLong(value);
         }
         return 0;
+    }
+
+    /**
+     * parse explain result set
+     *
+     * @param explainSql row
+     * @return value list
+     */
+    private String extractValueList(String explainSql) {
+        // Match "value" or "values"
+        String[] list = explainSql.split("value(s)?");
+        if (list.length > 1) {
+            String valuesPart = list[1].split(";")[0];
+            return valuesPart.trim();
+        }
+        return "";
     }
 }

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/sqlcheck/rule/MySQLUnable2JudgeAffectedRows.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/sqlcheck/rule/MySQLUnable2JudgeAffectedRows.java
@@ -30,11 +30,11 @@ import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
-public class Unable2JudgeAffectedRows implements SqlCheckRule {
+public class MySQLUnable2JudgeAffectedRows implements SqlCheckRule {
 
     private final MySQLAffectedRowsExceedLimit targetRule;
 
-    public Unable2JudgeAffectedRows(@NonNull MySQLAffectedRowsExceedLimit targetRule) {
+    public MySQLUnable2JudgeAffectedRows(@NonNull MySQLAffectedRowsExceedLimit targetRule) {
         this.targetRule = targetRule;
     }
 

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/sqlcheck/rule/SqlCheckRules.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/sqlcheck/rule/SqlCheckRules.java
@@ -85,6 +85,7 @@ import com.oceanbase.odc.service.sqlcheck.factory.TooManyInExpressionFactory;
 import com.oceanbase.odc.service.sqlcheck.factory.TooManyOutOfLineIndexFactory;
 import com.oceanbase.odc.service.sqlcheck.factory.TooManyTableJoinFactory;
 import com.oceanbase.odc.service.sqlcheck.factory.TruncateTableExistsFactory;
+import com.oceanbase.odc.service.sqlcheck.factory.Unable2JudgeAffectedRowsFactory;
 import com.oceanbase.odc.service.sqlcheck.factory.ZeroFillExistsFactory;
 import com.oceanbase.odc.service.sqlcheck.model.SqlCheckRuleType;
 
@@ -153,6 +154,7 @@ public class SqlCheckRules {
         rules.add(new OfflineDdlExistsFactory(jdbc));
         rules.add(new TruncateTableExistsFactory());
         rules.add(new SqlAffectedRowsFactory(jdbc));
+        rules.add(new Unable2JudgeAffectedRowsFactory(jdbc));
         return rules;
     }
 

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/sqlcheck/rule/Unable2JudgeAffectedRows.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/sqlcheck/rule/Unable2JudgeAffectedRows.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2023 OceanBase.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.oceanbase.odc.service.sqlcheck.rule;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.springframework.jdbc.core.JdbcOperations;
+
+import com.oceanbase.odc.core.shared.constant.DialectType;
+import com.oceanbase.odc.service.sqlcheck.SqlCheckContext;
+import com.oceanbase.odc.service.sqlcheck.SqlCheckUtil;
+import com.oceanbase.odc.service.sqlcheck.model.CheckViolation;
+import com.oceanbase.odc.service.sqlcheck.model.SqlCheckRuleType;
+import com.oceanbase.tools.sqlparser.statement.Statement;
+
+import lombok.NonNull;
+
+public class Unable2JudgeAffectedRows extends MySQLAffectedRowsExceedLimit {
+
+    public Unable2JudgeAffectedRows(@NonNull Long maxSqlAffectedRows,
+            DialectType dialectType,
+            JdbcOperations jdbcOperations) {
+        super(maxSqlAffectedRows, dialectType, jdbcOperations);
+    }
+
+    /**
+     * Get the rule type
+     */
+    @Override
+    public SqlCheckRuleType getType() {
+        return SqlCheckRuleType.ESTIMATE_SQL_AFFECTED_ROWS;
+    }
+
+    /**
+     * Execution rule check
+     */
+    @Override
+    public List<CheckViolation> check(@NonNull Statement statement, @NonNull SqlCheckContext context) {
+        long affectedRows = super.getAffectedRows(statement);
+        if (affectedRows < 0) {
+            return Collections.singletonList(SqlCheckUtil
+                    .buildViolation(statement.getText(), statement, getType(),
+                            new Object[] {maxSqlAffectedRows, affectedRows}));
+        }
+        return Collections.emptyList();
+    }
+}

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/sqlcheck/rule/Unable2JudgeAffectedRows.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/sqlcheck/rule/Unable2JudgeAffectedRows.java
@@ -18,8 +18,6 @@ package com.oceanbase.odc.service.sqlcheck.rule;
 import java.util.Collections;
 import java.util.List;
 
-import org.springframework.jdbc.core.JdbcOperations;
-
 import com.oceanbase.odc.core.shared.constant.DialectType;
 import com.oceanbase.odc.service.sqlcheck.SqlCheckContext;
 import com.oceanbase.odc.service.sqlcheck.SqlCheckRule;
@@ -35,12 +33,8 @@ import lombok.extern.slf4j.Slf4j;
 public class Unable2JudgeAffectedRows implements SqlCheckRule {
 
     private final BaseAffectedRowsExceedLimit targetRule;
-    private final JdbcOperations jdbcOperations;
-    private final Long maxSqlAffectedRows;
 
     public Unable2JudgeAffectedRows(@NonNull BaseAffectedRowsExceedLimit targetRule) {
-        this.jdbcOperations = targetRule.getJdbcOperations();
-        this.maxSqlAffectedRows = targetRule.getMaxSqlAffectedRows();
         this.targetRule = targetRule;
     }
 
@@ -63,7 +57,7 @@ public class Unable2JudgeAffectedRows implements SqlCheckRule {
     @Override
     public List<CheckViolation> check(@NonNull Statement statement, @NonNull SqlCheckContext context) {
         try {
-            long affectedRows = this.targetRule.getStatementAffectedRows(statement, jdbcOperations, maxSqlAffectedRows);
+            long affectedRows = this.targetRule.getStatementAffectedRows(statement);
             if (affectedRows < 0) {
                 return Collections.singletonList(SqlCheckUtil
                         .buildViolation(statement.getText(), statement, getType(), new Object[] {}));

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/sqlcheck/rule/Unable2JudgeAffectedRows.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/sqlcheck/rule/Unable2JudgeAffectedRows.java
@@ -30,11 +30,11 @@ import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
-public class MySQLUnable2JudgeAffectedRows implements SqlCheckRule {
+public class Unable2JudgeAffectedRows implements SqlCheckRule {
 
     private final MySQLAffectedRowsExceedLimit targetRule;
 
-    public MySQLUnable2JudgeAffectedRows(@NonNull MySQLAffectedRowsExceedLimit targetRule) {
+    public Unable2JudgeAffectedRows(@NonNull MySQLAffectedRowsExceedLimit targetRule) {
         this.targetRule = targetRule;
     }
 

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/sqlcheck/rule/Unable2JudgeAffectedRows.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/sqlcheck/rule/Unable2JudgeAffectedRows.java
@@ -56,14 +56,15 @@ public class Unable2JudgeAffectedRows extends MySQLAffectedRowsExceedLimit {
             long affectedRows = super.getAffectedRows(statement);
             if (affectedRows < 0) {
                 return Collections.singletonList(SqlCheckUtil
-                    .buildViolation(statement.getText(), statement, getType(),
-                        new Object[] {maxSqlAffectedRows, affectedRows}));
+                        .buildViolation(statement.getText(), statement, getType(),
+                                new Object[] {maxSqlAffectedRows, affectedRows}));
             }
         } catch (Exception e) {
             log.warn("Unable to get affected rows, sql={}", statement.getText(), e);
             return Collections.singletonList(SqlCheckUtil
-                .buildViolation(statement.getText(), statement, getType(),
-                    new Object[] {maxSqlAffectedRows, "Unable to get affected rows caused by: " + e.getMessage()}));
+                    .buildViolation(statement.getText(), statement, getType(),
+                            new Object[] {maxSqlAffectedRows,
+                                    "Unable to get affected rows caused by: " + e.getMessage()}));
         }
 
         return Collections.emptyList();

--- a/server/odc-service/src/test/java/com/oceanbase/odc/service/sqlcheck/MySQLCheckerTest.java
+++ b/server/odc-service/src/test/java/com/oceanbase/odc/service/sqlcheck/MySQLCheckerTest.java
@@ -1689,7 +1689,7 @@ public class MySQLCheckerTest {
                 Collections.singletonList(
                         new Unable2JudgeAffectedRows(2L, DialectType.MYSQL, jdbcTemplate)));
         List<CheckViolation> actualInsert = insertChecker.check(insert);
-        Assert.assertEquals(1, actualInsert.size());
+        Assert.assertEquals(0, actualInsert.size());
     }
 
     @Test
@@ -1707,7 +1707,7 @@ public class MySQLCheckerTest {
                 Collections.singletonList(
                         new Unable2JudgeAffectedRows(3L, DialectType.MYSQL, jdbcTemplate)));
         List<CheckViolation> actualInsert = insertChecker.check(insert);
-        Assert.assertEquals(1, actualInsert.size());
+        Assert.assertEquals(0, actualInsert.size());
     }
 
     @Test

--- a/server/odc-service/src/test/java/com/oceanbase/odc/service/sqlcheck/MySQLCheckerTest.java
+++ b/server/odc-service/src/test/java/com/oceanbase/odc/service/sqlcheck/MySQLCheckerTest.java
@@ -1543,16 +1543,16 @@ public class MySQLCheckerTest {
     @Test
     public void check_restrictSqlAffectedRows4Insert_unsupported() {
         String insert =
-            "insert into users (id, name, age, email) \n"
-            + "set \n"
-            + "column1 = 'value1' \n"
-            + "column2 = 'value2'";
+                "insert into users (id, name, age, email) \n"
+                        + "set \n"
+                        + "column1 = 'value1' \n"
+                        + "column2 = 'value2'";
 
         JdbcTemplate jdbcTemplate = Mockito.mock(JdbcTemplate.class);
 
         DefaultSqlChecker insertChecker = new DefaultSqlChecker(DialectType.MYSQL, "$$",
-            Collections.singletonList(
-                new MySQLAffectedRowsExceedLimit(0L, DialectType.MYSQL, jdbcTemplate)));
+                Collections.singletonList(
+                        new MySQLAffectedRowsExceedLimit(0L, DialectType.MYSQL, jdbcTemplate)));
         List<CheckViolation> actualInsert = insertChecker.check(insert);
         Assert.assertEquals(0, actualInsert.size());
     }
@@ -1561,9 +1561,9 @@ public class MySQLCheckerTest {
     public void check_restrictSqlAffectedRows4Insert_setValue() {
         String insert =
                 "insert into users \n"
-                + "set \n"
-                + "column1 = 'value1', \n"
-                + "column2 = 'value2'";
+                        + "set \n"
+                        + "column1 = 'value1', \n"
+                        + "column2 = 'value2'";
 
         JdbcTemplate jdbcTemplate = Mockito.mock(JdbcTemplate.class);
 
@@ -1643,17 +1643,17 @@ public class MySQLCheckerTest {
     @Test
     public void check_unable2JudgeAffectedRows_values() {
         String insert =
-            "insert into users (id, name, age, email) \n"
-            + "values \n"
-            + "('2', 'b-bot', 3, 'o'), \n"
-            + "('3', 'c-bot', 3, 'o'), \n"
-            + "('4', 'd-bot', 3, '(o)')";
+                "insert into users (id, name, age, email) \n"
+                        + "values \n"
+                        + "('2', 'b-bot', 3, 'o'), \n"
+                        + "('3', 'c-bot', 3, 'o'), \n"
+                        + "('4', 'd-bot', 3, '(o)')";
 
         JdbcTemplate jdbcTemplate = Mockito.mock(JdbcTemplate.class);
 
         DefaultSqlChecker insertChecker = new DefaultSqlChecker(DialectType.MYSQL, "$$",
-            Collections.singletonList(
-                new Unable2JudgeAffectedRows(3L, DialectType.MYSQL, jdbcTemplate)));
+                Collections.singletonList(
+                        new Unable2JudgeAffectedRows(3L, DialectType.MYSQL, jdbcTemplate)));
         List<CheckViolation> actualInsert = insertChecker.check(insert);
         Assert.assertEquals(0, actualInsert.size());
     }
@@ -1661,18 +1661,18 @@ public class MySQLCheckerTest {
     @Test
     public void check_unable2JudgeAffectedRows_valuesExceed() {
         String insert =
-            "insert into users (id, name, age, email) \n"
-            + "values \n"
-            + "('2', 'b-bot', 3, 'o'), \n"
-            + "('3', 'c-bot', 3, 'o'), \n"
-            + "('4', 'd-bot', 3, '(o)'), \n"
-            + "('5', 'e-bot', 3, 'o')";
+                "insert into users (id, name, age, email) \n"
+                        + "values \n"
+                        + "('2', 'b-bot', 3, 'o'), \n"
+                        + "('3', 'c-bot', 3, 'o'), \n"
+                        + "('4', 'd-bot', 3, '(o)'), \n"
+                        + "('5', 'e-bot', 3, 'o')";
 
         JdbcTemplate jdbcTemplate = Mockito.mock(JdbcTemplate.class);
 
         DefaultSqlChecker insertChecker = new DefaultSqlChecker(DialectType.MYSQL, "$$",
-            Collections.singletonList(
-                new Unable2JudgeAffectedRows(3L, DialectType.MYSQL, jdbcTemplate)));
+                Collections.singletonList(
+                        new Unable2JudgeAffectedRows(3L, DialectType.MYSQL, jdbcTemplate)));
         List<CheckViolation> actualInsert = insertChecker.check(insert);
         Assert.assertEquals(0, actualInsert.size());
     }
@@ -1680,14 +1680,14 @@ public class MySQLCheckerTest {
     @Test
     public void check_unable2JudgeAffectedRows_valueIsNull() {
         String insert =
-            "insert into users (id, name, age, email) \n"
-            + "value ()";
+                "insert into users (id, name, age, email) \n"
+                        + "value ()";
 
         JdbcTemplate jdbcTemplate = Mockito.mock(JdbcTemplate.class);
 
         DefaultSqlChecker insertChecker = new DefaultSqlChecker(DialectType.MYSQL, "$$",
-            Collections.singletonList(
-                new Unable2JudgeAffectedRows(2L, DialectType.MYSQL, jdbcTemplate)));
+                Collections.singletonList(
+                        new Unable2JudgeAffectedRows(2L, DialectType.MYSQL, jdbcTemplate)));
         List<CheckViolation> actualInsert = insertChecker.check(insert);
         Assert.assertEquals(1, actualInsert.size());
     }
@@ -1695,17 +1695,17 @@ public class MySQLCheckerTest {
     @Test
     public void check_unable2JudgeAffectedRows_valuesIsNull() {
         String insert =
-            "insert into users (id, name, age, email) \n"
-            + "values \n"
-            + "('2', 'b-bot', 3, 'o'), \n"
-            + "('3', 'c-bot', 3, 'o'), \n"
-            + "()";
+                "insert into users (id, name, age, email) \n"
+                        + "values \n"
+                        + "('2', 'b-bot', 3, 'o'), \n"
+                        + "('3', 'c-bot', 3, 'o'), \n"
+                        + "()";
 
         JdbcTemplate jdbcTemplate = Mockito.mock(JdbcTemplate.class);
 
         DefaultSqlChecker insertChecker = new DefaultSqlChecker(DialectType.MYSQL, "$$",
-            Collections.singletonList(
-                new Unable2JudgeAffectedRows(3L, DialectType.MYSQL, jdbcTemplate)));
+                Collections.singletonList(
+                        new Unable2JudgeAffectedRows(3L, DialectType.MYSQL, jdbcTemplate)));
         List<CheckViolation> actualInsert = insertChecker.check(insert);
         Assert.assertEquals(1, actualInsert.size());
     }
@@ -1713,16 +1713,16 @@ public class MySQLCheckerTest {
     @Test
     public void check_unable2JudgeAffectedRows_setValue() {
         String insert =
-            "insert into users (id, name, age, email) \n"
-            + "set \n"
-            + "column1 = 'value1' \n"
-            + "column2 = 'value2'";
+                "insert into users (id, name, age, email) \n"
+                        + "set \n"
+                        + "column1 = 'value1' \n"
+                        + "column2 = 'value2'";
 
         JdbcTemplate jdbcTemplate = Mockito.mock(JdbcTemplate.class);
 
         DefaultSqlChecker insertChecker = new DefaultSqlChecker(DialectType.MYSQL, "$$",
-            Collections.singletonList(
-                new Unable2JudgeAffectedRows(2L, DialectType.MYSQL, jdbcTemplate)));
+                Collections.singletonList(
+                        new Unable2JudgeAffectedRows(2L, DialectType.MYSQL, jdbcTemplate)));
         List<CheckViolation> actualInsert = insertChecker.check(insert);
         Assert.assertEquals(0, actualInsert.size());
     }
@@ -1730,16 +1730,16 @@ public class MySQLCheckerTest {
     @Test
     public void check_unable2JudgeAffectedRows_setValueFailed() {
         String insert =
-            "insert into users \n"
-            + "set \n"
-            + "column1 = 'value1', \n"
-            + "column2 = 'value2'";
+                "insert into users \n"
+                        + "set \n"
+                        + "column1 = 'value1', \n"
+                        + "column2 = 'value2'";
 
         JdbcTemplate jdbcTemplate = Mockito.mock(JdbcTemplate.class);
 
         DefaultSqlChecker insertChecker = new DefaultSqlChecker(DialectType.MYSQL, "$$",
-            Collections.singletonList(
-                new Unable2JudgeAffectedRows(0L, DialectType.MYSQL, jdbcTemplate)));
+                Collections.singletonList(
+                        new Unable2JudgeAffectedRows(0L, DialectType.MYSQL, jdbcTemplate)));
         List<CheckViolation> actualInsert = insertChecker.check(insert);
         Assert.assertEquals(0, actualInsert.size());
     }

--- a/server/odc-service/src/test/java/com/oceanbase/odc/service/sqlcheck/MySQLCheckerTest.java
+++ b/server/odc-service/src/test/java/com/oceanbase/odc/service/sqlcheck/MySQLCheckerTest.java
@@ -1505,18 +1505,18 @@ public class MySQLCheckerTest {
     @Test
     public void check_restrictSqlAffectedRows4Insert_values() {
         String insert =
-            "insert into users (id, name, age, email) \n"
-            + "values \n"
-            + "('2', 'b-bot', 3, 'o'), \n"
-            + "('3', 'c-bot', 3, 'o'), \n"
-            + "('4', 'd-bot', 3, '(o)'), \n"
-            + "('5', 'e-bot', 3, 'o')";
+                "insert into users (id, name, age, email) \n"
+                        + "values \n"
+                        + "('2', 'b-bot', 3, 'o'), \n"
+                        + "('3', 'c-bot', 3, 'o'), \n"
+                        + "('4', 'd-bot', 3, '(o)'), \n"
+                        + "('5', 'e-bot', 3, 'o')";
 
         JdbcTemplate jdbcTemplate = Mockito.mock(JdbcTemplate.class);
 
         DefaultSqlChecker insertChecker = new DefaultSqlChecker(DialectType.MYSQL, "$$",
-            Collections.singletonList(
-                new MySQLAffectedRowsExceedLimit(3L, DialectType.MYSQL, jdbcTemplate)));
+                Collections.singletonList(
+                        new MySQLAffectedRowsExceedLimit(3L, DialectType.MYSQL, jdbcTemplate)));
         List<CheckViolation> actualInsert = insertChecker.check(insert);
 
         Assert.assertEquals(1, actualInsert.size());
@@ -1525,18 +1525,18 @@ public class MySQLCheckerTest {
     @Test
     public void check_restrictSqlAffectedRows4Insert_select() {
         String insert =
-            "insert into users (id, name, age, email) \n"
-            + "select id, name, age, email \n"
-            + "from out_users where \n"
-            + "id in ('1', '2', '3')";
+                "insert into users (id, name, age, email) \n"
+                        + "select id, name, age, email \n"
+                        + "from out_users where \n"
+                        + "id in ('1', '2', '3')";
 
         JdbcTemplate jdbcTemplate = Mockito.mock(JdbcTemplate.class);
 
         Mockito.when(jdbcTemplate.query(Mockito.anyString(), Mockito.any(RowMapper.class)))
-            .thenReturn(Collections.singletonList(3L));
+                .thenReturn(Collections.singletonList(3L));
         DefaultSqlChecker insertChecker = new DefaultSqlChecker(DialectType.MYSQL, "$$",
-            Collections.singletonList(
-                new MySQLAffectedRowsExceedLimit(2L, DialectType.MYSQL, jdbcTemplate)));
+                Collections.singletonList(
+                        new MySQLAffectedRowsExceedLimit(2L, DialectType.MYSQL, jdbcTemplate)));
         List<CheckViolation> actualInsert = insertChecker.check(insert);
         System.out.println(actualInsert);
         Assert.assertEquals(1, actualInsert.size());
@@ -1545,16 +1545,16 @@ public class MySQLCheckerTest {
     @Test
     public void check_restrictSqlAffectedRows4Insert_unsupported() {
         String insert =
-            "insert into users (id, name, age, email) \n"
-            + "set \n"
-            + "column1 = 'value1' \n"
-            + "column2 = 'value2'";
+                "insert into users (id, name, age, email) \n"
+                        + "set \n"
+                        + "column1 = 'value1' \n"
+                        + "column2 = 'value2'";
 
         JdbcTemplate jdbcTemplate = Mockito.mock(JdbcTemplate.class);
 
         DefaultSqlChecker insertChecker = new DefaultSqlChecker(DialectType.MYSQL, "$$",
-            Collections.singletonList(
-                new MySQLAffectedRowsExceedLimit(2L, DialectType.MYSQL, jdbcTemplate)));
+                Collections.singletonList(
+                        new MySQLAffectedRowsExceedLimit(2L, DialectType.MYSQL, jdbcTemplate)));
         List<CheckViolation> actualInsert = insertChecker.check(insert);
         System.out.println(actualInsert);
         Assert.assertEquals(0, actualInsert.size());

--- a/server/odc-service/src/test/java/com/oceanbase/odc/service/sqlcheck/MySQLCheckerTest.java
+++ b/server/odc-service/src/test/java/com/oceanbase/odc/service/sqlcheck/MySQLCheckerTest.java
@@ -81,7 +81,7 @@ import com.oceanbase.odc.service.sqlcheck.rule.TooManyColumnRefInPrimaryKey;
 import com.oceanbase.odc.service.sqlcheck.rule.TooManyInExpression;
 import com.oceanbase.odc.service.sqlcheck.rule.TooManyOutOfLineIndex;
 import com.oceanbase.odc.service.sqlcheck.rule.TooManyTableJoin;
-import com.oceanbase.odc.service.sqlcheck.rule.Unable2JudgeAffectedRows;
+import com.oceanbase.odc.service.sqlcheck.rule.MySQLUnable2JudgeAffectedRows;
 
 /**
  * {@link MySQLCheckerTest}
@@ -1653,7 +1653,7 @@ public class MySQLCheckerTest {
 
         DefaultSqlChecker insertChecker = new DefaultSqlChecker(DialectType.MYSQL, "$$",
                 Collections.singletonList(
-                        new Unable2JudgeAffectedRows(
+                        new MySQLUnable2JudgeAffectedRows(
                                 new MySQLAffectedRowsExceedLimit(3L, DialectType.MYSQL, jdbcTemplate))));
         List<CheckViolation> actualInsert = insertChecker.check(insert);
         Assert.assertEquals(0, actualInsert.size());
@@ -1673,7 +1673,7 @@ public class MySQLCheckerTest {
 
         DefaultSqlChecker insertChecker = new DefaultSqlChecker(DialectType.MYSQL, "$$",
                 Collections.singletonList(
-                        new Unable2JudgeAffectedRows(
+                        new MySQLUnable2JudgeAffectedRows(
                                 new MySQLAffectedRowsExceedLimit(3L, DialectType.MYSQL, jdbcTemplate))));
         List<CheckViolation> actualInsert = insertChecker.check(insert);
         Assert.assertEquals(0, actualInsert.size());
@@ -1689,7 +1689,7 @@ public class MySQLCheckerTest {
 
         DefaultSqlChecker insertChecker = new DefaultSqlChecker(DialectType.MYSQL, "$$",
                 Collections.singletonList(
-                        new Unable2JudgeAffectedRows(
+                        new MySQLUnable2JudgeAffectedRows(
                                 new MySQLAffectedRowsExceedLimit(2L, DialectType.MYSQL, jdbcTemplate))));
         List<CheckViolation> actualInsert = insertChecker.check(insert);
         Assert.assertEquals(0, actualInsert.size());
@@ -1708,7 +1708,7 @@ public class MySQLCheckerTest {
 
         DefaultSqlChecker insertChecker = new DefaultSqlChecker(DialectType.MYSQL, "$$",
                 Collections.singletonList(
-                        new Unable2JudgeAffectedRows(
+                        new MySQLUnable2JudgeAffectedRows(
                                 new MySQLAffectedRowsExceedLimit(3L, DialectType.MYSQL, jdbcTemplate))));
         List<CheckViolation> actualInsert = insertChecker.check(insert);
         Assert.assertEquals(0, actualInsert.size());
@@ -1726,7 +1726,7 @@ public class MySQLCheckerTest {
 
         DefaultSqlChecker insertChecker = new DefaultSqlChecker(DialectType.MYSQL, "$$",
                 Collections.singletonList(
-                        new Unable2JudgeAffectedRows(
+                        new MySQLUnable2JudgeAffectedRows(
                                 new MySQLAffectedRowsExceedLimit(2L, DialectType.MYSQL, jdbcTemplate))));
         List<CheckViolation> actualInsert = insertChecker.check(insert);
         Assert.assertEquals(0, actualInsert.size());
@@ -1744,7 +1744,7 @@ public class MySQLCheckerTest {
 
         DefaultSqlChecker insertChecker = new DefaultSqlChecker(DialectType.MYSQL, "$$",
                 Collections.singletonList(
-                        new Unable2JudgeAffectedRows(
+                        new MySQLUnable2JudgeAffectedRows(
                                 new MySQLAffectedRowsExceedLimit(0L, DialectType.MYSQL, jdbcTemplate))));
         List<CheckViolation> actualInsert = insertChecker.check(insert);
         Assert.assertEquals(0, actualInsert.size());

--- a/server/odc-service/src/test/java/com/oceanbase/odc/service/sqlcheck/MySQLCheckerTest.java
+++ b/server/odc-service/src/test/java/com/oceanbase/odc/service/sqlcheck/MySQLCheckerTest.java
@@ -1498,7 +1498,6 @@ public class MySQLCheckerTest {
                 Collections.singletonList(
                         new MySQLAffectedRowsExceedLimit(2L, DialectType.MYSQL, jdbcTemplate)));
         List<CheckViolation> actualInsert = insertChecker.check(insert);
-
         Assert.assertEquals(0, actualInsert.size());
     }
 
@@ -1518,7 +1517,6 @@ public class MySQLCheckerTest {
                 Collections.singletonList(
                         new MySQLAffectedRowsExceedLimit(3L, DialectType.MYSQL, jdbcTemplate)));
         List<CheckViolation> actualInsert = insertChecker.check(insert);
-
         Assert.assertEquals(1, actualInsert.size());
     }
 
@@ -1538,7 +1536,6 @@ public class MySQLCheckerTest {
                 Collections.singletonList(
                         new MySQLAffectedRowsExceedLimit(2L, DialectType.MYSQL, jdbcTemplate)));
         List<CheckViolation> actualInsert = insertChecker.check(insert);
-        System.out.println(actualInsert);
         Assert.assertEquals(1, actualInsert.size());
     }
 
@@ -1556,7 +1553,6 @@ public class MySQLCheckerTest {
                 Collections.singletonList(
                         new MySQLAffectedRowsExceedLimit(2L, DialectType.MYSQL, jdbcTemplate)));
         List<CheckViolation> actualInsert = insertChecker.check(insert);
-        System.out.println(actualInsert);
         Assert.assertEquals(0, actualInsert.size());
     }
 

--- a/server/odc-service/src/test/java/com/oceanbase/odc/service/sqlcheck/MySQLCheckerTest.java
+++ b/server/odc-service/src/test/java/com/oceanbase/odc/service/sqlcheck/MySQLCheckerTest.java
@@ -1653,7 +1653,8 @@ public class MySQLCheckerTest {
 
         DefaultSqlChecker insertChecker = new DefaultSqlChecker(DialectType.MYSQL, "$$",
                 Collections.singletonList(
-                        new Unable2JudgeAffectedRows(3L, DialectType.MYSQL, jdbcTemplate)));
+                        new Unable2JudgeAffectedRows(
+                                new MySQLAffectedRowsExceedLimit(3L, DialectType.MYSQL, jdbcTemplate))));
         List<CheckViolation> actualInsert = insertChecker.check(insert);
         Assert.assertEquals(0, actualInsert.size());
     }
@@ -1672,7 +1673,8 @@ public class MySQLCheckerTest {
 
         DefaultSqlChecker insertChecker = new DefaultSqlChecker(DialectType.MYSQL, "$$",
                 Collections.singletonList(
-                        new Unable2JudgeAffectedRows(3L, DialectType.MYSQL, jdbcTemplate)));
+                        new Unable2JudgeAffectedRows(
+                                new MySQLAffectedRowsExceedLimit(3L, DialectType.MYSQL, jdbcTemplate))));
         List<CheckViolation> actualInsert = insertChecker.check(insert);
         Assert.assertEquals(0, actualInsert.size());
     }
@@ -1687,7 +1689,8 @@ public class MySQLCheckerTest {
 
         DefaultSqlChecker insertChecker = new DefaultSqlChecker(DialectType.MYSQL, "$$",
                 Collections.singletonList(
-                        new Unable2JudgeAffectedRows(2L, DialectType.MYSQL, jdbcTemplate)));
+                        new Unable2JudgeAffectedRows(
+                                new MySQLAffectedRowsExceedLimit(2L, DialectType.MYSQL, jdbcTemplate))));
         List<CheckViolation> actualInsert = insertChecker.check(insert);
         Assert.assertEquals(0, actualInsert.size());
     }
@@ -1705,7 +1708,8 @@ public class MySQLCheckerTest {
 
         DefaultSqlChecker insertChecker = new DefaultSqlChecker(DialectType.MYSQL, "$$",
                 Collections.singletonList(
-                        new Unable2JudgeAffectedRows(3L, DialectType.MYSQL, jdbcTemplate)));
+                        new Unable2JudgeAffectedRows(
+                                new MySQLAffectedRowsExceedLimit(3L, DialectType.MYSQL, jdbcTemplate))));
         List<CheckViolation> actualInsert = insertChecker.check(insert);
         Assert.assertEquals(0, actualInsert.size());
     }
@@ -1722,7 +1726,8 @@ public class MySQLCheckerTest {
 
         DefaultSqlChecker insertChecker = new DefaultSqlChecker(DialectType.MYSQL, "$$",
                 Collections.singletonList(
-                        new Unable2JudgeAffectedRows(2L, DialectType.MYSQL, jdbcTemplate)));
+                        new Unable2JudgeAffectedRows(
+                                new MySQLAffectedRowsExceedLimit(2L, DialectType.MYSQL, jdbcTemplate))));
         List<CheckViolation> actualInsert = insertChecker.check(insert);
         Assert.assertEquals(0, actualInsert.size());
     }
@@ -1739,7 +1744,8 @@ public class MySQLCheckerTest {
 
         DefaultSqlChecker insertChecker = new DefaultSqlChecker(DialectType.MYSQL, "$$",
                 Collections.singletonList(
-                        new Unable2JudgeAffectedRows(0L, DialectType.MYSQL, jdbcTemplate)));
+                        new Unable2JudgeAffectedRows(
+                                new MySQLAffectedRowsExceedLimit(0L, DialectType.MYSQL, jdbcTemplate))));
         List<CheckViolation> actualInsert = insertChecker.check(insert);
         Assert.assertEquals(0, actualInsert.size());
     }

--- a/server/odc-service/src/test/java/com/oceanbase/odc/service/sqlcheck/MySQLCheckerTest.java
+++ b/server/odc-service/src/test/java/com/oceanbase/odc/service/sqlcheck/MySQLCheckerTest.java
@@ -81,7 +81,7 @@ import com.oceanbase.odc.service.sqlcheck.rule.TooManyColumnRefInPrimaryKey;
 import com.oceanbase.odc.service.sqlcheck.rule.TooManyInExpression;
 import com.oceanbase.odc.service.sqlcheck.rule.TooManyOutOfLineIndex;
 import com.oceanbase.odc.service.sqlcheck.rule.TooManyTableJoin;
-import com.oceanbase.odc.service.sqlcheck.rule.MySQLUnable2JudgeAffectedRows;
+import com.oceanbase.odc.service.sqlcheck.rule.Unable2JudgeAffectedRows;
 
 /**
  * {@link MySQLCheckerTest}
@@ -1653,7 +1653,7 @@ public class MySQLCheckerTest {
 
         DefaultSqlChecker insertChecker = new DefaultSqlChecker(DialectType.MYSQL, "$$",
                 Collections.singletonList(
-                        new MySQLUnable2JudgeAffectedRows(
+                        new Unable2JudgeAffectedRows(
                                 new MySQLAffectedRowsExceedLimit(3L, DialectType.MYSQL, jdbcTemplate))));
         List<CheckViolation> actualInsert = insertChecker.check(insert);
         Assert.assertEquals(0, actualInsert.size());
@@ -1673,7 +1673,7 @@ public class MySQLCheckerTest {
 
         DefaultSqlChecker insertChecker = new DefaultSqlChecker(DialectType.MYSQL, "$$",
                 Collections.singletonList(
-                        new MySQLUnable2JudgeAffectedRows(
+                        new Unable2JudgeAffectedRows(
                                 new MySQLAffectedRowsExceedLimit(3L, DialectType.MYSQL, jdbcTemplate))));
         List<CheckViolation> actualInsert = insertChecker.check(insert);
         Assert.assertEquals(0, actualInsert.size());
@@ -1689,7 +1689,7 @@ public class MySQLCheckerTest {
 
         DefaultSqlChecker insertChecker = new DefaultSqlChecker(DialectType.MYSQL, "$$",
                 Collections.singletonList(
-                        new MySQLUnable2JudgeAffectedRows(
+                        new Unable2JudgeAffectedRows(
                                 new MySQLAffectedRowsExceedLimit(2L, DialectType.MYSQL, jdbcTemplate))));
         List<CheckViolation> actualInsert = insertChecker.check(insert);
         Assert.assertEquals(0, actualInsert.size());
@@ -1708,7 +1708,7 @@ public class MySQLCheckerTest {
 
         DefaultSqlChecker insertChecker = new DefaultSqlChecker(DialectType.MYSQL, "$$",
                 Collections.singletonList(
-                        new MySQLUnable2JudgeAffectedRows(
+                        new Unable2JudgeAffectedRows(
                                 new MySQLAffectedRowsExceedLimit(3L, DialectType.MYSQL, jdbcTemplate))));
         List<CheckViolation> actualInsert = insertChecker.check(insert);
         Assert.assertEquals(0, actualInsert.size());
@@ -1726,7 +1726,7 @@ public class MySQLCheckerTest {
 
         DefaultSqlChecker insertChecker = new DefaultSqlChecker(DialectType.MYSQL, "$$",
                 Collections.singletonList(
-                        new MySQLUnable2JudgeAffectedRows(
+                        new Unable2JudgeAffectedRows(
                                 new MySQLAffectedRowsExceedLimit(2L, DialectType.MYSQL, jdbcTemplate))));
         List<CheckViolation> actualInsert = insertChecker.check(insert);
         Assert.assertEquals(0, actualInsert.size());
@@ -1744,7 +1744,7 @@ public class MySQLCheckerTest {
 
         DefaultSqlChecker insertChecker = new DefaultSqlChecker(DialectType.MYSQL, "$$",
                 Collections.singletonList(
-                        new MySQLUnable2JudgeAffectedRows(
+                        new Unable2JudgeAffectedRows(
                                 new MySQLAffectedRowsExceedLimit(0L, DialectType.MYSQL, jdbcTemplate))));
         List<CheckViolation> actualInsert = insertChecker.check(insert);
         Assert.assertEquals(0, actualInsert.size());


### PR DESCRIPTION
What type of PR is this?

bugfix

What this PR does / why we need it:

added a new rule to deal with the unable to judge the affected rows.

restrict affected rows can not work when use insert statement.
because native mysql explain the insert ... statement have difference process from update/delete.

Process mode:
* case1: For INSERT INTO ... VALUES(...) statements, ODC checks the count of value list.
* case2: For INSERT INTO ... SELECT ... statements, ODC runs EXPLAIN statements to get affected rows.

Which issue(s) this PR fixes:

Fixes #3316 

Special notes for your reviewer:
```docs

```