### PR TITLE
fix(db): The method of determining whether opening the global client session is incorrect

### DIFF
--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/db/session/DefaultDBSessionManage.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/db/session/DefaultDBSessionManage.java
@@ -310,6 +310,7 @@ public class DefaultDBSessionManage implements DBSessionManageFacade {
                         int columnIndex = rs.findColumn("time");
                         return columnIndex > 0;
                     } catch (SQLException e) {
+                        log.warn("Failed to find the column 'time' in the result set", e);
                         return false;
                     }
                 });

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/db/session/DefaultDBSessionManage.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/db/session/DefaultDBSessionManage.java
@@ -18,6 +18,7 @@ package com.oceanbase.odc.service.db.session;
 import static com.oceanbase.odc.core.shared.constant.DialectType.OB_MYSQL;
 
 import java.sql.Connection;
+import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -300,38 +301,18 @@ public class DefaultDBSessionManage implements DBSessionManageFacade {
                 || VersionUtils.isLessThan(obVersion, GLOBAL_CLIENT_SESSION_OB_VERSION_NUMBER)) {
             return false;
         }
-        try {
-            Integer proxyId = getOBProxyConfig(connectionSession, "proxy_id");
-            Integer clientSessionIdVersion = getOBProxyConfig(connectionSession, "client_session_id_version");
-
-            return proxyId != null
-                    && proxyId >= GLOBAL_CLIENT_SESSION_PROXY_ID_MIN
-                    && proxyId <= GLOBAL_CLIENT_SESSION_PROXY_ID_MAX
-                    && clientSessionIdVersion != null
-                    && clientSessionIdVersion == GLOBAL_CLIENT_SESSION_ID_VERSION;
-        } catch (Exception e) {
-            log.warn("Failed to determine if global client session is enabled: {}", e.getMessage());
-            return false;
-        }
-    }
-
-    /**
-     * Gets the value of OBProxy's configuration variable If an exception occurs or the version does not
-     * support, return null.
-     * 
-     * @param connectionSession
-     * @param configName
-     * @return
-     */
-    private Integer getOBProxyConfig(ConnectionSession connectionSession, String configName) {
-        try {
-            return connectionSession.getSyncJdbcExecutor(ConnectionSessionConstants.BACKEND_DS_KEY)
-                    .query("show proxyconfig like '" + configName + "';",
-                            rs -> rs.next() ? rs.getInt("value") : null);
-        } catch (Exception e) {
-            log.warn("Failed to obtain the value of OBProxy's configuration variable: {}", e.getMessage());
-            return null;
-        }
+        // Check whether the global session is open
+        // If the global session is open, the "time" column will be displayed in the result set after
+        // executing the sql statement of "show processlist"
+        return connectionSession.getSyncJdbcExecutor(ConnectionSessionConstants.BACKEND_DS_KEY)
+                .query("show processlist", rs -> {
+                    try {
+                        int columnIndex = rs.findColumn("time");
+                        return columnIndex > 0;
+                    } catch (SQLException e) {
+                        return false;
+                    }
+                });
     }
 
     private boolean isUnknownThreadIdError(Exception e) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines.
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request.
3. Ensure you have added or ran the appropriate tests for your PR.
5. If the PR is unfinished, you may add or remove a WIP or [WIP] prefix to your pull request title.
-->

#### What type of PR is this?
type-bug
<!--
Add one of the following kinds:
type-bug
type-feature
type-docs
etc.

Optionally add one or more of the following kinds if applicable:
module-resultset
module-sql execution
etc.
-->

#### What this PR does / why we need it:
The current method for determining whether a global session is enabled applies only to `system` tenants, but not to `mysql` and `oralce` tenants. Instead, should adopt this way that determining whether the result set after running `show processlist` contains the column `time`.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

<!--
This section is used to describe how this PR is implemented. 
If this is a PR that fixes a bug, this section describes how the bug was fixed.
If it's a new feature, this section briefly describes how to implement the new feature.
etc.
-->

#### Additional documentation e.g., usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```