### PR TITLE
fix(session): killing session may fail due to a wrong regex

### DIFF
--- a/server/odc-common/src/main/java/com/oceanbase/odc/common/util/HostUtils.java
+++ b/server/odc-common/src/main/java/com/oceanbase/odc/common/util/HostUtils.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2023 OceanBase.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.oceanbase.odc.common.util;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import javax.validation.constraints.NotNull;
+
+import lombok.Data;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * @Author: Lebie
+ * @Date: 2025/1/15 13:47
+ * @Description: []
+ */
+@Slf4j
+public class HostUtils {
+    // valid expression examples: 0.0.0.0:8888, 127.1:8888, etc
+    private static final String SERVER_REGEX = "(?<ip>([0-9]{1,3}\\.){1,3}([0-9]{1,3})):(?<port>[0-9]{1,5})";
+    private static final Pattern SERVER_PATTERN = Pattern.compile(SERVER_REGEX);
+
+
+    @NotNull
+    public static ServerAddress extractServerAddress(String ipAndPort) {
+        String trimmed = StringUtils.trim(ipAndPort);
+        if (StringUtils.isBlank(trimmed)) {
+            log.info("unable to extract server address, text is empty");
+            throw new IllegalArgumentException("Empty server address!");
+        }
+        Matcher matcher = SERVER_PATTERN.matcher(trimmed);
+        if (!matcher.matches()) {
+            log.info("unable to extract server address, does not match pattern");
+            throw new IllegalArgumentException("Invalid server address!");
+        }
+        String ipAddress = matcher.group("ip");
+        String port = matcher.group("port");
+        if (StringUtils.isEmpty(ipAddress) || StringUtils.isEmpty(port)) {
+            log.info("unable to extract server address, ipAddress={}, port={}", ipAddress, port);
+            throw new IllegalArgumentException("Invalid server address!");
+        }
+        return new ServerAddress(ipAddress, port);
+    }
+
+
+
+    @Data
+    public static class ServerAddress {
+        String ipAddress;
+        String port;
+
+        public ServerAddress(String ipAddress, String port) {
+            this.ipAddress = ipAddress;
+            this.port = port;
+        }
+    }
+}

--- a/server/odc-common/src/main/java/com/oceanbase/odc/common/util/HostUtils.java
+++ b/server/odc-common/src/main/java/com/oceanbase/odc/common/util/HostUtils.java
@@ -15,9 +15,6 @@
  */
 package com.oceanbase.odc.common.util;
 
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
 import javax.validation.constraints.NotNull;
 
 import lombok.Data;
@@ -30,10 +27,6 @@ import lombok.extern.slf4j.Slf4j;
  */
 @Slf4j
 public class HostUtils {
-    // valid expression examples: 0.0.0.0:8888, 127.1:8888, etc
-    private static final String SERVER_REGEX = "(?<ip>([0-9]{1,3}\\.){1,3}([0-9]{1,3})):(?<port>[0-9]{1,5})";
-    private static final Pattern SERVER_PATTERN = Pattern.compile(SERVER_REGEX);
-
 
     @NotNull
     public static ServerAddress extractServerAddress(String ipAndPort) {
@@ -42,18 +35,16 @@ public class HostUtils {
             log.info("unable to extract server address, text is empty");
             throw new IllegalArgumentException("Empty server address!");
         }
-        Matcher matcher = SERVER_PATTERN.matcher(trimmed);
-        if (!matcher.matches()) {
-            log.info("unable to extract server address, does not match pattern");
+        String[] segments = StringUtils.split(trimmed, ":");
+        if (segments.length != 2) {
+            log.info("unable to extract server address, segments={}", segments);
             throw new IllegalArgumentException("Invalid server address!");
         }
-        String ipAddress = matcher.group("ip");
-        String port = matcher.group("port");
-        if (StringUtils.isEmpty(ipAddress) || StringUtils.isEmpty(port)) {
-            log.info("unable to extract server address, ipAddress={}, port={}", ipAddress, port);
+        if (StringUtils.isEmpty(segments[0]) || StringUtils.isEmpty(segments[1])) {
+            log.info("unable to extract server address, segments={}", segments);
             throw new IllegalArgumentException("Invalid server address!");
         }
-        return new ServerAddress(ipAddress, port);
+        return new ServerAddress(segments[0], segments[1]);
     }
 
 

--- a/server/odc-common/src/test/java/com/oceanbase/odc/common/util/HostUtilsTest.java
+++ b/server/odc-common/src/test/java/com/oceanbase/odc/common/util/HostUtilsTest.java
@@ -31,14 +31,8 @@ public class HostUtilsTest {
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void testExtractServerAddress_InvalidExpression1() {
-        String ipAndPort = "1.1.1.1.1:1234";
-        HostUtils.extractServerAddress(ipAndPort);
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void testExtractServerAddress_InvalidExpression2() {
-        String ipAndPort = "1.1.1?1:1234";
+    public void testExtractServerAddress_InvalidExpression() {
+        String ipAndPort = "1.1.1.1";
         HostUtils.extractServerAddress(ipAndPort);
     }
 }

--- a/server/odc-common/src/test/java/com/oceanbase/odc/common/util/HostUtilsTest.java
+++ b/server/odc-common/src/test/java/com/oceanbase/odc/common/util/HostUtilsTest.java
@@ -35,4 +35,10 @@ public class HostUtilsTest {
         String ipAndPort = "1.1.1.1.1:1234";
         HostUtils.extractServerAddress(ipAndPort);
     }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testExtractServerAddress_InvalidExpression2() {
+        String ipAndPort = "1.1.1?1:1234";
+        HostUtils.extractServerAddress(ipAndPort);
+    }
 }

--- a/server/odc-common/src/test/java/com/oceanbase/odc/common/util/HostUtilsTest.java
+++ b/server/odc-common/src/test/java/com/oceanbase/odc/common/util/HostUtilsTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2023 OceanBase.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.oceanbase.odc.common.util;
+
+import org.junit.Test;
+
+import com.oceanbase.odc.common.util.HostUtils.ServerAddress;
+
+import junit.framework.Assert;
+
+public class HostUtilsTest {
+    @Test
+    public void testExtractServerAddress_ValidExpression() {
+        String ipAndPort = "1.1.1.1:1234";
+        ServerAddress actual = HostUtils.extractServerAddress(ipAndPort);
+        Assert.assertEquals("1.1.1.1", actual.getIpAddress());
+        Assert.assertEquals("1234", actual.getPort());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testExtractServerAddress_InvalidExpression1() {
+        String ipAndPort = "1.1.1.1.1:1234";
+        HostUtils.extractServerAddress(ipAndPort);
+    }
+}

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/db/session/DefaultDBSessionManage.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/db/session/DefaultDBSessionManage.java
@@ -35,11 +35,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
-
-import javax.validation.constraints.NotNull;
 
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.SetUtils;
@@ -48,6 +44,8 @@ import org.springframework.stereotype.Service;
 
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.Lists;
+import com.oceanbase.odc.common.util.HostUtils;
+import com.oceanbase.odc.common.util.HostUtils.ServerAddress;
 import com.oceanbase.odc.common.util.StringUtils;
 import com.oceanbase.odc.common.util.VersionUtils;
 import com.oceanbase.odc.core.authority.util.SkipAuthorize;
@@ -82,9 +80,6 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class DefaultDBSessionManage implements DBSessionManageFacade {
 
-    private static final String SERVER_REGEX = ".*(?<ip>([0-9]{1,3}.){1,3}([0-9]{1,3})):"
-            + "(?<port>[0-9]{1,5}).*";
-    private static final Pattern SERVER_PATTERN = Pattern.compile(SERVER_REGEX);
     private static final ConnectionMapper CONNECTION_MAPPER = ConnectionMapper.INSTANCE;
     private static final String GLOBAL_CLIENT_SESSION_OB_PROXY_VERSION_NUMBER = "4.2.3";
     private static final String GLOBAL_CLIENT_SESSION_OB_VERSION_NUMBER = "4.2.5";
@@ -237,7 +232,7 @@ public class DefaultDBSessionManage implements DBSessionManageFacade {
         Map<String, ServerAddress> sessionId2SvrAddr =
                 getSessionList(connectionSession, s -> s.getSvrIp() != null)
                         .stream().collect(Collectors.toMap(OdcDBSession::getSessionId,
-                                s -> extractServerAddress(MoreObjects.firstNonNull(s.getSvrIp(), ""))));
+                                s -> HostUtils.extractServerAddress(MoreObjects.firstNonNull(s.getSvrIp(), ""))));
         Map<String, String> sqlId2SessionId = sqlTupleSessionIds.stream().collect(
                 Collectors.toMap(s -> s.getSqlTuple().getSqlId(), SqlTupleSessionId::getSessionId));
 
@@ -424,28 +419,6 @@ public class DefaultDBSessionManage implements DBSessionManageFacade {
         }
     }
 
-    // extract text(query from the dictionary) to server address(ip, port)
-    // the text is expected be like 0.0.0.0:8888
-    @NotNull
-    private ServerAddress extractServerAddress(String text) {
-        String trimmed = StringUtils.trim(text);
-        if (StringUtils.isBlank(trimmed)) {
-            log.info("unable to extract server address, text is empty");
-            throw new IllegalStateException("Empty server address!");
-        }
-        Matcher matcher = SERVER_PATTERN.matcher(trimmed);
-        if (!matcher.matches()) {
-            log.info("unable to extract server address, does not match pattern");
-            throw new IllegalStateException("Invalid server address!");
-        }
-        String ipAddress = matcher.group("ip");
-        String port = matcher.group("port");
-        if (StringUtils.isEmpty(ipAddress) || StringUtils.isEmpty(port)) {
-            log.info("unable to extract server address, ipAddress={}, port={}", ipAddress, port);
-            throw new IllegalStateException("Invalid server address!");
-        }
-        return new ServerAddress(ipAddress, port);
-    }
 
     private CompletableFuture<Void> doKillAllSessions(List<OdcDBSession> list, ConnectionSession connectionSession,
             Executor executor) {
@@ -474,17 +447,6 @@ public class DefaultDBSessionManage implements DBSessionManageFacade {
         } catch (InterruptedException | ExecutionException | TimeoutException e) {
             log.warn("Kill all sessions occur error", e);
             throw new IllegalStateException("Kill all sessions occur error", e);
-        }
-    }
-
-    @Data
-    static class ServerAddress {
-        String ipAddress;
-        String port;
-
-        public ServerAddress(String ipAddress, String port) {
-            this.ipAddress = ipAddress;
-            this.port = port;
         }
     }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines.
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request.
3. Ensure you have added or ran the appropriate tests for your PR.
5. If the PR is unfinished, you may add or remove a WIP or [WIP] prefix to your pull request title.
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
type-bug
type-feature
type-docs
etc.

Optionally add one or more of the following kinds if applicable:
module-resultset
module-sql execution
etc.
-->
type-bug
#### What this PR does / why we need it:
The previous regex to extract observer IP and port is wrong. This regular expression has two issues:
1. It allows any characters before and after, which can cause logical errors. For example, with an input like 1.1.1.1:8888, the IP will be captured as 1.1 instead of 1.1.1.1 because .* is a greedy pattern that tries to match as many characters as possible. 
3. The dot (.) is not escaped, which means it matches any character in regex, but it should actually represent the dot (.) itself.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

<!--
This section is used to describe how this PR is implemented. 
If this is a PR that fixes a bug, this section describes how the bug was fixed.
If it's a new feature, this section briefly describes how to implement the new feature.
etc.
-->

#### Additional documentation e.g., usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```