### PR TITLE
fix(structure-compare):the structure synchronization task cannot be initiated when the structure comparison task is not created by yourself

### DIFF
--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/structurecompare/StructureComparisonService.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/structurecompare/StructureComparisonService.java
@@ -106,7 +106,7 @@ public class StructureComparisonService {
         try {
             StorageObject storageObject =
                     objectStorageFacade.loadObject("structure-comparison".concat(File.separator)
-                            .concat(authenticationFacade.currentUserIdStr()), taskEntity.getStorageObjectId());
+                            .concat(String.valueOf(taskEntity.getCreatorId())), taskEntity.getStorageObjectId());
             Validate.notNull(storageObject, "StorageObject can not be null");
             Validate.notNull(storageObject.getMetadata(), "ObjectMetadata can not be null");
             if (storageObject.getMetadata().getTotalLength() > MAX_TOTAL_SCRIPT_SIZE_BYTES) {


### PR DESCRIPTION

#### What type of PR is this?
type-bug

#### What this PR does / why we need it:
fix the structure synchronization task cannot be initiated when the structure comparison task is not created by yourself, because the object storage is isolated by user id so that user1 can not see user2's object storage.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

<!--
This section is used to describe how this PR is implemented. 
If this is a PR that fixes a bug, this section describes how the bug was fixed.
If it's a new feature, this section briefly describes how to implement the new feature.
etc.
-->

#### Additional documentation e.g., usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```