### PR TITLE
fix(scheduleTask): correct status on task restart

### DIFF
--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/schedule/ScheduleService.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/schedule/ScheduleService.java
@@ -586,6 +586,7 @@ public class ScheduleService {
      * @param scheduleId the task must belong to a valid schedule,so this param is not be null.
      * @param scheduleTaskId the task uid. Start a paused or pending task.
      */
+    @Transactional(rollbackFor = Exception.class)
     public void startTask(Long scheduleId, Long scheduleTaskId) {
         nullSafeGetByIdWithCheckPermission(scheduleId, true);
         Lock lock = jdbcLockRegistry.obtain(getScheduleTaskLockKey(scheduleTaskId));

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/schedule/ScheduleTaskService.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/schedule/ScheduleTaskService.java
@@ -32,6 +32,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.alibaba.fastjson.JSON;
 import com.oceanbase.odc.common.json.JsonUtils;
@@ -56,6 +57,7 @@ import com.oceanbase.odc.service.dispatch.DispatchResponse;
 import com.oceanbase.odc.service.dispatch.RequestDispatcher;
 import com.oceanbase.odc.service.dispatch.TaskDispatchChecker;
 import com.oceanbase.odc.service.dlm.DLMService;
+import com.oceanbase.odc.service.dlm.model.DlmTableUnit;
 import com.oceanbase.odc.service.quartz.QuartzJobService;
 import com.oceanbase.odc.service.quartz.util.ScheduleTaskUtils;
 import com.oceanbase.odc.service.schedule.factory.ScheduleResponseMapperFactory;
@@ -171,6 +173,7 @@ public class ScheduleTaskService {
     /**
      * Trigger an existing task to retry or resume a terminated task.
      */
+    @Transactional(rollbackFor = Exception.class)
     public void start(Long id) {
         ScheduleTask scheduleTask = nullSafeGetModelById(id);
         if (!scheduleTask.getStatus().isRetryAllowed()) {
@@ -179,6 +182,24 @@ public class ScheduleTaskService {
                     id);
             throw new IllegalStateException(
                     "The task cannot be restarted because it is currently in progress or has already completed.");
+        }
+        switch (ScheduleTaskType.valueOf(scheduleTask.getJobGroup())) {
+            case DATA_ARCHIVE:
+            case DATA_ARCHIVE_ROLLBACK:
+            case DATA_ARCHIVE_DELETE:
+            case DATA_DELETE: {
+                List<DlmTableUnit> tableUnits = dlmService.findByScheduleTaskId(scheduleTask.getId()).stream()
+                        .peek(unit -> {
+                            // Re-run all unfinished tableUnits
+                            if (unit.getStatus() != TaskStatus.DONE) {
+                                unit.setStatus(TaskStatus.PREPARING);
+                            }
+                        }).collect(Collectors.toList());
+                dlmService.createOrUpdateDlmTableUnits(tableUnits);
+                break;
+            }
+            default:
+                break;
         }
         try {
             JobKey jobKey = new JobKey(scheduleTask.getJobName(), scheduleTask.getJobGroup());


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines.
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request.
3. Ensure you have added or ran the appropriate tests for your PR.
5. If the PR is unfinished, you may add or remove a WIP or [WIP] prefix to your pull request title.
-->

#### What type of PR is this?
type-bug

<!--
Add one of the following kinds:
type-bug
type-feature
type-docs
etc.

Optionally add one or more of the following kinds if applicable:
module-resultset
module-sql execution
etc.
-->

#### What this PR does / why we need it:
The schedule task shows the wrong status if the task is restarted.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

<!--
This section is used to describe how this PR is implemented. 
If this is a PR that fixes a bug, this section describes how the bug was fixed.
If it's a new feature, this section briefly describes how to implement the new feature.
etc.
-->

#### Additional documentation e.g., usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```