### PR TITLE
fix(DefaultSqlExecuteTaskManager): npe in DefaultSqlExecuteTaskManager

### DIFF
--- a/server/odc-core/src/main/java/com/oceanbase/odc/core/sql/execute/task/DefaultSqlExecuteTaskManager.java
+++ b/server/odc-core/src/main/java/com/oceanbase/odc/core/sql/execute/task/DefaultSqlExecuteTaskManager.java
@@ -15,9 +15,9 @@
  */
 package com.oceanbase.odc.core.sql.execute.task;
 
-import java.util.LinkedList;
-import java.util.List;
+import java.util.Collection;
 import java.util.concurrent.Callable;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.Future;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.Semaphore;
@@ -50,7 +50,7 @@ public class DefaultSqlExecuteTaskManager extends DefaultTaskManager implements 
     private final int maxConcurrentTaskCount;
     private final Semaphore taskCountSemaphore;
     private final long waitingTimeoutForSubmitTask;
-    private final List<Future<?>> activeFuture;
+    private final Collection<Future<?>> activeFuture;
 
     public DefaultSqlExecuteTaskManager(int maxConcurrentTaskCount) {
         this(maxConcurrentTaskCount, "default", 10, TimeUnit.SECONDS);
@@ -73,7 +73,7 @@ public class DefaultSqlExecuteTaskManager extends DefaultTaskManager implements 
         this.taskCountSemaphore = new Semaphore(maxConcurrentTaskCount);
         Validate.isTrue(timeout > 0, "Timeout can not be negative");
         this.waitingTimeoutForSubmitTask = TimeUnit.MILLISECONDS.convert(timeout, timeUnit);
-        this.activeFuture = new LinkedList<>();
+        this.activeFuture = new ConcurrentLinkedQueue<>();
     }
 
     @Override

--- a/server/odc-core/src/main/java/com/oceanbase/odc/core/sql/execute/task/DefaultSqlExecuteTaskManager.java
+++ b/server/odc-core/src/main/java/com/oceanbase/odc/core/sql/execute/task/DefaultSqlExecuteTaskManager.java
@@ -15,7 +15,6 @@
  */
 package com.oceanbase.odc.core.sql.execute.task;
 
-import java.util.Collection;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.Future;

--- a/server/odc-core/src/main/java/com/oceanbase/odc/core/sql/execute/task/DefaultSqlExecuteTaskManager.java
+++ b/server/odc-core/src/main/java/com/oceanbase/odc/core/sql/execute/task/DefaultSqlExecuteTaskManager.java
@@ -50,7 +50,7 @@ public class DefaultSqlExecuteTaskManager extends DefaultTaskManager implements 
     private final int maxConcurrentTaskCount;
     private final Semaphore taskCountSemaphore;
     private final long waitingTimeoutForSubmitTask;
-    private final Collection<Future<?>> activeFuture;
+    private final ConcurrentLinkedQueue<Future<?>> activeFuture;
 
     public DefaultSqlExecuteTaskManager(int maxConcurrentTaskCount) {
         this(maxConcurrentTaskCount, "default", 10, TimeUnit.SECONDS);


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines.
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request.
3. Ensure you have added or ran the appropriate tests for your PR.
5. If the PR is unfinished, you may add or remove a WIP or [WIP] prefix to your pull request title.
-->

#### What type of PR is this?
type-bug
<!--
Add one of the following kinds:
type-bug
type-feature
type-docs
etc.

Optionally add one or more of the following kinds if applicable:
module-resultset
module-sql execution
etc.
-->

#### What this PR does / why we need it:
Use LinkedList is concurrent unsafe ，replace with ConcurrentLinkedQueue. 
Concurrent access to LinkedList may result in npe
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

<!--
This section is used to describe how this PR is implemented. 
If this is a PR that fixes a bug, this section describes how the bug was fixed.
If it's a new feature, this section briefly describes how to implement the new feature.
etc.
-->

#### Additional documentation e.g., usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```