### PR TITLE
fix(data-transfer): read timout occurred when getting large for internal usage

### DIFF
--- a/server/odc-server/src/main/resources/data.sql
+++ b/server/odc-server/src/main/resources/data.sql
@@ -713,7 +713,7 @@ INSERT INTO config_system_configuration ( `key`, `value`, `description` ) VALUES
 
 INSERT INTO config_system_configuration ( `key`, `value`, `description` ) VALUES( 'odc.task.datatransfer.use-server-prep-stmts', 'true', '导入导出是否开启 ps 协议，默认为开启' ) ON DUPLICATE KEY UPDATE `id` = `id`;
 INSERT INTO config_system_configuration ( `key`, `value`, `description` ) VALUES( 'odc.task.datatransfer.cursor-fetch-size', '20', '导出时游标的 fetch size，默认为 20，最大值为 1000' ) ON DUPLICATE KEY UPDATE `id` = `id`;
-INSERT INTO config_system_configuration ( `key`, `value`, `description` ) VALUES( 'odc.task.datatransfer.internal-download-import-file-timeout-millis', '300', '从其他节点下载导入文件的 http 超时时间，默认为 5 分钟' ) ON DUPLICATE KEY UPDATE `id` = `id`;
+INSERT INTO config_system_configuration ( `key`, `value`, `description` ) VALUES( 'odc.task.datatransfer.internal-download-import-file-timeout-millis', '300', 'The HTTP timeout for downloading imported files from other nodes. 5 minutes by default' ) ON DUPLICATE KEY UPDATE `id` = `id`;
 
 INSERT INTO config_system_configuration ( `key`, `value`, `description` ) VALUES( 'odc.data-security.masking.enabled', 'true', '是否开启数据脱敏，默认为开启' ) ON DUPLICATE KEY UPDATE `id` = `id`;
 INSERT INTO config_system_configuration ( `key`, `value`, `description` ) VALUES( 'odc.task.partition-plan.schedule-cron', '0 0 * * * ?', '默认调度周期：每天 0 点' ) ON DUPLICATE KEY UPDATE `id` = `id`;

--- a/server/odc-server/src/main/resources/data.sql
+++ b/server/odc-server/src/main/resources/data.sql
@@ -713,6 +713,7 @@ INSERT INTO config_system_configuration ( `key`, `value`, `description` ) VALUES
 
 INSERT INTO config_system_configuration ( `key`, `value`, `description` ) VALUES( 'odc.task.datatransfer.use-server-prep-stmts', 'true', '导入导出是否开启 ps 协议，默认为开启' ) ON DUPLICATE KEY UPDATE `id` = `id`;
 INSERT INTO config_system_configuration ( `key`, `value`, `description` ) VALUES( 'odc.task.datatransfer.cursor-fetch-size', '20', '导出时游标的 fetch size，默认为 20，最大值为 1000' ) ON DUPLICATE KEY UPDATE `id` = `id`;
+INSERT INTO config_system_configuration ( `key`, `value`, `description` ) VALUES( 'odc.task.datatransfer.internal-download-import-file-timeout-millis', '300', '从其他节点下载导入文件的 http 超时时间，默认为 5 分钟' ) ON DUPLICATE KEY UPDATE `id` = `id`;
 
 INSERT INTO config_system_configuration ( `key`, `value`, `description` ) VALUES( 'odc.data-security.masking.enabled', 'true', '是否开启数据脱敏，默认为开启' ) ON DUPLICATE KEY UPDATE `id` = `id`;
 INSERT INTO config_system_configuration ( `key`, `value`, `description` ) VALUES( 'odc.task.partition-plan.schedule-cron', '0 0 * * * ?', '默认调度周期：每天 0 点' ) ON DUPLICATE KEY UPDATE `id` = `id`;

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/datatransfer/model/DataTransferProperties.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/datatransfer/model/DataTransferProperties.java
@@ -31,4 +31,6 @@ public class DataTransferProperties {
 
     private boolean useServerPrepStmts;
 
+    private int internalDownloadImportFileTimeoutMillis;
+
 }

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/flow/OdcInternalFileService.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/flow/OdcInternalFileService.java
@@ -82,7 +82,7 @@ public class OdcInternalFileService {
     }
 
     public void getExternalImportFiles(TaskEntity taskEntity, ExecutorInfo creatorInfo, List<String> importFileNames,
-            int requestTimeoutSeconds) throws Exception {
+            int requestTimeoutMillis) throws Exception {
         String checkString = String.valueOf(taskEntity.getId())
                 + taskEntity.getCreatorId()
                 + taskEntity.getCreateTime()
@@ -97,9 +97,9 @@ public class OdcInternalFileService {
         try (CloseableHttpClient httpClient = HttpClients.createDefault()) {
             HttpGet httpGet = new HttpGet();
             RequestConfig config = RequestConfig.custom()
-                    .setConnectTimeout(requestTimeoutSeconds)
-                    .setConnectionRequestTimeout(requestTimeoutSeconds)
-                    .setSocketTimeout(requestTimeoutSeconds)
+                    .setConnectTimeout(requestTimeoutMillis)
+                    .setConnectionRequestTimeout(requestTimeoutMillis)
+                    .setSocketTimeout(requestTimeoutMillis)
                     .build();
             httpGet.setConfig(config);
             for (String fileName : importFileNames) {

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/flow/OdcInternalFileService.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/flow/OdcInternalFileService.java
@@ -59,7 +59,6 @@ public class OdcInternalFileService {
     private LocalFileManager localFileManager;
     @Autowired
     private FlowTaskInstanceService flowTaskInstanceService;
-    private static final Integer HTTP_REQUEST_TIME_OUT = 10000;
 
     public List<BinaryDataResult> downloadImportFile(@NonNull Long taskId, @NonNull String targetFileName,
             @NonNull String checkCode) throws IOException {
@@ -82,8 +81,8 @@ public class OdcInternalFileService {
         return flowTaskInstanceService.internalDownload(taskEntity, targetFileName);
     }
 
-    public void getExternalImportFiles(TaskEntity taskEntity, ExecutorInfo creatorInfo, List<String> importFileNames)
-            throws Exception {
+    public void getExternalImportFiles(TaskEntity taskEntity, ExecutorInfo creatorInfo, List<String> importFileNames,
+            int requestTimeoutSeconds) throws Exception {
         String checkString = String.valueOf(taskEntity.getId())
                 + taskEntity.getCreatorId()
                 + taskEntity.getCreateTime()
@@ -98,9 +97,9 @@ public class OdcInternalFileService {
         try (CloseableHttpClient httpClient = HttpClients.createDefault()) {
             HttpGet httpGet = new HttpGet();
             RequestConfig config = RequestConfig.custom()
-                    .setConnectTimeout(HTTP_REQUEST_TIME_OUT)
-                    .setConnectionRequestTimeout(HTTP_REQUEST_TIME_OUT)
-                    .setSocketTimeout(HTTP_REQUEST_TIME_OUT)
+                    .setConnectTimeout(requestTimeoutSeconds)
+                    .setConnectionRequestTimeout(requestTimeoutSeconds)
+                    .setSocketTimeout(requestTimeoutSeconds)
                     .build();
             httpGet.setConfig(config);
             for (String fileName : importFileNames) {

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/flow/task/DataTransferRuntimeFlowableTask.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/flow/task/DataTransferRuntimeFlowableTask.java
@@ -49,7 +49,7 @@ public class DataTransferRuntimeFlowableTask extends BaseODCFlowTaskDelegate<Voi
      * ODC allows importing up to 2 GB of files. We estimate a 5-minute timeout based on transmission
      * rate of 10 MB/s.
      */
-    private static final int DEFAULT_GET_IMPORT_FILE_TIMEOUT_SECONDS = 300;
+    private static final int DEFAULT_GET_IMPORT_FILE_TIMEOUT_MILLIS = 300 * 1000;
 
     @Autowired
     private DataTransferService dataTransferService;
@@ -92,7 +92,7 @@ public class DataTransferRuntimeFlowableTask extends BaseODCFlowTaskDelegate<Voi
              * 导入任务不在当前机器上，需要进行 {@code HTTP GET} 获取导入文件
              */
             odcInternalFileService.getExternalImportFiles(taskEntity, submitter, config.getImportFileName(),
-                    DEFAULT_GET_IMPORT_FILE_TIMEOUT_SECONDS);
+                    DEFAULT_GET_IMPORT_FILE_TIMEOUT_MILLIS);
         }
         config.setExecutionTimeoutSeconds(taskEntity.getExecutionExpirationIntervalSeconds());
         context = dataTransferService.create(taskId + "", config);

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/flow/task/DataTransferRuntimeFlowableTask.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/flow/task/DataTransferRuntimeFlowableTask.java
@@ -45,6 +45,11 @@ import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 public class DataTransferRuntimeFlowableTask extends BaseODCFlowTaskDelegate<Void> {
+    /**
+     * ODC allows importing up to 2 GB of files. We estimate a 5-minute timeout based on transmission
+     * rate of 10 MB/s.
+     */
+    private static final int DEFAULT_GET_IMPORT_FILE_TIMEOUT_SECONDS = 300;
 
     @Autowired
     private DataTransferService dataTransferService;
@@ -86,7 +91,8 @@ public class DataTransferRuntimeFlowableTask extends BaseODCFlowTaskDelegate<Voi
             /**
              * 导入任务不在当前机器上，需要进行 {@code HTTP GET} 获取导入文件
              */
-            odcInternalFileService.getExternalImportFiles(taskEntity, submitter, config.getImportFileName());
+            odcInternalFileService.getExternalImportFiles(taskEntity, submitter, config.getImportFileName(),
+                    DEFAULT_GET_IMPORT_FILE_TIMEOUT_SECONDS);
         }
         config.setExecutionTimeoutSeconds(taskEntity.getExecutionExpirationIntervalSeconds());
         context = dataTransferService.create(taskId + "", config);

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/flow/task/DataTransferRuntimeFlowableTask.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/flow/task/DataTransferRuntimeFlowableTask.java
@@ -28,6 +28,7 @@ import com.oceanbase.odc.metadb.task.TaskEntity;
 import com.oceanbase.odc.plugin.task.api.datatransfer.model.DataTransferConfig;
 import com.oceanbase.odc.plugin.task.api.datatransfer.model.DataTransferTaskResult;
 import com.oceanbase.odc.service.datatransfer.DataTransferService;
+import com.oceanbase.odc.service.datatransfer.model.DataTransferProperties;
 import com.oceanbase.odc.service.datatransfer.task.DataTransferTaskContext;
 import com.oceanbase.odc.service.flow.OdcInternalFileService;
 import com.oceanbase.odc.service.flow.util.FlowTaskUtil;
@@ -45,16 +46,13 @@ import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 public class DataTransferRuntimeFlowableTask extends BaseODCFlowTaskDelegate<Void> {
-    /**
-     * ODC allows importing up to 2 GB of files. We estimate a 5-minute timeout based on transmission
-     * rate of 10 MB/s.
-     */
-    private static final int DEFAULT_GET_IMPORT_FILE_TIMEOUT_MILLIS = 300 * 1000;
 
     @Autowired
     private DataTransferService dataTransferService;
     @Autowired
     private OdcInternalFileService odcInternalFileService;
+    @Autowired
+    private DataTransferProperties dataTransferProperties;
     private volatile DataTransferTaskContext context;
 
     @Override
@@ -92,7 +90,7 @@ public class DataTransferRuntimeFlowableTask extends BaseODCFlowTaskDelegate<Voi
              * 导入任务不在当前机器上，需要进行 {@code HTTP GET} 获取导入文件
              */
             odcInternalFileService.getExternalImportFiles(taskEntity, submitter, config.getImportFileName(),
-                    DEFAULT_GET_IMPORT_FILE_TIMEOUT_MILLIS);
+                    dataTransferProperties.getInternalDownloadImportFileTimeoutMillis());
         }
         config.setExecutionTimeoutSeconds(taskEntity.getExecutionExpirationIntervalSeconds());
         context = dataTransferService.create(taskId + "", config);


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines.
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request.
3. Ensure you have added or ran the appropriate tests for your PR.
5. If the PR is unfinished, you may add or remove a WIP or [WIP] prefix to your pull request title.
-->

#### What type of PR is this?
type-bug
<!--
Add one of the following kinds:
type-bug
type-feature
type-docs
etc.

Optionally add one or more of the following kinds if applicable:
module-resultset
module-sql execution
etc.
-->

#### What this PR does / why we need it:

When getting internal file for datatransfer, the default timeout was 10s . This is to small. ODC allows importing up to 2 GB of files.  So We estimate a 5-minute timeout based on transmission rate of 10 MB/s.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #3759