### PR TITLE
build: build_rpm_without_sqlconsole.sh support BUILD_LIBS variable

### DIFF
--- a/script/build_rpm_without_sqlconsole.sh
+++ b/script/build_rpm_without_sqlconsole.sh
@@ -13,6 +13,7 @@ mvn_extra_args=$@
 
 # read environment variables
 fetch_from_oss_flag=${FETCH_FROM_OSS:-"0"}
+build_libs_flag=${BUILD_LIBS:-"1"}
 
 if ! source $(dirname "$0")/functions.sh; then
     echo "source functions.sh failed"
@@ -23,7 +24,15 @@ function build_rpm_without_sqlconsole() {
     log_info "maven build jar start"
     echo "mvn_extra_args:" "${mvn_extra_args[@]}"
 
-    maven_install_libs "${mvn_extra_args[@]}"
+    if [ "${build_libs_flag}" == "1" ]; then
+        if ! maven_install_libs "${mvn_extra_args[@]}"; then
+            log_error "maven build libs failed"
+            return 2
+        fi
+    else
+        log_info "skip maven build libs"
+    fi
+
     if ! maven_build_jar "${mvn_extra_args[@]}"; then
         log_error "maven build jar failed"
         return 4


### PR DESCRIPTION

#### What type of PR is this?

type-feature

#### What this PR does / why we need it:
build_rpm_without_sqlconsole.sh support BUILD_LIBS variable,
for reduce time cost while manual build rpm pacakge.
