### PR TITLE
fix(osc): new create table ddl not display when use alter table mode

### DIFF
--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/onlineschemachange/oscfms/action/CreateGhostTableAction.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/onlineschemachange/oscfms/action/CreateGhostTableAction.java
@@ -113,6 +113,7 @@ public class CreateGhostTableAction implements Action<OscActionContext, OscActio
         }
         log.info("Successfully created new table, ddl: {}", finalTableDdl);
         validateColumnDifferent(taskParam, session);
+        oscContext.getScheduleTaskRepository().updateTaskParameters(scheduleTaskId, JsonUtils.toJson(taskParam));
     }
 
     @VisibleForTesting


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines.
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request.
3. Ensure you have added or ran the appropriate tests for your PR.
5. If the PR is unfinished, you may add or remove a WIP or [WIP] prefix to your pull request title.
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
type-bug
type-feature
type-docs
etc.

Optionally add one or more of the following kinds if applicable:
module-resultset
module-sql execution
etc.
-->
type-bug
#### What this PR does / why we need it:
set ScheduleTask.OnlineSchemaChangeScheduleTaskParameters.newTableCreateDdlForDisplay to correct value when use alter table mode.


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
1. Front end fetch newTableDDL in ScheduleTask.OnlineSchemaChangeScheduleTaskResult.newTableDdl
2. newTableDdl is assigned by OnlineSchemaChangeScheduleTaskParameters.newTableCreateDdlForDisplay
3. if OnlineSchemaChangeScheduleTaskParameters.newTableCreateDdlForDisplay not set, OnlineSchemaChangeScheduleTaskResult.newTableDdl will be covered to null
4. this patch set newTableCreateDdlForDisplay to guarantee the following operation always fetch right value for newTableDdl
#### Special notes for your reviewer:

<!--
This section is used to describe how this PR is implemented. 
If this is a PR that fixes a bug, this section describes how the bug was fixed.
If it's a new feature, this section briefly describes how to implement the new feature.
etc.
-->

#### Additional documentation e.g., usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```