### PR TITLE
fix(query-profie): NPE occurred when `filter`'s value is null

### DIFF
--- a/server/plugins/connect-plugin-ob-mysql/src/main/java/com/oceanbase/odc/plugin/connect/obmysql/diagnose/PlanGraphBuilder.java
+++ b/server/plugins/connect-plugin-ob-mysql/src/main/java/com/oceanbase/odc/plugin/connect/obmysql/diagnose/PlanGraphBuilder.java
@@ -22,6 +22,7 @@ import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -120,14 +121,16 @@ public class PlanGraphBuilder {
         // parse access predicates
         if (StringUtils.isNotEmpty(record.getAccessPredicates())) {
             Map<String, List<String>> access = parsePredicates(record.getAccessPredicates(), parameters);
-            operator.setAttribute("Access predicates",
-                    singletonList(String.join(",", access.get("access"))));
+            if (access.containsKey("access") && Objects.nonNull(access.get("access"))) {
+                operator.setAttribute("Access predicates", singletonList(String.join(",", access.get("access"))));
+            }
         }
         // parse filter predicates
         if (StringUtils.isNotEmpty(record.getFilterPredicates())) {
             Map<String, List<String>> filter = parsePredicates(record.getFilterPredicates(), parameters);
-            operator.setAttribute("Filter predicates",
-                    singletonList(String.join(" AND ", filter.get("filter"))));
+            if (filter.containsKey("filter") && Objects.nonNull(filter.get("filter"))) {
+                operator.setAttribute("Filter predicates", singletonList(String.join(" AND ", filter.get("filter"))));
+            }
         }
         // parse special predicates
         if (StringUtils.isNotEmpty(record.getSpecialPredicates())) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines.
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request.
3. Ensure you have added or ran the appropriate tests for your PR.
5. If the PR is unfinished, you may add or remove a WIP or [WIP] prefix to your pull request title.
-->

#### What type of PR is this?
type-bug
<!--
Add one of the following kinds:
type-bug
type-feature
type-docs
etc.

Optionally add one or more of the following kinds if applicable:
module-resultset
module-sql execution
etc.
-->

#### What this PR does / why we need it:
When query from `gv$ob_sql_plan` view, the `fiter` value could be null. But we missed this, so there may be a NPE for some queries.