### PR TITLE
fix(sync-database): modify syncDatabaseTaskExecutor QueueCapacity to Integer.MAX_VALUE

### DIFF
--- a/server/odc-service/src/main/java/com/oceanbase/odc/config/ScheduleConfiguration.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/config/ScheduleConfiguration.java
@@ -195,7 +195,7 @@ public class ScheduleConfiguration {
         executor.setWaitForTasksToCompleteOnShutdown(true);
         executor.setAwaitTerminationSeconds(5);
         executor.setTaskDecorator(new TraceDecorator<>());
-        executor.setRejectedExecutionHandler(new ThreadPoolExecutor.DiscardPolicy());
+        executor.setRejectedExecutionHandler(new ThreadPoolExecutor.CallerRunsPolicy());
         executor.initialize();
         log.info("syncDatabaseTaskExecutor initialized");
         return executor;

--- a/server/odc-service/src/main/java/com/oceanbase/odc/config/ScheduleConfiguration.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/config/ScheduleConfiguration.java
@@ -190,12 +190,12 @@ public class ScheduleConfiguration {
         int poolSize = Math.max(SystemUtils.availableProcessors() * 8, 64);
         executor.setCorePoolSize(poolSize);
         executor.setMaxPoolSize(poolSize);
-        executor.setQueueCapacity(0);
+        executor.setQueueCapacity(Integer.MAX_VALUE);
         executor.setThreadNamePrefix("database-sync-");
         executor.setWaitForTasksToCompleteOnShutdown(true);
         executor.setAwaitTerminationSeconds(5);
         executor.setTaskDecorator(new TraceDecorator<>());
-        executor.setRejectedExecutionHandler(new ThreadPoolExecutor.CallerRunsPolicy());
+        executor.setRejectedExecutionHandler(new ThreadPoolExecutor.DiscardPolicy());
         executor.initialize();
         log.info("syncDatabaseTaskExecutor initialized");
         return executor;


### PR DESCRIPTION
#### What type of PR is this?
type-bug

#### What this PR does / why we need it:
modify `syncDatabaseTaskExecutor`QueueCapacity  to `Integer.MAX_VALUE` to avoid the situation where the data source cannot trigger synchronization forever after the submitted synchronization database task exceeds the maximum number of thread pools.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #3670

#### Special notes for your reviewer:

<!--
This section is used to describe how this PR is implemented. 
If this is a PR that fixes a bug, this section describes how the bug was fixed.
If it's a new feature, this section briefly describes how to implement the new feature.
etc.
-->

#### Additional documentation e.g., usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```