### PR TITLE
fix(logicaldatabase): it may NPE when the logical database task starts

### DIFF
--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/task/base/logicdatabasechange/LogicalDatabaseChangeTask.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/task/base/logicdatabasechange/LogicalDatabaseChangeTask.java
@@ -21,6 +21,7 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -78,16 +79,16 @@ public class LogicalDatabaseChangeTask extends TaskBase<Map<String, ExecutionRes
     public LogicalDatabaseChangeTask() {}
 
     @Override
-    protected void doInit(JobContext context) throws Exception {
+    protected void doInit(JobContext context) {
         Map<String, String> jobParameters = context.getJobParameters();
         taskParameters = JsonUtils.fromJson(jobParameters.get(JobParametersKeyConstants.TASK_PARAMETER_JSON_KEY),
                 PublishLogicalDatabaseChangeReq.class);
         sqlRewriter = new RelationFactorRewriter();
         executionGroups = new ArrayList<>();
+        initExecutorContext();
     }
 
-    @Override
-    public boolean start() throws Exception {
+    private void initExecutorContext() {
         try {
             DialectType dialectType = taskParameters.getLogicalDatabaseResp().getDialectType();
             DetailLogicalDatabaseResp detailLogicalDatabaseResp = taskParameters.getLogicalDatabaseResp();
@@ -180,6 +181,13 @@ public class LogicalDatabaseChangeTask extends TaskBase<Map<String, ExecutionRes
         } catch (Exception ex) {
             log.warn("start logical database change task failed, ", ex);
             context.getExceptionListener().onException(ex);
+        }
+    }
+
+    @Override
+    public boolean start() throws Exception {
+        if (Objects.isNull(this.executionGroupContext)) {
+            log.warn("logical database change task is not initialized");
             return false;
         }
         while (!Thread.currentThread().isInterrupted()) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines.
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request.
3. Ensure you have added or ran the appropriate tests for your PR.
5. If the PR is unfinished, you may add or remove a WIP or [WIP] prefix to your pull request title.
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
type-bug
type-feature
type-docs
etc.

Optionally add one or more of the following kinds if applicable:
module-resultset
module-sql execution
etc.
-->
type-bug
#### What this PR does / why we need it:
The logical database task may have NPE in the log, but the task will success.
This is because when `TaskMonitor` call `getTaskResult`, the `executionGroupContext` may be null.
I fixed this by moving the process of init the `executionGroupContext` into `doInit` method.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

<!--
This section is used to describe how this PR is implemented. 
If this is a PR that fixes a bug, this section describes how the bug was fixed.
If it's a new feature, this section briefly describes how to implement the new feature.
etc.
-->

#### Additional documentation e.g., usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```