### PR TITLE
fix(db-browser):can not get the precision of year data type column

### DIFF
--- a/libs/db-browser/src/main/java/com/oceanbase/tools/dbbrowser/schema/mysql/MySQLNoLessThan5700SchemaAccessor.java
+++ b/libs/db-browser/src/main/java/com/oceanbase/tools/dbbrowser/schema/mysql/MySQLNoLessThan5700SchemaAccessor.java
@@ -121,6 +121,7 @@ public class MySQLNoLessThan5700SchemaAccessor implements DBSchemaAccessor {
         SPECIAL_TYPE_NAMES.add("bigint");
         SPECIAL_TYPE_NAMES.add("float");
         SPECIAL_TYPE_NAMES.add("double");
+        SPECIAL_TYPE_NAMES.add("year");
     }
 
     public MySQLNoLessThan5700SchemaAccessor(@NonNull JdbcOperations jdbcOperations) {
@@ -572,6 +573,9 @@ public class MySQLNoLessThan5700SchemaAccessor implements DBSchemaAccessor {
         if (SPECIAL_TYPE_NAMES.contains(Objects.isNull(typeName) ? null : typeName.toLowerCase())) {
             String precisionAndScale = DBSchemaAccessorUtil.parsePrecisionAndScale(column.getFullTypeName());
             if (StringUtils.isBlank(precisionAndScale)) {
+                if ("year".equalsIgnoreCase(typeName)) {
+                    column.setPrecision(4L);
+                }
                 return;
             }
             DBColumnTypeDisplay display = DBColumnTypeDisplay.fromName(typeName);

--- a/libs/db-browser/src/test/java/com/oceanbase/tools/dbbrowser/schema/MySQLNoLessThan5700SchemaAccessorTest.java
+++ b/libs/db-browser/src/test/java/com/oceanbase/tools/dbbrowser/schema/MySQLNoLessThan5700SchemaAccessorTest.java
@@ -373,7 +373,7 @@ public class MySQLNoLessThan5700SchemaAccessorTest extends BaseTestEnv {
                 DataType.of("col24", "time", 0, 0L, 0, null),
                 DataType.of("col25", "date", 0, null, 0, null),
                 DataType.of("col26", "datetime", 0, 0L, 0, null),
-                DataType.of("col27", "year", 0, 0L, 0, null)));
+                DataType.of("col27", "year", 4, 4L, 0, null)));
     }
 
     @Data


### PR DESCRIPTION


#### What type of PR is this?
type-bug

#### What this PR does / why we need it:
fix can not get the precision of year data type column.
The precision of the year field type can only be 4，It can be declared as YEAR with an implicit display width of 4 characters, or equivalently as YEAR(4) with an explicit display width. We can only get the precision by parse COLUMN_TYPE or use default width of 4 .
<img width="1599" alt="image" src="https://github.com/user-attachments/assets/5004b7eb-54df-4c8f-afb7-4c18c9cb65df" />
<img width="1362" alt="image" src="https://github.com/user-attachments/assets/85612d88-c0f7-4602-8eb6-dcc2722d6d72" />


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #3713

#### Special notes for your reviewer:

<!--
This section is used to describe how this PR is implemented. 
If this is a PR that fixes a bug, this section describes how the bug was fixed.
If it's a new feature, this section briefly describes how to implement the new feature.
etc.
-->

#### Additional documentation e.g., usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```