### PR TITLE
feat(object-storage): use s3 sdk for google cloud storage

### DIFF
--- a/server/integration-test/src/test/java/com/oceanbase/odc/ITConfigurations.java
+++ b/server/integration-test/src/test/java/com/oceanbase/odc/ITConfigurations.java
@@ -86,6 +86,18 @@ public class ITConfigurations {
         return configuration;
     }
 
+    public static ObjectStorageConfiguration getGCSConfiguration() {
+        ObjectStorageConfiguration configuration = new ObjectStorageConfiguration();
+        configuration.setCloudProvider(CloudProvider.GOOGLE_CLOUD);
+        configuration.setPublicEndpoint(get("odc.cloud.object-storage.gcs.endpoint"));
+        configuration.setAccessKeyId(get("odc.cloud.object-storage.gcs.access-key-id"));
+        configuration.setAccessKeySecret(get("odc.cloud.object-storage.gcs.access-key-secret"));
+        configuration.setBucketName(get("odc.cloud.object-storage.gcs.bucket-name"));
+        configuration.setRoleArn(get("odc.cloud.object-storage.gcs.role-arn"));
+        configuration.setRoleSessionName(get("odc.cloud.object-storage.gcs.role-session-name"));
+        return configuration;
+    }
+
     public static OnlineSchemaChangeProperties getOscPrivateCloudProperties() {
         OnlineSchemaChangeProperties configuration = new OnlineSchemaChangeProperties();
         OmsProperties omsConfiguration = new OmsProperties();

--- a/server/integration-test/src/test/java/com/oceanbase/odc/service/objectstorage/cloud/GCSObjectStorageServiceIT.java
+++ b/server/integration-test/src/test/java/com/oceanbase/odc/service/objectstorage/cloud/GCSObjectStorageServiceIT.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2023 OceanBase.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.oceanbase.odc.service.objectstorage.cloud;
+
+import org.junit.Ignore;
+
+import com.oceanbase.odc.ITConfigurations;
+import com.oceanbase.odc.service.objectstorage.cloud.client.CloudClient;
+import com.oceanbase.odc.service.objectstorage.cloud.model.ObjectStorageConfiguration;
+
+@Ignore
+public class GCSObjectStorageServiceIT extends AbstractCloudObjectStorageServiceTest {
+
+    @Override
+    CloudObjectStorageService createCloudObjectStorageService() {
+        ObjectStorageConfiguration configuration = ITConfigurations.getGCSConfiguration();
+        CloudClient cloudClient = new CloudResourceConfigurations().publicEndpointCloudClient(() -> configuration);
+        CloudClient internalCloudClient =
+                new CloudResourceConfigurations().internalEndpointCloudClient(() -> configuration);
+        return new CloudObjectStorageService(cloudClient, internalCloudClient, () -> configuration);
+    }
+
+}

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/objectstorage/client/CloudObjectStorageClient.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/objectstorage/client/CloudObjectStorageClient.java
@@ -41,6 +41,7 @@ import com.oceanbase.odc.service.objectstorage.cloud.CloudObjectStorage;
 import com.oceanbase.odc.service.objectstorage.cloud.model.CloudObjectStorageConstants;
 import com.oceanbase.odc.service.objectstorage.cloud.model.CompleteMultipartUploadRequest;
 import com.oceanbase.odc.service.objectstorage.cloud.model.CompleteMultipartUploadResult;
+import com.oceanbase.odc.service.objectstorage.cloud.model.DeleteObjectRequest;
 import com.oceanbase.odc.service.objectstorage.cloud.model.DeleteObjectsRequest;
 import com.oceanbase.odc.service.objectstorage.cloud.model.DeleteObjectsResult;
 import com.oceanbase.odc.service.objectstorage.cloud.model.GetObjectRequest;
@@ -164,6 +165,16 @@ public class CloudObjectStorageClient implements ObjectStorageClient {
         log.info("Delete files success, tryDeleteObjectName={}, deletedObjectNames={}",
                 objectNames, deletedObjects);
         return deletedObjects;
+    }
+
+    @Override
+    public String deleteObject(String objectName) {
+        verifySupported();
+        DeleteObjectRequest request = new DeleteObjectRequest(getBucketName(), objectName);
+        String deleted = internalEndpointCloudObjectStorage.deleteObject(request);
+        log.info("Delete file success, tryDeleteObjectName={}, deletedObjectName={}",
+                objectName, deleted);
+        return deleted;
     }
 
     @Override

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/objectstorage/client/LocalObjectStorageClient.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/objectstorage/client/LocalObjectStorageClient.java
@@ -25,6 +25,8 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 
+import javax.validation.constraints.NotBlank;
+
 import org.apache.commons.collections4.CollectionUtils;
 
 import com.oceanbase.odc.service.objectstorage.cloud.model.ObjectTagging;
@@ -94,6 +96,12 @@ public class LocalObjectStorageClient implements ObjectStorageClient {
         HashSet<String> objectNameSet = new HashSet<>(objectNames);
         blockOperator.batchDelete(objectNameSet);
         return new ArrayList<>();
+    }
+
+    @Override
+    public String deleteObject(@NotBlank String objectName) throws IOException {
+        blockOperator.deleteByObjectId(objectName);
+        return objectName;
     }
 
     @Override

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/objectstorage/client/ObjectStorageClient.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/objectstorage/client/ObjectStorageClient.java
@@ -49,6 +49,8 @@ public interface ObjectStorageClient {
 
     List<String> deleteObjects(@NotEmpty List<String> objectNames) throws IOException;
 
+    String deleteObject(@NotBlank String objectName) throws IOException;
+
     InputStream getObject(@NotBlank String objectName) throws IOException;
 
     InputStream getAbortableObject(@NotBlank String objectName) throws IOException;

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/objectstorage/cloud/CloudObjectStorage.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/objectstorage/cloud/CloudObjectStorage.java
@@ -24,6 +24,7 @@ import com.oceanbase.odc.service.objectstorage.cloud.client.CloudException;
 import com.oceanbase.odc.service.objectstorage.cloud.model.CompleteMultipartUploadRequest;
 import com.oceanbase.odc.service.objectstorage.cloud.model.CompleteMultipartUploadResult;
 import com.oceanbase.odc.service.objectstorage.cloud.model.CopyObjectResult;
+import com.oceanbase.odc.service.objectstorage.cloud.model.DeleteObjectRequest;
 import com.oceanbase.odc.service.objectstorage.cloud.model.DeleteObjectsRequest;
 import com.oceanbase.odc.service.objectstorage.cloud.model.DeleteObjectsResult;
 import com.oceanbase.odc.service.objectstorage.cloud.model.GetObjectRequest;
@@ -68,6 +69,8 @@ public interface CloudObjectStorage {
             throws CloudException;
 
     DeleteObjectsResult deleteObjects(DeleteObjectsRequest request) throws CloudException;
+
+    String deleteObject(DeleteObjectRequest request) throws CloudException;
 
     boolean doesObjectExist(String bucketName, String key) throws CloudException;
 

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/objectstorage/cloud/CloudObjectStorageService.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/objectstorage/cloud/CloudObjectStorageService.java
@@ -20,7 +20,6 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
-import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 
@@ -164,8 +163,8 @@ public class CloudObjectStorageService {
      * @throws IOException
      */
     public boolean delete(@NotBlank String objectName) throws IOException {
-        List<String> deletedObjectNames = delete(Collections.singletonList(objectName));
-        return !deletedObjectNames.isEmpty();
+        cloudObjectStorageClient.deleteObject(objectName);
+        return true;
     }
 
     /**

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/objectstorage/cloud/CloudResourceConfigurations.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/objectstorage/cloud/CloudResourceConfigurations.java
@@ -101,6 +101,7 @@ public class CloudResourceConfigurations {
                 case AWS:
                 case TENCENT_CLOUD:
                 case HUAWEI_CLOUD:
+                case GOOGLE_CLOUD:
                     return createAmazonCloudClient(configuration);
                 default:
                     return new NullCloudClient();
@@ -136,6 +137,10 @@ public class CloudResourceConfigurations {
                 .withCredentials(credentialsProvider)
                 .withClientConfiguration(clientConfiguration)
                 .disableChunkedEncoding();
+        // GCS does not support region
+        if (configuration.getCloudProvider() == CloudProvider.GOOGLE_CLOUD) {
+            region = "EMPTY";
+        }
         // if not AWS, means use S3 SDK to access other cloud storage, then we must set endpoint
         if (!configuration.getCloudProvider().isAWS()) {
             String endpoint = configuration.getPublicEndpoint();

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/objectstorage/cloud/client/AlibabaCloudClient.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/objectstorage/cloud/client/AlibabaCloudClient.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
 import java.text.ParseException;
+import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
@@ -50,6 +51,7 @@ import com.oceanbase.odc.core.shared.Verify;
 import com.oceanbase.odc.service.objectstorage.cloud.model.CompleteMultipartUploadRequest;
 import com.oceanbase.odc.service.objectstorage.cloud.model.CompleteMultipartUploadResult;
 import com.oceanbase.odc.service.objectstorage.cloud.model.CopyObjectResult;
+import com.oceanbase.odc.service.objectstorage.cloud.model.DeleteObjectRequest;
 import com.oceanbase.odc.service.objectstorage.cloud.model.DeleteObjectsRequest;
 import com.oceanbase.odc.service.objectstorage.cloud.model.DeleteObjectsResult;
 import com.oceanbase.odc.service.objectstorage.cloud.model.GetObjectRequest;
@@ -195,6 +197,17 @@ public class AlibabaCloudClient implements CloudClient {
             result.setRequestId(ossResult.getRequestId());
             result.setDeletedObjects(ossResult.getDeletedObjects());
             return result;
+        });
+    }
+
+    @Override
+    public String deleteObject(DeleteObjectRequest request) throws CloudException {
+        com.aliyun.oss.model.DeleteObjectsRequest ossRequest =
+                new com.aliyun.oss.model.DeleteObjectsRequest(request.getBucketName())
+                        .withKeys(Collections.singletonList(request.getKey()));
+        return callOssMethod("Delete object", () -> {
+            com.aliyun.oss.model.DeleteObjectsResult ossResult = oss.deleteObjects(ossRequest);
+            return ossResult.getDeletedObjects().get(0);
         });
     }
 

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/objectstorage/cloud/client/AmazonCloudClient.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/objectstorage/cloud/client/AmazonCloudClient.java
@@ -51,6 +51,7 @@ import com.oceanbase.odc.core.shared.Verify;
 import com.oceanbase.odc.service.objectstorage.cloud.model.CompleteMultipartUploadRequest;
 import com.oceanbase.odc.service.objectstorage.cloud.model.CompleteMultipartUploadResult;
 import com.oceanbase.odc.service.objectstorage.cloud.model.CopyObjectResult;
+import com.oceanbase.odc.service.objectstorage.cloud.model.DeleteObjectRequest;
 import com.oceanbase.odc.service.objectstorage.cloud.model.DeleteObjectsRequest;
 import com.oceanbase.odc.service.objectstorage.cloud.model.DeleteObjectsResult;
 import com.oceanbase.odc.service.objectstorage.cloud.model.GetObjectRequest;
@@ -208,6 +209,16 @@ public class AmazonCloudClient implements CloudClient {
             result.setDeletedObjects(
                     s3Result.getDeletedObjects().stream().map(DeletedObject::getKey).collect(Collectors.toList()));
             return result;
+        });
+    }
+
+    @Override
+    public String deleteObject(DeleteObjectRequest request) throws CloudException {
+        com.amazonaws.services.s3.model.DeleteObjectRequest s3Request =
+                new com.amazonaws.services.s3.model.DeleteObjectRequest(request.getBucketName(), request.getKey());
+        return callAmazonMethod("Delete object", () -> {
+            s3.deleteObject(s3Request);
+            return s3Request.getKey();
         });
     }
 

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/objectstorage/cloud/client/NullCloudClient.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/objectstorage/cloud/client/NullCloudClient.java
@@ -24,6 +24,7 @@ import com.oceanbase.odc.core.shared.exception.UnsupportedException;
 import com.oceanbase.odc.service.objectstorage.cloud.model.CompleteMultipartUploadRequest;
 import com.oceanbase.odc.service.objectstorage.cloud.model.CompleteMultipartUploadResult;
 import com.oceanbase.odc.service.objectstorage.cloud.model.CopyObjectResult;
+import com.oceanbase.odc.service.objectstorage.cloud.model.DeleteObjectRequest;
 import com.oceanbase.odc.service.objectstorage.cloud.model.DeleteObjectsRequest;
 import com.oceanbase.odc.service.objectstorage.cloud.model.DeleteObjectsResult;
 import com.oceanbase.odc.service.objectstorage.cloud.model.GetObjectRequest;
@@ -84,6 +85,11 @@ public class NullCloudClient implements CloudClient {
 
     @Override
     public DeleteObjectsResult deleteObjects(DeleteObjectsRequest request) throws CloudException {
+        throw new UnsupportedException();
+    }
+
+    @Override
+    public String deleteObject(DeleteObjectRequest request) throws CloudException {
         throw new UnsupportedException();
     }
 

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/objectstorage/cloud/model/DeleteObjectRequest.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/objectstorage/cloud/model/DeleteObjectRequest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2023 OceanBase.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.oceanbase.odc.service.objectstorage.cloud.model;
+
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+/**
+ * @author: liuyizhuo.lyz
+ * @date: 2024/10/29
+ */
+@Data
+@EqualsAndHashCode(callSuper = true)
+public class DeleteObjectRequest extends GenericRequest {
+    public DeleteObjectRequest() {}
+
+    public DeleteObjectRequest(String bucketName) {
+        super(bucketName);
+    }
+
+    public DeleteObjectRequest(String bucketName, String key) {
+        super(bucketName, key);
+    }
+
+    public DeleteObjectRequest(String bucketName, String key, String versionId) {
+        super(bucketName, key, versionId);
+    }
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines.
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request.
3. Ensure you have added or ran the appropriate tests for your PR.
5. If the PR is unfinished, you may add or remove a WIP or [WIP] prefix to your pull request title.
-->

#### What type of PR is this?
type-feature
<!--
Add one of the following kinds:
type-bug
type-feature
type-docs
etc.

Optionally add one or more of the following kinds if applicable:
module-resultset
module-sql execution
etc.
-->

#### What this PR does / why we need it:

This PR uses the S3 SDK to support for Google Cloud Storage (GCS).
Most of the object storage operations currently supported by ODC are compatible with the S3 protocol in GCS.

However, please note that batch deletion in GCS is not compatible with the S3 SDK. Therefore, a separate `deleteObject` method has been added for deleting objects.