### PR TITLE
fix(datatransfer): failed to re-import odc exported zip file

### DIFF
--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/datatransfer/task/DataTransferTask.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/datatransfer/task/DataTransferTask.java
@@ -364,7 +364,7 @@ public class DataTransferTask implements Callable<DataTransferTaskResult> {
         exportOutput.toFolder(destDir);
         LOGGER.info("Extract file to working dir, from={}, dest={}", from.getAbsolutePath(),
                 destDir.getAbsolutePath());
-        return exportOutput;
+        return new ExportOutput(destDir);
     }
 
     private void copyExportedFiles(DataTransferTaskResult result, String exportPath) {


### PR DESCRIPTION

#### What this PR does / why we need it:

4.3.3 would fail to re-import odc exported zip file.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

<!--
This section is used to describe how this PR is implemented. 
If this is a PR that fixes a bug, this section describes how the bug was fixed.
If it's a new feature, this section briefly describes how to implement the new feature.
etc.
-->

#### Additional documentation e.g., usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```