### PR TITLE
fix(workflow): add dfa transfer from unknown state

### DIFF
--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/resource/k8s/status/K8sDeploymentStatusDfa.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/resource/k8s/status/K8sDeploymentStatusDfa.java
@@ -65,7 +65,7 @@ public class K8sDeploymentStatusDfa extends AbstractDfa<ResourceState, K8sDeploy
         transfers.addAll(new K8sResourceStatusTransferBuilder<K8sDeployment>().from(ResourceState.UNKNOWN)
                 .matchesK8sResource(getErrorDeploymentMatchers(current)).to(ResourceState.ERROR_STATE).build());
         transfers.addAll(new K8sResourceStatusTransferBuilder<K8sDeployment>().from(ResourceState.UNKNOWN)
-                .matchesK8sResource(getErrorDeploymentMatchers(current)).to(ResourceState.DESTROYED).build());
+                .matchesK8sResource(Collections.singletonList(Objects::isNull)).to(ResourceState.DESTROYED).build());
         return new K8sDeploymentStatusDfa(transfers);
     }
 

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/resource/k8s/status/K8sDeploymentStatusDfa.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/resource/k8s/status/K8sDeploymentStatusDfa.java
@@ -60,6 +60,12 @@ public class K8sDeploymentStatusDfa extends AbstractDfa<ResourceState, K8sDeploy
                 .matchesK8sResource(Collections.singletonList(Objects::isNull)).to(ResourceState.DESTROYED).build());
         transfers.addAll(new K8sResourceStatusTransferBuilder<K8sDeployment>().from(ResourceState.DESTROYING)
                 .matchesK8sResource(Collections.singletonList(Objects::nonNull)).to(ResourceState.DESTROYING).build());
+        transfers.addAll(new K8sResourceStatusTransferBuilder<K8sDeployment>().from(ResourceState.UNKNOWN)
+                .matchesK8sResource(getAvailableDeploymentMatchers(current)).to(ResourceState.AVAILABLE).build());
+        transfers.addAll(new K8sResourceStatusTransferBuilder<K8sDeployment>().from(ResourceState.UNKNOWN)
+                .matchesK8sResource(getErrorDeploymentMatchers(current)).to(ResourceState.ERROR_STATE).build());
+        transfers.addAll(new K8sResourceStatusTransferBuilder<K8sDeployment>().from(ResourceState.UNKNOWN)
+                .matchesK8sResource(getErrorDeploymentMatchers(current)).to(ResourceState.DESTROYED).build());
         return new K8sDeploymentStatusDfa(transfers);
     }
 

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/resource/k8s/status/K8sServiceStatusDfa.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/resource/k8s/status/K8sServiceStatusDfa.java
@@ -58,6 +58,12 @@ public class K8sServiceStatusDfa extends AbstractDfa<ResourceState, K8sService> 
         transfers.addAll(new K8sResourceStatusTransferBuilder<K8sService>()
                 .from(ResourceState.DESTROYING)
                 .matchesK8sResource(getNonNullMatchers()).to(ResourceState.DESTROYING).build());
+        transfers.addAll(new K8sResourceStatusTransferBuilder<K8sService>()
+                .from(ResourceState.UNKNOWN)
+                .matchesK8sResource(getNonNullMatchers()).to(ResourceState.AVAILABLE).build());
+        transfers.addAll(new K8sResourceStatusTransferBuilder<K8sService>()
+                .from(ResourceState.UNKNOWN)
+                .matchesK8sResource(getNonNullMatchers()).to(ResourceState.DESTROYED).build());
         return new K8sServiceStatusDfa(transfers);
     }
 

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/resource/k8s/status/K8sServiceStatusDfa.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/resource/k8s/status/K8sServiceStatusDfa.java
@@ -63,7 +63,7 @@ public class K8sServiceStatusDfa extends AbstractDfa<ResourceState, K8sService> 
                 .matchesK8sResource(getNonNullMatchers()).to(ResourceState.AVAILABLE).build());
         transfers.addAll(new K8sResourceStatusTransferBuilder<K8sService>()
                 .from(ResourceState.UNKNOWN)
-                .matchesK8sResource(getNonNullMatchers()).to(ResourceState.DESTROYED).build());
+                .matchesK8sResource(getNullMatchers()).to(ResourceState.DESTROYED).build());
         return new K8sServiceStatusDfa(transfers);
     }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines.
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request.
3. Ensure you have added or ran the appropriate tests for your PR.
5. If the PR is unfinished, you may add or remove a WIP or [WIP] prefix to your pull request title.
-->

#### What type of PR is this?
type-bug
<!--
Add one of the following kinds:
type-bug
type-feature
type-docs
etc.

Optionally add one or more of the following kinds if applicable:
module-resultset
module-sql execution
etc.
-->

#### What this PR does / why we need it:
Now when k8s resource's state is UNKNOWN, it would be it's final state. And when the real resource is back to normal , the state could not be changed.