### PR TITLE
fix(logicaldatabase): unexpection exception throwed when there is no SQL needs to run in some physical database

### DIFF
--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/connection/logicaldatabase/core/executor/sql/SqlExecutionHandler.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/connection/logicaldatabase/core/executor/sql/SqlExecutionHandler.java
@@ -22,6 +22,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.springframework.jdbc.core.StatementCallback;
 
+import com.aliyuncs.utils.StringUtils;
 import com.oceanbase.odc.core.session.ConnectionSession;
 import com.oceanbase.odc.core.session.ConnectionSessionConstants;
 import com.oceanbase.odc.core.session.ConnectionSessionUtil;
@@ -74,6 +75,15 @@ public class SqlExecutionHandler implements ExecutionHandler<SqlExecuteReq, SqlE
     public ExecutionResult<SqlExecutionResultWrapper> execute(
             ExecutionGroupContext<SqlExecuteReq, SqlExecutionResultWrapper> context)
             throws SQLException {
+        if (StringUtils.isEmpty(req.getSql())) {
+            return new ExecutionResult<>(
+                    new SqlExecutionResultWrapper(req.getLogicalDatabaseId(), req.getPhysicalDatabaseId(),
+                            req.getScheduleTaskId(),
+                            SqlExecuteResult.emptyResult(SqlTuple.newTuple("-- No SQL needs to execute in this run"),
+                                    SqlExecuteStatus.SUCCESS)),
+                    ExecutionStatus.SUCCESS, req.getOrder());
+        }
+
         this.connectionSession = generateSession(req.getConnectionConfig());
         try {
             OdcStatementCallBack statementCallBack = new OdcStatementCallBack(

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/task/executor/task/LogicalDatabaseChangeTask.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/task/executor/task/LogicalDatabaseChangeTask.java
@@ -16,6 +16,7 @@
 package com.oceanbase.odc.service.task.executor.task;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
@@ -120,7 +121,8 @@ public class LogicalDatabaseChangeTask extends BaseTask<Map<String, ExecutionRes
                     Long databaseId = entry.getKey();
                     DataNode dataNode = entry.getValue();
                     String rewrittenSqls =
-                            databaseId2RewrittenSqls.get(databaseId).stream().collect(Collectors.joining(";"));
+                            databaseId2RewrittenSqls.getOrDefault(databaseId, Collections.emptyList()).stream()
+                                    .collect(Collectors.joining(taskParameters.getDelimiter()));
                     SqlExecuteReq req = new SqlExecuteReq();
                     req.setSql(rewrittenSqls);
                     req.setDialectType(dialectType);


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines.
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request.
3. Ensure you have added or ran the appropriate tests for your PR.
5. If the PR is unfinished, you may add or remove a WIP or [WIP] prefix to your pull request title.
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
type-bug
type-feature
type-docs
etc.

Optionally add one or more of the following kinds if applicable:
module-resultset
module-sql execution
etc.
-->
type-bug
#### What this PR does / why we need it:
Some unexpected errors happen if the physical database does not need to run SQL in this round. This PR set a default SQL '-- No SQL needs to execute in this run' to mock the running, and it will always succeed.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #3373 

#### Special notes for your reviewer:

<!--
This section is used to describe how this PR is implemented. 
If this is a PR that fixes a bug, this section describes how the bug was fixed.
If it's a new feature, this section briefly describes how to implement the new feature.
etc.
-->

#### Additional documentation e.g., usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```