### PR TITLE
fix(pl-edit): procedure name in drop procedure statements are recognized as the table name in DBSchemaExtractor

### DIFF
--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/session/util/DBSchemaExtractor.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/session/util/DBSchemaExtractor.java
@@ -234,15 +234,6 @@ public class DBSchemaExtractor {
         }
 
         @Override
-        public RelationFactor visitDrop_view_stmt(
-                com.oceanbase.tools.sqlparser.obmysql.OBParser.Drop_view_stmtContext ctx) {
-            ctx.table_list().relation_factor().stream()
-                    .map(e -> MySQLFromReferenceFactory.getRelationFactor(e).getSchema()).distinct()
-                    .forEach(e -> identities.add(new DBSchemaIdentity(e, null)));
-            return null;
-        }
-
-        @Override
         public RelationFactor visitPartition_option(Partition_optionContext ctx) {
             return null;
         }
@@ -397,63 +388,54 @@ public class DBSchemaExtractor {
 
         @Override
         public RelationFactor visitDrop_package_stmt(OBParser.Drop_package_stmtContext ctx) {
-            String databaseName = ctx.relation_factor().normal_relation_factor().database_factor().getText();
-            if (databaseName != null) {
-                identities.add(new DBSchemaIdentity(databaseName, null));
+            RelationFactor relationFactor = OracleFromReferenceFactory.getRelationFactor(ctx.relation_factor());
+            if (relationFactor.getSchema() != null) {
+                identities.add(new DBSchemaIdentity(relationFactor.getSchema(), null));
             }
             return null;
         }
 
         @Override
         public RelationFactor visitDrop_procedure_stmt(OBParser.Drop_procedure_stmtContext ctx) {
-            String databaseName = ctx.relation_factor().normal_relation_factor().database_factor().getText();
-            if (databaseName != null) {
-                identities.add(new DBSchemaIdentity(databaseName, null));
+            RelationFactor relationFactor = OracleFromReferenceFactory.getRelationFactor(ctx.relation_factor());
+            if (relationFactor.getSchema() != null) {
+                identities.add(new DBSchemaIdentity(relationFactor.getSchema(), null));
             }
             return null;
         }
 
         @Override
         public RelationFactor visitDrop_function_stmt(OBParser.Drop_function_stmtContext ctx) {
-            String databaseName = ctx.relation_factor().normal_relation_factor().database_factor().getText();
-            if (databaseName != null) {
-                identities.add(new DBSchemaIdentity(databaseName, null));
+            RelationFactor relationFactor = OracleFromReferenceFactory.getRelationFactor(ctx.relation_factor());
+            if (relationFactor.getSchema() != null) {
+                identities.add(new DBSchemaIdentity(relationFactor.getSchema(), null));
             }
             return null;
         }
 
         @Override
         public RelationFactor visitDrop_trigger_stmt(OBParser.Drop_trigger_stmtContext ctx) {
-            String databaseName = ctx.relation_factor().normal_relation_factor().database_factor().getText();
-            if (databaseName != null) {
-                identities.add(new DBSchemaIdentity(databaseName, null));
+            RelationFactor relationFactor = OracleFromReferenceFactory.getRelationFactor(ctx.relation_factor());
+            if (relationFactor.getSchema() != null) {
+                identities.add(new DBSchemaIdentity(relationFactor.getSchema(), null));
             }
             return null;
         }
 
         @Override
         public RelationFactor visitDrop_type_stmt(OBParser.Drop_type_stmtContext ctx) {
-            String databaseName = ctx.relation_factor().normal_relation_factor().database_factor().getText();
-            if (databaseName != null) {
-                identities.add(new DBSchemaIdentity(databaseName, null));
-            }
-            return null;
-        }
-
-        @Override
-        public RelationFactor visitDrop_view_stmt(OBParser.Drop_view_stmtContext ctx) {
-            String databaseName = ctx.relation_factor().normal_relation_factor().database_factor().getText();
-            if (databaseName != null) {
-                identities.add(new DBSchemaIdentity(databaseName, null));
+            RelationFactor relationFactor = OracleFromReferenceFactory.getRelationFactor(ctx.relation_factor());
+            if (relationFactor.getSchema() != null) {
+                identities.add(new DBSchemaIdentity(relationFactor.getSchema(), null));
             }
             return null;
         }
 
         @Override
         public RelationFactor visitDrop_sequence_stmt(OBParser.Drop_sequence_stmtContext ctx) {
-            String databaseName = ctx.relation_factor().normal_relation_factor().database_factor().getText();
-            if (databaseName != null) {
-                identities.add(new DBSchemaIdentity(databaseName, null));
+            RelationFactor relationFactor = OracleFromReferenceFactory.getRelationFactor(ctx.relation_factor());
+            if (relationFactor.getSchema() != null) {
+                identities.add(new DBSchemaIdentity(relationFactor.getSchema(), null));
             }
             return null;
         }

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/session/util/DBSchemaExtractor.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/session/util/DBSchemaExtractor.java
@@ -200,6 +200,7 @@ public class DBSchemaExtractor {
 
         private final Set<DBSchemaIdentity> identities = new HashSet<>();
 
+        @Override
         public RelationFactor visitDrop_function_stmt(
                 com.oceanbase.tools.sqlparser.obmysql.OBParser.Drop_function_stmtContext ctx) {
             RelationFactor relationFactor = MySQLFromReferenceFactory.getRelationFactor(
@@ -210,6 +211,7 @@ public class DBSchemaExtractor {
             return null;
         }
 
+        @Override
         public RelationFactor visitDrop_procedure_stmt(
                 com.oceanbase.tools.sqlparser.obmysql.OBParser.Drop_procedure_stmtContext ctx) {
             RelationFactor relationFactor = MySQLFromReferenceFactory.getRelationFactor(
@@ -220,6 +222,7 @@ public class DBSchemaExtractor {
             return null;
         }
 
+        @Override
         public RelationFactor visitDrop_trigger_stmt(
                 com.oceanbase.tools.sqlparser.obmysql.OBParser.Drop_trigger_stmtContext ctx) {
             RelationFactor relationFactor = MySQLFromReferenceFactory.getRelationFactor(
@@ -227,6 +230,15 @@ public class DBSchemaExtractor {
             if (relationFactor.getSchema() != null) {
                 identities.add(new DBSchemaIdentity(relationFactor.getSchema(), null));
             }
+            return null;
+        }
+
+        @Override
+        public RelationFactor visitDrop_view_stmt(
+                com.oceanbase.tools.sqlparser.obmysql.OBParser.Drop_view_stmtContext ctx) {
+            ctx.table_list().relation_factor().stream()
+                    .map(e -> MySQLFromReferenceFactory.getRelationFactor(e).getSchema()).distinct()
+                    .forEach(e -> identities.add(new DBSchemaIdentity(e, null)));
             return null;
         }
 
@@ -382,6 +394,78 @@ public class DBSchemaExtractor {
             extends com.oceanbase.tools.sqlparser.oboracle.OBParserBaseVisitor<RelationFactor> {
 
         private final Set<DBSchemaIdentity> identities = new HashSet<>();
+
+        @Override
+        public RelationFactor visitDrop_package_stmt(OBParser.Drop_package_stmtContext ctx) {
+            String databaseName = ctx.relation_factor().normal_relation_factor().database_factor().getText();
+            if (databaseName != null) {
+                identities.add(new DBSchemaIdentity(databaseName, null));
+            }
+            return null;
+        }
+
+        @Override
+        public RelationFactor visitDrop_procedure_stmt(OBParser.Drop_procedure_stmtContext ctx) {
+            String databaseName = ctx.relation_factor().normal_relation_factor().database_factor().getText();
+            if (databaseName != null) {
+                identities.add(new DBSchemaIdentity(databaseName, null));
+            }
+            return null;
+        }
+
+        @Override
+        public RelationFactor visitDrop_function_stmt(OBParser.Drop_function_stmtContext ctx) {
+            String databaseName = ctx.relation_factor().normal_relation_factor().database_factor().getText();
+            if (databaseName != null) {
+                identities.add(new DBSchemaIdentity(databaseName, null));
+            }
+            return null;
+        }
+
+        @Override
+        public RelationFactor visitDrop_trigger_stmt(OBParser.Drop_trigger_stmtContext ctx) {
+            String databaseName = ctx.relation_factor().normal_relation_factor().database_factor().getText();
+            if (databaseName != null) {
+                identities.add(new DBSchemaIdentity(databaseName, null));
+            }
+            return null;
+        }
+
+        @Override
+        public RelationFactor visitDrop_type_stmt(OBParser.Drop_type_stmtContext ctx) {
+            String databaseName = ctx.relation_factor().normal_relation_factor().database_factor().getText();
+            if (databaseName != null) {
+                identities.add(new DBSchemaIdentity(databaseName, null));
+            }
+            return null;
+        }
+
+        @Override
+        public RelationFactor visitDrop_view_stmt(OBParser.Drop_view_stmtContext ctx) {
+            String databaseName = ctx.relation_factor().normal_relation_factor().database_factor().getText();
+            if (databaseName != null) {
+                identities.add(new DBSchemaIdentity(databaseName, null));
+            }
+            return null;
+        }
+
+        @Override
+        public RelationFactor visitDrop_sequence_stmt(OBParser.Drop_sequence_stmtContext ctx) {
+            String databaseName = ctx.relation_factor().normal_relation_factor().database_factor().getText();
+            if (databaseName != null) {
+                identities.add(new DBSchemaIdentity(databaseName, null));
+            }
+            return null;
+        }
+
+        @Override
+        public RelationFactor visitDrop_synonym_stmt(OBParser.Drop_synonym_stmtContext ctx) {
+            String databaseName = ctx.database_factor().getText();
+            if (databaseName != null) {
+                identities.add(new DBSchemaIdentity(databaseName, null));
+            }
+            return null;
+        }
 
         @Override
         public RelationFactor visitPartition_option(OBParser.Partition_optionContext ctx) {

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/session/util/DBSchemaExtractor.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/session/util/DBSchemaExtractor.java
@@ -200,6 +200,36 @@ public class DBSchemaExtractor {
 
         private final Set<DBSchemaIdentity> identities = new HashSet<>();
 
+        public RelationFactor visitDrop_function_stmt(
+                com.oceanbase.tools.sqlparser.obmysql.OBParser.Drop_function_stmtContext ctx) {
+            RelationFactor relationFactor = MySQLFromReferenceFactory.getRelationFactor(
+                    ctx.relation_factor().normal_relation_factor());
+            if (relationFactor.getSchema() != null) {
+                identities.add(new DBSchemaIdentity(relationFactor.getSchema(), null));
+            }
+            return null;
+        }
+
+        public RelationFactor visitDrop_procedure_stmt(
+                com.oceanbase.tools.sqlparser.obmysql.OBParser.Drop_procedure_stmtContext ctx) {
+            RelationFactor relationFactor = MySQLFromReferenceFactory.getRelationFactor(
+                    ctx.relation_factor().normal_relation_factor());
+            if (relationFactor.getSchema() != null) {
+                identities.add(new DBSchemaIdentity(relationFactor.getSchema(), null));
+            }
+            return null;
+        }
+
+        public RelationFactor visitDrop_trigger_stmt(
+                com.oceanbase.tools.sqlparser.obmysql.OBParser.Drop_trigger_stmtContext ctx) {
+            RelationFactor relationFactor = MySQLFromReferenceFactory.getRelationFactor(
+                    ctx.relation_factor().normal_relation_factor());
+            if (relationFactor.getSchema() != null) {
+                identities.add(new DBSchemaIdentity(relationFactor.getSchema(), null));
+            }
+            return null;
+        }
+
         @Override
         public RelationFactor visitPartition_option(Partition_optionContext ctx) {
             return null;

--- a/server/odc-service/src/test/resources/session/test_db_schema_extractor.yaml
+++ b/server/odc-service/src/test/resources/session/test_db_schema_extractor.yaml
@@ -184,7 +184,7 @@
   sqls:
     - "SELECT * FROM DB1.TABLE1@FAKE_DBLINK;"
   expected: [ ]
-# access ob mysql function ,procedure and trigger
+# drop function ,procedure and trigger
 - id: 23
   dialect_type: OB_MYSQL
   default_schema: DEFAULT_SCHEMA
@@ -209,3 +209,97 @@
   expected:
     - schema: db1
       table: ~
+- id: 26
+  dialect_type: OB_ORACLE
+  default_schema: DEFAULT_SCHEMA
+  sqls:
+    - "DROP FUNCTION DB1.FUNC1"
+  expected:
+    - schema: DB1
+      table: ~
+- id: 27
+  dialect_type: OB_ORACLE
+  default_schema: DEFAULT_SCHEMA
+  sqls:
+    - "DROP PROCEDURE DB1.PROC1"
+  expected:
+    - schema: DB1
+      table: ~
+- id: 28
+  dialect_type: OB_ORACLE
+  default_schema: DEFAULT_SCHEMA
+  sqls:
+    - "DROP TRIGGER DB1.TRIGGER1"
+  expected:
+    - schema: DB1
+      table: ~
+#drop sequence、type、package、synonym、public synonym for ob oracle
+- id: 29
+  dialect_type: OB_ORACLE
+  default_schema: DEFAULT_SCHEMA
+  sqls:
+    - "DROP SEQUENCE DB1.SEQ1"
+  expected:
+    - schema: DB1
+      table: ~
+- id: 30
+  dialect_type: OB_ORACLE
+  default_schema: DEFAULT_SCHEMA
+  sqls:
+    - "DROP TYPE DB1.TYPE1"
+  expected:
+    - schema: DB1
+      table: ~
+- id: 31
+  dialect_type: OB_ORACLE
+  default_schema: DEFAULT_SCHEMA
+  sqls:
+    - "DROP PACKAGE DB1.PACKAGE1"
+  expected:
+    - schema: DB1
+      table: ~
+- id: 32
+  dialect_type: OB_ORACLE
+  default_schema: DEFAULT_SCHEMA
+  sqls:
+    - "DROP SYNONYM DB1.SYNONYM1"
+  expected:
+    - schema: DB1
+      table: ~
+- id : 33
+  dialect_type: OB_ORACLE
+  default_schema: DEFAULT_SCHEMA
+  sqls:
+    - "DROP PUBLIC SYNONYM DB1.SYNONYM1"
+  expected:
+    - schema: DB1
+      table: ~
+# drop view
+- id: 34
+  dialect_type: OB_ORACLE
+  default_schema: DEFAULT_SCHEMA
+  sqls:
+    - "DROP VIEW DB1.VIEW1"
+  expected:
+    - schema: DB1
+      table: ~
+- id: 35
+  dialect_type: OB_MYSQL
+  default_schema: DEFAULT_SCHEMA
+  sqls:
+    - "DROP VIEW DB1.VIEW1"
+  expected:
+    - schema: DB1
+      table: ~
+- id: 36
+  dialect_type: OB_MYSQL
+  default_schema: DEFAULT_SCHEMA
+  sqls:
+    - "DROP VIEW DB1.VIEW1,DB2.VIEW2"
+  expected:
+    - schema: DB1
+      table: ~
+    - schema: DB2
+      table: ~
+
+

--- a/server/odc-service/src/test/resources/session/test_db_schema_extractor.yaml
+++ b/server/odc-service/src/test/resources/session/test_db_schema_extractor.yaml
@@ -184,3 +184,28 @@
   sqls:
     - "SELECT * FROM DB1.TABLE1@FAKE_DBLINK;"
   expected: [ ]
+# acess ob mysql function ,procedure and trigger
+- id: 23
+  dialect_type: OB_MYSQL
+  default_schema: DEFAULT_SCHEMA
+  sqls:
+    - "drop function db1.func1"
+  expected:
+    - schema: db1
+      table: ~
+- id: 24
+  dialect_type: OB_MYSQL
+  default_schema: DEFAULT_SCHEMA
+  sqls:
+    - "drop procedure db1.proc1"
+  expected:
+    - schema: db1
+      table: ~
+- id: 25
+  dialect_type: OB_MYSQL
+  default_schema: DEFAULT_SCHEMA
+  sqls:
+    - "drop trigger db1.trigger1"
+  expected:
+    - schema: db1
+      table: ~

--- a/server/odc-service/src/test/resources/session/test_db_schema_extractor.yaml
+++ b/server/odc-service/src/test/resources/session/test_db_schema_extractor.yaml
@@ -274,32 +274,5 @@
   expected:
     - schema: DB1
       table: ~
-# drop view
-- id: 34
-  dialect_type: OB_ORACLE
-  default_schema: DEFAULT_SCHEMA
-  sqls:
-    - "DROP VIEW DB1.VIEW1"
-  expected:
-    - schema: DB1
-      table: ~
-- id: 35
-  dialect_type: OB_MYSQL
-  default_schema: DEFAULT_SCHEMA
-  sqls:
-    - "DROP VIEW DB1.VIEW1"
-  expected:
-    - schema: DB1
-      table: ~
-- id: 36
-  dialect_type: OB_MYSQL
-  default_schema: DEFAULT_SCHEMA
-  sqls:
-    - "DROP VIEW DB1.VIEW1,DB2.VIEW2"
-  expected:
-    - schema: DB1
-      table: ~
-    - schema: DB2
-      table: ~
 
 

--- a/server/odc-service/src/test/resources/session/test_db_schema_extractor.yaml
+++ b/server/odc-service/src/test/resources/session/test_db_schema_extractor.yaml
@@ -184,7 +184,7 @@
   sqls:
     - "SELECT * FROM DB1.TABLE1@FAKE_DBLINK;"
   expected: [ ]
-# acess ob mysql function ,procedure and trigger
+# access ob mysql function ,procedure and trigger
 - id: 23
   dialect_type: OB_MYSQL
   default_schema: DEFAULT_SCHEMA


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines.
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request.
3. Ensure you have added or ran the appropriate tests for your PR.
5. If the PR is unfinished, you may add or remove a WIP or [WIP] prefix to your pull request title.
-->

#### What type of PR is this?
type-bug
<!--
Add one of the following kinds:
type-bug
type-feature
type-docs
etc.

Optionally add one or more of the following kinds if applicable:
module-resultset
module-sql execution
etc.
-->

#### What this PR does / why we need it:
![image](https://github.com/user-attachments/assets/8753b29c-bff7-461c-be2c-21a747aed124)
When doing pl editing ,procedure name in drop procedure statement is recognized as the table name, which trigger the table permission check.
the improved approach is to have DBSchemaExtractor omit the procedure name when extracting the table names
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

<!--
This section is used to describe how this PR is implemented. 
If this is a PR that fixes a bug, this section describes how the bug was fixed.
If it's a new feature, this section briefly describes how to implement the new feature.
etc.
-->

#### Additional documentation e.g., usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```