### PR TITLE
fix(sql-execute): nls_format invalidation

### DIFF
--- a/server/integration-test/src/test/java/com/oceanbase/odc/service/session/NlsFormatInterceptorTest.java
+++ b/server/integration-test/src/test/java/com/oceanbase/odc/service/session/NlsFormatInterceptorTest.java
@@ -96,7 +96,7 @@ public class NlsFormatInterceptorTest {
         NlsFormatInterceptor interceptor = new NlsFormatInterceptor();
         String expect = "DD-MON-RR";
         SqlExecuteResult r = getResponse("-- comment\nset nls_date_format='" + expect + "';",
-            SqlExecuteStatus.SUCCESS);
+                SqlExecuteStatus.SUCCESS);
         interceptor.afterCompletion(r, session, getContext());
         Assert.assertEquals(expect, ConnectionSessionUtil.getNlsDateFormat(session));
     }

--- a/server/integration-test/src/test/java/com/oceanbase/odc/service/session/NlsFormatInterceptorTest.java
+++ b/server/integration-test/src/test/java/com/oceanbase/odc/service/session/NlsFormatInterceptorTest.java
@@ -91,6 +91,17 @@ public class NlsFormatInterceptorTest {
     }
 
     @Test
+    public void afterCompletion_commentWithSetVar_withoutScope_setSucceed() throws Exception {
+        ConnectionSession session = getConnectionSession(ConnectType.OB_ORACLE);
+        NlsFormatInterceptor interceptor = new NlsFormatInterceptor();
+        String expect = "DD-MON-RR";
+        SqlExecuteResult r = getResponse("-- comment\nset nls_date_format='" + expect + "';",
+            SqlExecuteStatus.SUCCESS);
+        interceptor.afterCompletion(r, session, getContext());
+        Assert.assertEquals(expect, ConnectionSessionUtil.getNlsDateFormat(session));
+    }
+
+    @Test
     public void afterCompletion_multiCommentsWithSetVar_setSucceed() throws Exception {
         ConnectionSession session = getConnectionSession(ConnectType.OB_ORACLE);
         NlsFormatInterceptor interceptor = new NlsFormatInterceptor();

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/session/interceptor/NlsFormatInterceptor.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/session/interceptor/NlsFormatInterceptor.java
@@ -195,7 +195,7 @@ public class NlsFormatInterceptor extends BaseTimeConsumingInterceptor {
                             .generate();
                 }
                 name = ctx.sys_var_and_val().obj_access_ref_normal().getText();
-            } else if (ctx.set_expr_or_default() != null ) {
+            } else if (ctx.set_expr_or_default() != null) {
                 if (ctx.set_expr_or_default().bit_expr() != null) {
                     value = new OracleExpressionFactory(ctx.set_expr_or_default().bit_expr()).generate();
                 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines.
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request.
3. Ensure you have added or ran the appropriate tests for your PR.
5. If the PR is unfinished, you may add or remove a WIP or [WIP] prefix to your pull request title.
-->

#### What type of PR is this?
type-bug
<!--
Add one of the following kinds:
type-bug
type-feature
type-docs
etc.

Optionally add one or more of the following kinds if applicable:
module-resultset
module-sql execution
etc.
-->

#### What this PR does / why we need it:
The NlsFormatInterceptor failed to recognize statement like `set variables='xxx'`.
![image](https://github.com/user-attachments/assets/bae7b3aa-b479-48eb-bbbe-5ff32c017ec2)


![image](https://github.com/user-attachments/assets/60744b03-b612-4f4e-966f-8368b16d1a05)
