### PR TITLE
feat(cloud): add getConfiguration method in CloudMetadataClient

### DIFF
--- a/server/odc-service/src/main/java/com/oceanbase/odc/config/BeanConfiguration.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/config/BeanConfiguration.java
@@ -207,7 +207,7 @@ public class BeanConfiguration {
         }
 
         @Override
-        public com.oceanbase.odc.service.config.model.Configuration getConfiguration(String projectId, String action) {
+        public com.oceanbase.odc.service.config.model.Configuration getConfiguration(String projectId, String key) {
             throw new UnsupportedException("CloudMetadata not supported");
         }
     }

--- a/server/odc-service/src/main/java/com/oceanbase/odc/config/BeanConfiguration.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/config/BeanConfiguration.java
@@ -205,6 +205,11 @@ public class BeanConfiguration {
         public void deleteDatabaseUsers(String instanceId, String tenantId, List<String> users) {
             throw new UnsupportedException("CloudMetadata not supported");
         }
+
+        @Override
+        public com.oceanbase.odc.service.config.model.Configuration getConfiguration(String projectId, String action) {
+            throw new UnsupportedException("CloudMetadata not supported");
+        }
     }
 
     /**

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/connection/CloudMetadataClient.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/connection/CloudMetadataClient.java
@@ -22,6 +22,7 @@ import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 
 import com.oceanbase.odc.core.authority.exception.AccessDeniedException;
+import com.oceanbase.odc.service.config.model.Configuration;
 import com.oceanbase.odc.service.connection.model.OBDatabaseUser;
 import com.oceanbase.odc.service.connection.model.OBInstance;
 import com.oceanbase.odc.service.connection.model.OBInstanceType;
@@ -91,6 +92,8 @@ public interface CloudMetadataClient {
             Map<String, String> roles);
 
     void deleteDatabaseUsers(String instanceId, String tenantId, List<String> users);
+
+    Configuration getConfiguration(@NotBlank String projectId, @NotBlank String action);
 
     enum CloudPermissionAction {
         READONLY,

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/connection/CloudMetadataClient.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/connection/CloudMetadataClient.java
@@ -93,7 +93,7 @@ public interface CloudMetadataClient {
 
     void deleteDatabaseUsers(String instanceId, String tenantId, List<String> users);
 
-    Configuration getConfiguration(@NotBlank String projectId, @NotBlank String action);
+    Configuration getConfiguration(@NotBlank String projectId, @NotBlank String key);
 
     enum CloudPermissionAction {
         READONLY,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines.
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request.
3. Ensure you have added or ran the appropriate tests for your PR.
5. If the PR is unfinished, you may add or remove a WIP or [WIP] prefix to your pull request title.
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
type-bug
type-feature
type-docs
etc.

Optionally add one or more of the following kinds if applicable:
module-resultset
module-sql execution
etc.
-->

#### What this PR does / why we need it:
add getConfiguration method in CloudMetadataClient
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

<!--
This section is used to describe how this PR is implemented. 
If this is a PR that fixes a bug, this section describes how the bug was fixed.
If it's a new feature, this section briefly describes how to implement the new feature.
etc.
-->

#### Additional documentation e.g., usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```