### PR TITLE
fix(notification): incorrent status of DLM task notification

### DIFF
--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/task/listener/JobTerminateNotifyListener.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/task/listener/JobTerminateNotifyListener.java
@@ -19,13 +19,14 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import com.oceanbase.odc.common.event.AbstractEventListener;
+import com.oceanbase.odc.core.shared.constant.TaskStatus;
 import com.oceanbase.odc.metadb.task.JobEntity;
+import com.oceanbase.odc.service.dlm.DLMService;
 import com.oceanbase.odc.service.notification.Broker;
 import com.oceanbase.odc.service.notification.NotificationProperties;
 import com.oceanbase.odc.service.notification.helper.EventBuilder;
 import com.oceanbase.odc.service.schedule.ScheduleService;
 import com.oceanbase.odc.service.schedule.ScheduleTaskService;
-import com.oceanbase.odc.service.task.enums.JobStatus;
 import com.oceanbase.odc.service.task.service.TaskFrameworkService;
 
 import lombok.extern.slf4j.Slf4j;
@@ -50,6 +51,8 @@ public class JobTerminateNotifyListener extends AbstractEventListener<JobTermina
     private ScheduleTaskService scheduleTaskService;
     @Autowired
     private ScheduleService scheduleService;
+    @Autowired
+    private DLMService dlmService;
 
     @Override
     public void onEvent(JobTerminateEvent event) {
@@ -60,7 +63,11 @@ public class JobTerminateNotifyListener extends AbstractEventListener<JobTermina
             JobEntity jobEntity = taskFrameworkService.find(event.getJi().getId());
             scheduleTaskService.findByJobId(jobEntity.getId())
                     .ifPresent(task -> {
-                        broker.enqueueEvent(event.getStatus() == JobStatus.DONE ? eventBuilder.ofSucceededTask(task)
+                        TaskStatus status =
+                                "DLM".equalsIgnoreCase(jobEntity.getJobType())
+                                        ? dlmService.getFinalTaskStatus(task.getId())
+                                        : jobEntity.getStatus().convertTaskStatus();
+                        broker.enqueueEvent(status == TaskStatus.DONE ? eventBuilder.ofSucceededTask(task)
                                 : eventBuilder.ofFailedTask(task));
                     });
         } catch (Exception e) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines.
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request.
3. Ensure you have added or ran the appropriate tests for your PR.
5. If the PR is unfinished, you may add or remove a WIP or [WIP] prefix to your pull request title.
-->

#### What type of PR is this?
type-bug
<!--
Add one of the following kinds:
type-bug
type-feature
type-docs
etc.

Optionally add one or more of the following kinds if applicable:
module-resultset
module-sql execution
etc.
-->

#### What this PR does / why we need it:

We've added a hook for notification in `JobTerminateNotifyListener` , and determine the type of notification to be sent based on the status in `job_job` table.
But for DLM tasks , the job status is Incorrect. The real status should be found in `schedule_task`.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #3591
