### PR TITLE
fix(migrate): vectorydb only load on server mode

### DIFF
--- a/server/odc-migrate/src/main/java/com/oceanbase/odc/migrate/VectorDBMigrate.java
+++ b/server/odc-migrate/src/main/java/com/oceanbase/odc/migrate/VectorDBMigrate.java
@@ -31,6 +31,7 @@ import org.springframework.integration.jdbc.lock.JdbcLockRegistry;
 
 import com.oceanbase.odc.core.migrate.MigrateConfiguration;
 import com.oceanbase.odc.core.migrate.resource.model.ResourceConfig;
+import com.oceanbase.odc.service.common.ConditionOnServer;
 import com.oceanbase.odc.service.common.migrate.DefaultValueEncoderFactory;
 import com.oceanbase.odc.service.common.migrate.DefaultValueGeneratorFactory;
 import com.oceanbase.odc.service.common.migrate.ResourceConstants;
@@ -38,6 +39,7 @@ import com.oceanbase.odc.service.common.migrate.ResourceConstants;
 @Configuration
 @DependsOn({"vectordbLockConfiguration"})
 @ConditionalOnProperty(prefix = "odc.datasource.vectordb", name = {"url", "driver-class-name", "username", "password"})
+@ConditionOnServer
 public class VectorDBMigrate extends AbstractMigrate {
 
     @Autowired


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines.
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request.
3. Ensure you have added or ran the appropriate tests for your PR.
5. If the PR is unfinished, you may add or remove a WIP or [WIP] prefix to your pull request title.
-->

#### What type of PR is this?
type-bug



<!--
Add one of the following kinds:
type-bug
type-feature
type-docs
etc.

Optionally add one or more of the following kinds if applicable:
module-resultset
module-sql execution
etc.
-->

#### What this PR does / why we need it:
VectorDBMigrate only load on server mode.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

<!--
This section is used to describe how this PR is implemented. 
If this is a PR that fixes a bug, this section describes how the bug was fixed.
If it's a new feature, this section briefly describes how to implement the new feature.
etc.
-->

#### Additional documentation e.g., usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```