### PR TITLE
fix(logicaldatabase): failed to recognize the wrong expression like db.tb.xxx

### DIFF
--- a/server/integration-test/src/test/resources/connection/logicaldatabase/invalid_logical_table_expression_resolve.yaml
+++ b/server/integration-test/src/test/resources/connection/logicaldatabase/invalid_logical_table_expression_resolve.yaml
@@ -41,3 +41,11 @@
 - id: 11
   expression: "db.tb_[1-2147483648:1]"
   error_message_abstract: "In your expression, the range for [1-2147483648:1] must consist of valid positive integers."
+
+- id: 12
+  expression: "db.t_[1-3].tail"
+  error_message_abstract: "tail"
+
+- id: 13
+  expression: "db.t_[1-3].tail, db.t_[1-3].tail"
+  error_message_abstract: "tail"

--- a/server/odc-service/src/main/resources/antlr/logicaldatabase/LogicalTableExpression.g4
+++ b/server/odc-service/src/main/resources/antlr/logicaldatabase/LogicalTableExpression.g4
@@ -18,9 +18,9 @@ grammar LogicalTableExpression;
 @header {
 package com.oceanbase.odc.service.connection.logicaldatabase;
 }
-logicalTableExpressionList: logicalTableExpression (COMMA logicalTableExpression)* ;
+logicalTableExpressionList: logicalTableExpression (COMMA logicalTableExpression)* EOF;
 
-logicalTableExpression: schemaExpression DOT tableExpression ;
+logicalTableExpression: schemaExpression DOT tableExpression;
 
 schemaExpression: (schemaSliceRangeWithBracket IDENTIFIER?)* IDENTIFIER (schemaSliceRangeWithBracket IDENTIFIER?)* ;
 

--- a/server/odc-service/src/main/resources/antlr/logicaldatabase/LogicalTableExpression.g4
+++ b/server/odc-service/src/main/resources/antlr/logicaldatabase/LogicalTableExpression.g4
@@ -18,9 +18,9 @@ grammar LogicalTableExpression;
 @header {
 package com.oceanbase.odc.service.connection.logicaldatabase;
 }
-logicalTableExpressionList: logicalTableExpression (COMMA logicalTableExpression)* EOF;
+logicalTableExpressionList: logicalTableExpression (COMMA logicalTableExpression)* EOF ;
 
-logicalTableExpression: schemaExpression DOT tableExpression;
+logicalTableExpression: schemaExpression DOT tableExpression ;
 
 schemaExpression: (schemaSliceRangeWithBracket IDENTIFIER?)* IDENTIFIER (schemaSliceRangeWithBracket IDENTIFIER?)* ;
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines.
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request.
3. Ensure you have added or ran the appropriate tests for your PR.
5. If the PR is unfinished, you may add or remove a WIP or [WIP] prefix to your pull request title.
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
type-bug
type-feature
type-docs
etc.

Optionally add one or more of the following kinds if applicable:
module-resultset
module-sql execution
etc.
-->
type-bug
#### What this PR does / why we need it:
`db.tb.xxx ` should be a bad syntax expression. I edited .g4 to fix it.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #3463 

#### Special notes for your reviewer:

<!--
This section is used to describe how this PR is implemented. 
If this is a PR that fixes a bug, this section describes how the bug was fixed.
If it's a new feature, this section briefly describes how to implement the new feature.
etc.
-->

#### Additional documentation e.g., usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```