### PR TITLE
fix(logicaldatabase): incorrect status transform logic of logical database change subtasks

### DIFF
--- a/server/integration-test/src/test/java/com/oceanbase/odc/service/connection/logicaldatabase/LogicalDatabaseServiceTest.java
+++ b/server/integration-test/src/test/java/com/oceanbase/odc/service/connection/logicaldatabase/LogicalDatabaseServiceTest.java
@@ -35,6 +35,9 @@ import org.junit.Before;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
 
 import com.oceanbase.odc.ServiceTestEnv;
 import com.oceanbase.odc.core.shared.constant.DialectType;
@@ -102,6 +105,8 @@ public class LogicalDatabaseServiceTest extends ServiceTestEnv {
         when(databaseRepository.findByIdIn(anyCollection())).thenReturn(Arrays.asList(getPhysicalDatabase()));
         doNothing().when(projectPermissionValidator).checkProjectRole(anyLong(), anyList());
         doNothing().when(permissionHelper).checkDBPermissions(anyCollection(), anyCollection());
+        when(databaseRepository.findAll(any(Specification.class), any(Pageable.class)))
+                .thenReturn(new PageImpl<>(Arrays.asList(getPhysicalDatabase())));
     }
 
     @Test

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/connection/logicaldatabase/core/executor/execution/ExecutionResult.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/connection/logicaldatabase/core/executor/execution/ExecutionResult.java
@@ -45,6 +45,6 @@ public class ExecutionResult<Result> implements Serializable {
     }
 
     public boolean isCompleted() {
-        return status == ExecutionStatus.SUCCESS || status == ExecutionStatus.SKIPPED;
+        return this.status.isCompleted();
     }
 }

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/connection/logicaldatabase/core/executor/execution/ExecutionStatus.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/connection/logicaldatabase/core/executor/execution/ExecutionStatus.java
@@ -21,9 +21,12 @@ public enum ExecutionStatus {
     SKIPPED,
     RUNNING,
     PENDING,
+    SKIPPING,
+    TERMINATING,
+    TERMINATE_FAILED,
     TERMINATED;
 
     public boolean isCompleted() {
-        return this == SUCCESS || this == FAILED || this == SKIPPED || this == TERMINATED;
+        return this == SUCCESS || this == SKIPPED;
     }
 }

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/task/executor/task/LogicalDatabaseChangeTask.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/task/executor/task/LogicalDatabaseChangeTask.java
@@ -105,8 +105,16 @@ public class LogicalDatabaseChangeTask extends BaseTask<Map<String, ExecutionRes
                     dataNodesToExecute = LogicalDatabaseUtils.getDataNodesFromNotCreateTable(sql, dialectType,
                             taskParameters.getLogicalDatabaseResp());
                 }
+                if (CollectionUtils.isEmpty(dataNodesToExecute)) {
+                    log.warn("There is no physical database to operate on, sql={}", sql);
+                    continue;
+                }
                 RewriteResult rewriteResult = sqlRewriter.rewrite(
                         new RewriteContext(statement, dialectType, dataNodesToExecute));
+                if (rewriteResult == null || MapUtils.isEmpty(rewriteResult.getSqls())) {
+                    log.warn("Cannot rewrite the sql, sql={}", sql);
+                    continue;
+                }
                 Map<Long, List<String>> databaseId2RewrittenSqls = rewriteResult.getSqls().entrySet().stream()
                         .collect(Collectors.groupingBy(
                                 entry -> entry.getKey().getDatabaseId(),

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/task/processor/LogicalDBChangeResultProcessor.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/task/processor/LogicalDBChangeResultProcessor.java
@@ -18,7 +18,6 @@ package com.oceanbase.odc.service.task.processor;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -30,7 +29,6 @@ import com.oceanbase.odc.common.json.JsonUtils;
 import com.oceanbase.odc.core.shared.constant.TaskStatus;
 import com.oceanbase.odc.service.connection.logicaldatabase.LogicalDatabaseChangeService;
 import com.oceanbase.odc.service.connection.logicaldatabase.core.executor.execution.ExecutionResult;
-import com.oceanbase.odc.service.connection.logicaldatabase.core.executor.execution.ExecutionStatus;
 import com.oceanbase.odc.service.connection.logicaldatabase.core.executor.sql.SqlExecutionResultWrapper;
 import com.oceanbase.odc.service.connection.logicaldatabase.core.model.LogicalDBChangeExecutionUnit;
 import com.oceanbase.odc.service.schedule.ScheduleTaskService;
@@ -88,11 +86,8 @@ public class LogicalDBChangeResultProcessor implements ResultProcessor {
     }
 
     private TaskStatus getTaskStatus(Collection<ExecutionResult<SqlExecutionResultWrapper>> results) {
-        Set<ExecutionStatus> statuses = results.stream().map(ExecutionResult::getStatus).collect(Collectors.toSet());
         if (results.stream().allMatch(ExecutionResult::isCompleted)) {
             return TaskStatus.DONE;
-        } else if (statuses.contains(ExecutionStatus.FAILED)) {
-            return TaskStatus.FAILED;
         } else {
             return TaskStatus.RUNNING;
         }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines.
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request.
3. Ensure you have added or ran the appropriate tests for your PR.
5. If the PR is unfinished, you may add or remove a WIP or [WIP] prefix to your pull request title.
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
type-bug
type-feature
type-docs
etc.

Optionally add one or more of the following kinds if applicable:
module-resultset
module-sql execution
etc.
-->
type-bug
#### What this PR does / why we need it:
1. Fix the incorrect logic for changing the status of logical database subtasks. Previously, the implementation involved updating the metadb first and then publishing an action to the task framework when skipping or terminating, which was incorrect. Now, the implementation introduces three new states: `SKIPPING`, `TERMINATING`, and `TERMINATE_FAILED`. The odc-server layer no longer actively updates the result; instead, everything is handled by the task update, and the odc-server is responsible only for retrieval.
2. Make the rewrite and preview logic more robust. 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #3458 #3466 #3354 

#### Special notes for your reviewer:

<!--
This section is used to describe how this PR is implemented. 
If this is a PR that fixes a bug, this section describes how the bug was fixed.
If it's a new feature, this section briefly describes how to implement the new feature.
etc.
-->

#### Additional documentation e.g., usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```