### PR TITLE
fix(schedule): restore deleted method

### DIFF
--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/schedule/ScheduleTaskService.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/schedule/ScheduleTaskService.java
@@ -316,6 +316,12 @@ public class ScheduleTaskService {
         });
     }
 
+    public List<ScheduleTask> listByJobNames(Set<String> jobNames) {
+        return scheduleTaskRepository.findByJobNames(jobNames).stream()
+                .map(scheduleTaskMapper::entityToModel)
+                .collect(Collectors.toList());
+    }
+
     public List<ScheduleTaskEntity> listTaskByJobNameAndStatus(String jobName, List<TaskStatus> statuses) {
         return scheduleTaskRepository.findByJobNameAndStatusIn(jobName, statuses);
     }


### PR DESCRIPTION
The `com.oceanbase.odc.service.schedule.ScheduleTaskService#listByJobNames` method was deleted in PR https://github.com/oceanbase/odc/pull/3335 .
But we still need this. So  restore it.