### PR TITLE
adaption(obcloud): deploy new independent ODC 433 cluster for OBCloud

### DIFF
--- a/server/integration-test/src/test/java/com/oceanbase/odc/AuthorityTestEnv.java
+++ b/server/integration-test/src/test/java/com/oceanbase/odc/AuthorityTestEnv.java
@@ -39,6 +39,8 @@ import com.oceanbase.odc.metadb.iam.RolePermissionEntity;
 import com.oceanbase.odc.metadb.iam.RolePermissionRepository;
 import com.oceanbase.odc.metadb.iam.RoleRepository;
 import com.oceanbase.odc.metadb.iam.UserEntity;
+import com.oceanbase.odc.metadb.iam.UserOrganizationEntity;
+import com.oceanbase.odc.metadb.iam.UserOrganizationRepository;
 import com.oceanbase.odc.metadb.iam.UserPermissionRepository;
 import com.oceanbase.odc.metadb.iam.UserRepository;
 import com.oceanbase.odc.metadb.iam.UserRoleEntity;
@@ -52,6 +54,8 @@ public abstract class AuthorityTestEnv extends ServiceTestEnv {
 
     @Autowired
     protected UserRepository userRepository;
+    @Autowired
+    protected UserOrganizationRepository userOrganizationRepository;
 
     @Autowired
     protected RoleRepository roleRepository;
@@ -108,7 +112,13 @@ public abstract class AuthorityTestEnv extends ServiceTestEnv {
         entity.setActive(true);
         entity.setEnabled(true);
         entity.setDescription("internal for unit test");
-        return userRepository.saveAndFlush(entity);
+
+        UserEntity user = userRepository.saveAndFlush(entity);
+        UserOrganizationEntity userOrganizationEntity = new UserOrganizationEntity();
+        userOrganizationEntity.setOrganizationId(user.getOrganizationId());
+        userOrganizationEntity.setUserId(user.getId());
+        userOrganizationRepository.saveAndFlush(userOrganizationEntity);
+        return user;
     }
 
     protected RoleEntity createRole() {

--- a/server/integration-test/src/test/java/com/oceanbase/odc/authority/ResourceBindToSingleOrganizationValueProviderTest.java
+++ b/server/integration-test/src/test/java/com/oceanbase/odc/authority/ResourceBindToSingleOrganizationValueProviderTest.java
@@ -38,7 +38,7 @@ import com.oceanbase.odc.service.regulation.approval.model.ApprovalFlowConfig;
  * @date 2021-08-04 14:31
  * @since ODC-release_3.2.0
  */
-public class OrganizationIsolatedValueProviderTest {
+public class ResourceBindToSingleOrganizationValueProviderTest {
 
     @Test
     public void testListReturnValueOrganizationIsolated_success() {

--- a/server/integration-test/src/test/java/com/oceanbase/odc/authority/SingleOrganizationResourceValueProviderTest.java
+++ b/server/integration-test/src/test/java/com/oceanbase/odc/authority/SingleOrganizationResourceValueProviderTest.java
@@ -38,7 +38,7 @@ import com.oceanbase.odc.service.regulation.approval.model.ApprovalFlowConfig;
  * @date 2021-08-04 14:31
  * @since ODC-release_3.2.0
  */
-public class ResourceBindToSingleOrganizationValueProviderTest {
+public class SingleOrganizationResourceValueProviderTest {
 
     @Test
     public void testListReturnValueOrganizationIsolated_success() {

--- a/server/odc-core/src/main/java/com/oceanbase/odc/core/authority/BaseValueFilterSecurityManager.java
+++ b/server/odc-core/src/main/java/com/oceanbase/odc/core/authority/BaseValueFilterSecurityManager.java
@@ -26,7 +26,7 @@ import com.oceanbase.odc.core.authority.auth.ReturnValueProvider;
 import com.oceanbase.odc.core.authority.auth.SecurityContext;
 import com.oceanbase.odc.core.authority.exception.AccessDeniedException;
 import com.oceanbase.odc.core.authority.model.SecurityResource;
-import com.oceanbase.odc.core.shared.OrganizationIsolated;
+import com.oceanbase.odc.core.shared.OrganizationResource;
 
 import lombok.Getter;
 import lombok.NonNull;
@@ -67,7 +67,7 @@ abstract class BaseValueFilterSecurityManager extends BaseAuthorizerSecurityMana
     public Object decide(Subject subject, Object returnValue, SecurityContext context)
             throws AccessDeniedException {
         if (returnValue instanceof SecurityResource || returnValue instanceof Iterable
-                || returnValue instanceof Map || returnValue instanceof OrganizationIsolated) {
+                || returnValue instanceof Map || returnValue instanceof OrganizationResource) {
             return this.returnValueProvider.decide(subject, returnValue, context);
         }
         return returnValue;

--- a/server/odc-core/src/main/java/com/oceanbase/odc/core/shared/MultiOrganizationResource.java
+++ b/server/odc-core/src/main/java/com/oceanbase/odc/core/shared/MultiOrganizationResource.java
@@ -15,7 +15,11 @@
  */
 package com.oceanbase.odc.core.shared;
 
-public interface ResourceBindToSingleOrganization extends OrganizationResource {
-    Long organizationId();
+import java.util.Set;
 
+/**
+ * Organization resource bind to multi organizations.
+ */
+public interface MultiOrganizationResource extends OrganizationResource {
+    Set<Long> organizationIds();
 }

--- a/server/odc-core/src/main/java/com/oceanbase/odc/core/shared/OrganizationResource.java
+++ b/server/odc-core/src/main/java/com/oceanbase/odc/core/shared/OrganizationResource.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2023 OceanBase.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.oceanbase.odc.core.shared;
+
+/**
+ * @author jingtian
+ * @date 2025/1/14
+ */
+public interface OrganizationResource {
+    String resourceType();
+
+    Long id();
+}

--- a/server/odc-core/src/main/java/com/oceanbase/odc/core/shared/ResourceBindToMultiOrganizations.java
+++ b/server/odc-core/src/main/java/com/oceanbase/odc/core/shared/ResourceBindToMultiOrganizations.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2023 OceanBase.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.oceanbase.odc.core.shared;
+
+import java.util.Set;
+
+public interface ResourceBindToMultiOrganizations extends OrganizationResource {
+    Set<Long> organizationIds();
+}

--- a/server/odc-core/src/main/java/com/oceanbase/odc/core/shared/ResourceBindToSingleOrganization.java
+++ b/server/odc-core/src/main/java/com/oceanbase/odc/core/shared/ResourceBindToSingleOrganization.java
@@ -15,12 +15,7 @@
  */
 package com.oceanbase.odc.core.shared;
 
-public interface OrganizationIsolated {
-
-    String resourceType();
-
+public interface ResourceBindToSingleOrganization extends OrganizationResource {
     Long organizationId();
-
-    Long id();
 
 }

--- a/server/odc-core/src/main/java/com/oceanbase/odc/core/shared/SingleOrganizationResource.java
+++ b/server/odc-core/src/main/java/com/oceanbase/odc/core/shared/SingleOrganizationResource.java
@@ -15,8 +15,10 @@
  */
 package com.oceanbase.odc.core.shared;
 
-import java.util.Set;
+/**
+ * Organization resource bind to single organization.
+ */
+public interface SingleOrganizationResource extends OrganizationResource {
+    Long organizationId();
 
-public interface ResourceBindToMultiOrganizations extends OrganizationResource {
-    Set<Long> organizationIds();
 }

--- a/server/odc-server/src/main/java/com/oceanbase/odc/server/web/controller/v2/CloudMetadataController.java
+++ b/server/odc-server/src/main/java/com/oceanbase/odc/server/web/controller/v2/CloudMetadataController.java
@@ -15,10 +15,13 @@
  */
 package com.oceanbase.odc.server.web.controller.v2;
 
+import java.util.Objects;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.oceanbase.odc.service.common.response.ListResponse;
@@ -38,8 +41,13 @@ public class CloudMetadataController {
 
     @ApiOperation(value = "listInstances", notes = "Cloud Metadata list instances")
     @RequestMapping(value = "/clusters", method = RequestMethod.GET)
-    public ListResponse<OBInstance> listInstances() {
-        return Responses.list(cloudMetadataClient.listInstances());
+    public ListResponse<OBInstance> listInstances(
+            @RequestParam(required = false, name = "organizationId") Long organizationId) {
+        if (Objects.nonNull(organizationId)) {
+            return Responses.list(cloudMetadataClient.listInstances(organizationId));
+        } else {
+            return Responses.list(cloudMetadataClient.listInstances());
+        }
     }
 
     @ApiOperation(value = "listTenants", notes = "Cloud Metadata list tenants by instanceId")

--- a/server/odc-service/src/main/java/com/oceanbase/odc/config/BeanConfiguration.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/config/BeanConfiguration.java
@@ -152,6 +152,11 @@ public class BeanConfiguration {
         }
 
         @Override
+        public List<OBInstance> listInstances(Long organizationId) {
+            throw new UnsupportedException("CloudMetadata not supported");
+        }
+
+        @Override
         public List<OBTenant> listTenants(String instanceId) {
             throw new UnsupportedException("CloudMetadata not supported");
         }

--- a/server/odc-service/src/main/java/com/oceanbase/odc/metadb/iam/OrganizationRepository.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/metadb/iam/OrganizationRepository.java
@@ -15,6 +15,7 @@
  */
 package com.oceanbase.odc.metadb.iam;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
@@ -32,6 +33,7 @@ public interface OrganizationRepository
 
     Optional<OrganizationEntity> findByUniqueIdentifier(String uniqueIdentifier);
 
+    List<OrganizationEntity> findByUniqueIdentifierIn(Collection<String> uniqueIdentifiers);
 
     Optional<OrganizationEntity> findByName(String name);
 

--- a/server/odc-service/src/main/java/com/oceanbase/odc/metadb/iam/UserOrganizationRepository.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/metadb/iam/UserOrganizationRepository.java
@@ -15,6 +15,8 @@
  */
 package com.oceanbase.odc.metadb.iam;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.transaction.annotation.Transactional;
@@ -27,4 +29,6 @@ public interface UserOrganizationRepository extends JpaRepository<UserOrganizati
 
     @Transactional
     int deleteByUserIdAndOrganizationId(Long userId, Long organizationId);
+
+    List<UserOrganizationEntity> findByOrganizationId(Long organizationId);
 }

--- a/server/odc-service/src/main/java/com/oceanbase/odc/metadb/iam/UserOrganizationRepository.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/metadb/iam/UserOrganizationRepository.java
@@ -16,9 +16,12 @@
 package com.oceanbase.odc.metadb.iam;
 
 import java.util.List;
+import java.util.Set;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.transaction.annotation.Transactional;
 
 public interface UserOrganizationRepository extends JpaRepository<UserOrganizationEntity, Long>,
@@ -31,4 +34,7 @@ public interface UserOrganizationRepository extends JpaRepository<UserOrganizati
     int deleteByUserIdAndOrganizationId(Long userId, Long organizationId);
 
     List<UserOrganizationEntity> findByOrganizationId(Long organizationId);
+
+    @Query("select e.organizationId from UserOrganizationEntity e where e.userId=:userId")
+    Set<Long> findAllOrganizationIdByUserId(@Param("userId") Long userId);
 }

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/automation/model/AutomationRule.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/automation/model/AutomationRule.java
@@ -20,7 +20,7 @@ import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonProperty.Access;
-import com.oceanbase.odc.core.shared.OrganizationIsolated;
+import com.oceanbase.odc.core.shared.ResourceBindToSingleOrganization;
 import com.oceanbase.odc.core.shared.constant.ResourceType;
 import com.oceanbase.odc.metadb.automation.AutomationRuleEntity;
 
@@ -32,7 +32,7 @@ import lombok.Data;
  */
 
 @Data
-public class AutomationRule implements OrganizationIsolated {
+public class AutomationRule implements ResourceBindToSingleOrganization {
     @JsonProperty(access = Access.READ_ONLY)
     private Long id;
     private String name;

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/automation/model/AutomationRule.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/automation/model/AutomationRule.java
@@ -20,7 +20,7 @@ import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonProperty.Access;
-import com.oceanbase.odc.core.shared.ResourceBindToSingleOrganization;
+import com.oceanbase.odc.core.shared.SingleOrganizationResource;
 import com.oceanbase.odc.core.shared.constant.ResourceType;
 import com.oceanbase.odc.metadb.automation.AutomationRuleEntity;
 
@@ -32,7 +32,7 @@ import lombok.Data;
  */
 
 @Data
-public class AutomationRule implements ResourceBindToSingleOrganization {
+public class AutomationRule implements SingleOrganizationResource {
     @JsonProperty(access = Access.READ_ONLY)
     private Long id;
     private String name;

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/collaboration/environment/model/Environment.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/collaboration/environment/model/Environment.java
@@ -24,7 +24,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonProperty.Access;
 import com.oceanbase.odc.common.i18n.Internationalizable;
 import com.oceanbase.odc.core.authority.model.SecurityResource;
-import com.oceanbase.odc.core.shared.OrganizationIsolated;
+import com.oceanbase.odc.core.shared.ResourceBindToSingleOrganization;
 import com.oceanbase.odc.core.shared.constant.ResourceType;
 import com.oceanbase.odc.service.common.model.InnerUser;
 
@@ -41,7 +41,7 @@ import lombok.NonNull;
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
-public class Environment implements SecurityResource, OrganizationIsolated, Serializable {
+public class Environment implements SecurityResource, ResourceBindToSingleOrganization, Serializable {
     @JsonProperty(access = Access.READ_ONLY)
     private Long id;
 

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/collaboration/environment/model/Environment.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/collaboration/environment/model/Environment.java
@@ -24,7 +24,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonProperty.Access;
 import com.oceanbase.odc.common.i18n.Internationalizable;
 import com.oceanbase.odc.core.authority.model.SecurityResource;
-import com.oceanbase.odc.core.shared.ResourceBindToSingleOrganization;
+import com.oceanbase.odc.core.shared.SingleOrganizationResource;
 import com.oceanbase.odc.core.shared.constant.ResourceType;
 import com.oceanbase.odc.service.common.model.InnerUser;
 
@@ -41,7 +41,7 @@ import lombok.NonNull;
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
-public class Environment implements SecurityResource, ResourceBindToSingleOrganization, Serializable {
+public class Environment implements SecurityResource, SingleOrganizationResource, Serializable {
     @JsonProperty(access = Access.READ_ONLY)
     private Long id;
 

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/collaboration/project/model/Project.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/collaboration/project/model/Project.java
@@ -27,7 +27,7 @@ import com.fasterxml.jackson.annotation.JsonProperty.Access;
 import com.oceanbase.odc.common.i18n.Internationalizable;
 import com.oceanbase.odc.common.validate.Name;
 import com.oceanbase.odc.core.authority.model.SecurityResource;
-import com.oceanbase.odc.core.shared.ResourceBindToSingleOrganization;
+import com.oceanbase.odc.core.shared.SingleOrganizationResource;
 import com.oceanbase.odc.core.shared.constant.ResourceRoleName;
 import com.oceanbase.odc.core.shared.constant.ResourceType;
 import com.oceanbase.odc.service.common.model.InnerUser;
@@ -44,7 +44,7 @@ import lombok.NoArgsConstructor;
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
-public class Project implements SecurityResource, ResourceBindToSingleOrganization, Serializable {
+public class Project implements SecurityResource, SingleOrganizationResource, Serializable {
     @JsonProperty(access = Access.READ_ONLY)
     private Long id;
 

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/collaboration/project/model/Project.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/collaboration/project/model/Project.java
@@ -27,7 +27,7 @@ import com.fasterxml.jackson.annotation.JsonProperty.Access;
 import com.oceanbase.odc.common.i18n.Internationalizable;
 import com.oceanbase.odc.common.validate.Name;
 import com.oceanbase.odc.core.authority.model.SecurityResource;
-import com.oceanbase.odc.core.shared.OrganizationIsolated;
+import com.oceanbase.odc.core.shared.ResourceBindToSingleOrganization;
 import com.oceanbase.odc.core.shared.constant.ResourceRoleName;
 import com.oceanbase.odc.core.shared.constant.ResourceType;
 import com.oceanbase.odc.service.common.model.InnerUser;
@@ -44,7 +44,7 @@ import lombok.NoArgsConstructor;
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
-public class Project implements SecurityResource, OrganizationIsolated, Serializable {
+public class Project implements SecurityResource, ResourceBindToSingleOrganization, Serializable {
     @JsonProperty(access = Access.READ_ONLY)
     private Long id;
 

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/connection/CloudMetadataClient.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/connection/CloudMetadataClient.java
@@ -65,6 +65,11 @@ public interface CloudMetadataClient {
     List<OBInstance> listInstances();
 
     /**
+     * List all oceanbase instances under an organization
+     */
+    List<OBInstance> listInstances(Long organizationId);
+
+    /**
      * 获取集群下租户列表
      */
     List<OBTenant> listTenants(@NotBlank String instanceId);

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/connection/database/model/Database.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/connection/database/model/Database.java
@@ -27,7 +27,7 @@ import javax.validation.constraints.NotNull;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonProperty.Access;
 import com.oceanbase.odc.core.authority.model.SecurityResource;
-import com.oceanbase.odc.core.shared.OrganizationIsolated;
+import com.oceanbase.odc.core.shared.ResourceBindToSingleOrganization;
 import com.oceanbase.odc.core.shared.constant.ConnectType;
 import com.oceanbase.odc.core.shared.constant.DialectType;
 import com.oceanbase.odc.core.shared.constant.ResourceType;
@@ -46,7 +46,7 @@ import lombok.Data;
  * @Description: []
  */
 @Data
-public class Database implements SecurityResource, OrganizationIsolated, Serializable {
+public class Database implements SecurityResource, ResourceBindToSingleOrganization, Serializable {
 
     private static final long serialVersionUID = 729227718029437346L;
 

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/connection/database/model/Database.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/connection/database/model/Database.java
@@ -27,7 +27,7 @@ import javax.validation.constraints.NotNull;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonProperty.Access;
 import com.oceanbase.odc.core.authority.model.SecurityResource;
-import com.oceanbase.odc.core.shared.ResourceBindToSingleOrganization;
+import com.oceanbase.odc.core.shared.SingleOrganizationResource;
 import com.oceanbase.odc.core.shared.constant.ConnectType;
 import com.oceanbase.odc.core.shared.constant.DialectType;
 import com.oceanbase.odc.core.shared.constant.ResourceType;
@@ -46,7 +46,7 @@ import lombok.Data;
  * @Description: []
  */
 @Data
-public class Database implements SecurityResource, ResourceBindToSingleOrganization, Serializable {
+public class Database implements SecurityResource, SingleOrganizationResource, Serializable {
 
     private static final long serialVersionUID = 729227718029437346L;
 

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/connection/model/CloudConnectionConfig.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/connection/model/CloudConnectionConfig.java
@@ -30,6 +30,8 @@ public interface CloudConnectionConfig {
 
     OBInstanceRoleType getInstanceRoleType();
 
+    Long getOrganizationId();
+
     void setClusterName(String clusterName);
 
     void setTenantName(String tenantName);

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/connection/model/ConnectionConfig.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/connection/model/ConnectionConfig.java
@@ -39,7 +39,7 @@ import com.oceanbase.odc.common.validate.Name;
 import com.oceanbase.odc.core.authority.model.SecurityResource;
 import com.oceanbase.odc.core.session.ConnectionSessionUtil;
 import com.oceanbase.odc.core.shared.PreConditions;
-import com.oceanbase.odc.core.shared.ResourceBindToSingleOrganization;
+import com.oceanbase.odc.core.shared.SingleOrganizationResource;
 import com.oceanbase.odc.core.shared.constant.Cipher;
 import com.oceanbase.odc.core.shared.constant.ConnectEnvironmentType;
 import com.oceanbase.odc.core.shared.constant.ConnectType;
@@ -66,7 +66,7 @@ import lombok.ToString;
 @ToString(exclude = {"salt", "password", "sysTenantPassword", "readonlyPassword",
         "passwordEncrypted", "sysTenantPasswordEncrypted", "readonlyPasswordEncrypted", "sslFileEntry"})
 public class ConnectionConfig
-        implements SecurityResource, ResourceBindToSingleOrganization, CloudConnectionConfig, SSLConnectionConfig,
+        implements SecurityResource, SingleOrganizationResource, CloudConnectionConfig, SSLConnectionConfig,
         Serializable {
     private static final long serialVersionUID = -7198204983655038981L;
     private static final String SESSION_INIT_SCRIPT_KEY = "SESSION_INIT_SCRIPT";

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/connection/model/ConnectionConfig.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/connection/model/ConnectionConfig.java
@@ -38,8 +38,8 @@ import com.oceanbase.odc.common.util.StringUtils;
 import com.oceanbase.odc.common.validate.Name;
 import com.oceanbase.odc.core.authority.model.SecurityResource;
 import com.oceanbase.odc.core.session.ConnectionSessionUtil;
-import com.oceanbase.odc.core.shared.OrganizationIsolated;
 import com.oceanbase.odc.core.shared.PreConditions;
+import com.oceanbase.odc.core.shared.ResourceBindToSingleOrganization;
 import com.oceanbase.odc.core.shared.constant.Cipher;
 import com.oceanbase.odc.core.shared.constant.ConnectEnvironmentType;
 import com.oceanbase.odc.core.shared.constant.ConnectType;
@@ -66,7 +66,8 @@ import lombok.ToString;
 @ToString(exclude = {"salt", "password", "sysTenantPassword", "readonlyPassword",
         "passwordEncrypted", "sysTenantPasswordEncrypted", "readonlyPasswordEncrypted", "sslFileEntry"})
 public class ConnectionConfig
-        implements SecurityResource, OrganizationIsolated, CloudConnectionConfig, SSLConnectionConfig, Serializable {
+        implements SecurityResource, ResourceBindToSingleOrganization, CloudConnectionConfig, SSLConnectionConfig,
+        Serializable {
     private static final long serialVersionUID = -7198204983655038981L;
     private static final String SESSION_INIT_SCRIPT_KEY = "SESSION_INIT_SCRIPT";
     private static final String JDBC_URL_PARAMETERS_KEY = "JDBC_URL_PARAMETERS";

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/connection/model/OBInstance.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/connection/model/OBInstance.java
@@ -41,7 +41,7 @@ public class OBInstance {
     /**
      * 实例类型
      */
-    @JsonAlias("instanceType")
+    @JsonAlias({"instanceType", "type"})
     private OBInstanceType type;
 
     /**

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/connection/model/OBInstanceType.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/connection/model/OBInstanceType.java
@@ -21,16 +21,18 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import com.oceanbase.odc.common.i18n.Translatable;
 
 import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * @Author: Lebie
  * @Date: 2022/10/25 下午4:56
  * @Description: [公有云/多云 实例类型，公有云支持集群实例、MySQL 租户实例 和 Oracle 租户实例；多云目前只有 集群实例、租户实例、AP实例]
  */
+@Slf4j
 public enum OBInstanceType implements Translatable {
     CLUSTER("cluster"),
-    MYSQL_TENANT("mtenant"),
-    ORACLE_TENANT("otenant"),
+    MYSQL_TENANT("MYSQL_TENANT", "mtenant"),
+    ORACLE_TENANT("ORACLE_TENANT", "otenant"),
     MYSQL_SERVERLESS("mtenant_serverless"),
     ORACLE_SERVERLESS("otenant_serverless"),
     DEDICATED("DEDICATED"),
@@ -40,28 +42,35 @@ public enum OBInstanceType implements Translatable {
     // K8s共享集群模式
     K8s_SHARED("K8s_SHARED"),
     ANALYTICAL_CLUSTER("ANALYTICAL_CLUSTER"),
-    KV_CLUSTER("KV_CLUSTER");
+    KV_CLUSTER("KV_CLUSTER"),
+    BACKUP("backup"),
+    PRIMARY_STANDBY_CLUSTER("primary_standby_cluster"),
+    UNKNOWN("UNKNOWN");
+    ;
 
     @Getter
-    private String value;
+    private final String[] values;
 
     @JsonValue
     public String getName() {
         return this.name();
     }
 
-    OBInstanceType(String value) {
-        this.value = value;
+    OBInstanceType(String... values) {
+        this.values = values;
     }
 
     @JsonCreator
     public static OBInstanceType fromValue(String value) {
         for (OBInstanceType instanceType : OBInstanceType.values()) {
-            if (StringUtils.equalsIgnoreCase(instanceType.value, value)) {
-                return instanceType;
+            for (String type : instanceType.values) {
+                if (StringUtils.equalsIgnoreCase(type, value)) {
+                    return instanceType;
+                }
             }
         }
-        throw new IllegalArgumentException("OBInstanceType value not supported, given value '" + value + "'");
+        log.warn("Unknown OBInstanceType: {}", value);
+        return UNKNOWN;
     }
 
     @Override
@@ -69,4 +78,8 @@ public enum OBInstanceType implements Translatable {
         return name();
     }
 
+    public boolean isTenantInstance() {
+        return this == MYSQL_TENANT || this == ORACLE_TENANT || this == MYSQL_SERVERLESS
+                || this == ORACLE_SERVERLESS;
+    }
 }

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/connection/model/OBInstanceType.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/connection/model/OBInstanceType.java
@@ -15,7 +15,9 @@
  */
 package com.oceanbase.odc.service.connection.model;
 
-import com.alibaba.druid.util.StringUtils;
+import java.util.HashMap;
+import java.util.Map;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.oceanbase.odc.common.i18n.Translatable;
@@ -50,6 +52,7 @@ public enum OBInstanceType implements Translatable {
 
     @Getter
     private final String[] values;
+    private static final Map<String, OBInstanceType> VALUE_TO_INSTANCE_TYPE_MAP = buildValueToInstanceTypeMap();
 
     @JsonValue
     public String getName() {
@@ -62,15 +65,26 @@ public enum OBInstanceType implements Translatable {
 
     @JsonCreator
     public static OBInstanceType fromValue(String value) {
-        for (OBInstanceType instanceType : OBInstanceType.values()) {
-            for (String type : instanceType.values) {
-                if (StringUtils.equalsIgnoreCase(type, value)) {
-                    return instanceType;
-                }
-            }
+        OBInstanceType obInstanceType = VALUE_TO_INSTANCE_TYPE_MAP.get(value);
+        if (obInstanceType != null) {
+            return obInstanceType;
         }
         log.warn("Unknown OBInstanceType: {}", value);
         return UNKNOWN;
+    }
+
+    public static Map<String, OBInstanceType> getValueToInstanceTypeMap() {
+        return VALUE_TO_INSTANCE_TYPE_MAP;
+    }
+
+    private static Map<String, OBInstanceType> buildValueToInstanceTypeMap() {
+        Map<String, OBInstanceType> map = new HashMap<>();
+        for (OBInstanceType instanceType : OBInstanceType.values()) {
+            for (String typeValue : instanceType.getValues()) {
+                map.put(typeValue, instanceType);
+            }
+        }
+        return map;
     }
 
     @Override

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/connection/model/OBTenant.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/connection/model/OBTenant.java
@@ -15,6 +15,8 @@
  */
 package com.oceanbase.odc.service.connection.model;
 
+import java.util.List;
+
 import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
@@ -55,6 +57,9 @@ public class OBTenant {
     private OBInstanceType instanceType;
 
     private OBInstanceRoleType instanceRole;
+    private OBTenantStatus status;
+    @JsonAlias("tenantUsers")
+    private List<String> usernames;
 
     public static OBTenant of(String clusterInstanceId, String tenantId) {
         OBTenant obTenant = new OBTenant();

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/connection/model/OBTenantStatus.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/connection/model/OBTenantStatus.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2023 OceanBase.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.oceanbase.odc.service.connection.model;
+
+import java.util.Arrays;
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/**
+ * The status of the OB tenant, which comes from the TenantStatus enumeration value of OBCloud OCP.
+ * All tenant states are divided into two categories: ONLINE and NOT_CONNECTABLE
+ */
+public enum OBTenantStatus {
+    ONLINE("ONLINE"),
+    NOT_CONNECTABLE("NOT_CONNECTABLE");
+
+    private final String name;
+    private static final List<String> NOT_CONNECTABLE_VALUES =
+            Arrays.asList("PENDING_OFFLINE", "DELETED", "STOPPED", "END", "PENDING_CREATE");
+
+    OBTenantStatus(String name) {
+        this.name = name;
+    }
+
+    @JsonValue
+    public String getValue() {
+        return this.name;
+    }
+
+    @JsonCreator
+    public static OBTenantStatus fromValue(String name) {
+        if (NOT_CONNECTABLE_VALUES.contains(name)) {
+            return NOT_CONNECTABLE;
+        } else {
+            return ONLINE;
+        }
+    }
+}

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/connection/model/OBTenantStatus.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/connection/model/OBTenantStatus.java
@@ -20,6 +20,7 @@ import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
+import com.oceanbase.odc.common.util.StringUtils;
 
 /**
  * The status of the OB tenant, which comes from the TenantStatus enumeration value of OBCloud OCP.
@@ -44,7 +45,7 @@ public enum OBTenantStatus {
 
     @JsonCreator
     public static OBTenantStatus fromValue(String name) {
-        if (NOT_CONNECTABLE_VALUES.contains(name)) {
+        if (NOT_CONNECTABLE_VALUES.contains(StringUtils.upperCase(name))) {
             return NOT_CONNECTABLE;
         } else {
             return ONLINE;

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/connection/model/TestConnectionReq.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/connection/model/TestConnectionReq.java
@@ -154,6 +154,9 @@ public class TestConnectionReq implements CloudConnectionConfig, SSLConnectionCo
 
     private Map<String, Object> attributes;
 
+    @JsonProperty(access = Access.READ_ONLY)
+    private Long organizationId;
+
     public DialectType getDialectType() {
         if (Objects.nonNull(this.type)) {
             return this.type.getDialectType();
@@ -211,6 +214,7 @@ public class TestConnectionReq implements CloudConnectionConfig, SSLConnectionCo
         req.setCatalogName(connection.getCatalogName());
         req.setSessionInitScript(connection.getSessionInitScript());
         req.setJdbcUrlParameters(connection.getJdbcUrlParameters());
+        req.setOrganizationId(connection.getOrganizationId());
         return req;
     }
 

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/connection/table/model/Table.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/connection/table/model/Table.java
@@ -22,7 +22,7 @@ import java.util.Set;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonProperty.Access;
 import com.oceanbase.odc.core.authority.model.SecurityResource;
-import com.oceanbase.odc.core.shared.OrganizationIsolated;
+import com.oceanbase.odc.core.shared.ResourceBindToSingleOrganization;
 import com.oceanbase.odc.core.shared.constant.ResourceType;
 import com.oceanbase.odc.service.connection.database.model.Database;
 import com.oceanbase.odc.service.permission.database.model.DatabasePermissionType;
@@ -37,7 +37,7 @@ import lombok.Data;
  * @Version 1.0
  */
 @Data
-public class Table implements SecurityResource, OrganizationIsolated, Serializable {
+public class Table implements SecurityResource, ResourceBindToSingleOrganization, Serializable {
 
     private static final long serialVersionUID = -3902642503472738041L;
 

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/connection/table/model/Table.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/connection/table/model/Table.java
@@ -22,7 +22,7 @@ import java.util.Set;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonProperty.Access;
 import com.oceanbase.odc.core.authority.model.SecurityResource;
-import com.oceanbase.odc.core.shared.ResourceBindToSingleOrganization;
+import com.oceanbase.odc.core.shared.SingleOrganizationResource;
 import com.oceanbase.odc.core.shared.constant.ResourceType;
 import com.oceanbase.odc.service.connection.database.model.Database;
 import com.oceanbase.odc.service.permission.database.model.DatabasePermissionType;
@@ -37,7 +37,7 @@ import lombok.Data;
  * @Version 1.0
  */
 @Data
-public class Table implements SecurityResource, ResourceBindToSingleOrganization, Serializable {
+public class Table implements SecurityResource, SingleOrganizationResource, Serializable {
 
     private static final long serialVersionUID = -3902642503472738041L;
 

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/datasecurity/model/MaskingAlgorithm.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/datasecurity/model/MaskingAlgorithm.java
@@ -30,8 +30,8 @@ import com.oceanbase.odc.common.i18n.Internationalizable;
 import com.oceanbase.odc.common.validate.Name;
 import com.oceanbase.odc.core.authority.model.SecurityResource;
 import com.oceanbase.odc.core.datamasking.algorithm.Hash.HashType;
-import com.oceanbase.odc.core.shared.OrganizationIsolated;
 import com.oceanbase.odc.core.shared.PreConditions;
+import com.oceanbase.odc.core.shared.ResourceBindToSingleOrganization;
 import com.oceanbase.odc.core.shared.constant.ErrorCodes;
 import com.oceanbase.odc.core.shared.constant.ResourceType;
 import com.oceanbase.odc.service.common.model.InnerUser;
@@ -44,7 +44,7 @@ import lombok.Data;
  * @date 2023/5/10 10:56
  */
 @Data
-public class MaskingAlgorithm implements SecurityResource, OrganizationIsolated {
+public class MaskingAlgorithm implements SecurityResource, ResourceBindToSingleOrganization {
 
     @JsonProperty(access = Access.READ_ONLY)
     private Long id;

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/datasecurity/model/MaskingAlgorithm.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/datasecurity/model/MaskingAlgorithm.java
@@ -31,7 +31,7 @@ import com.oceanbase.odc.common.validate.Name;
 import com.oceanbase.odc.core.authority.model.SecurityResource;
 import com.oceanbase.odc.core.datamasking.algorithm.Hash.HashType;
 import com.oceanbase.odc.core.shared.PreConditions;
-import com.oceanbase.odc.core.shared.ResourceBindToSingleOrganization;
+import com.oceanbase.odc.core.shared.SingleOrganizationResource;
 import com.oceanbase.odc.core.shared.constant.ErrorCodes;
 import com.oceanbase.odc.core.shared.constant.ResourceType;
 import com.oceanbase.odc.service.common.model.InnerUser;
@@ -44,7 +44,7 @@ import lombok.Data;
  * @date 2023/5/10 10:56
  */
 @Data
-public class MaskingAlgorithm implements SecurityResource, ResourceBindToSingleOrganization {
+public class MaskingAlgorithm implements SecurityResource, SingleOrganizationResource {
 
     @JsonProperty(access = Access.READ_ONLY)
     private Long id;

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/datasecurity/model/SensitiveColumn.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/datasecurity/model/SensitiveColumn.java
@@ -23,7 +23,7 @@ import javax.validation.constraints.NotNull;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonProperty.Access;
 import com.oceanbase.odc.core.authority.model.SecurityResource;
-import com.oceanbase.odc.core.shared.ResourceBindToSingleOrganization;
+import com.oceanbase.odc.core.shared.SingleOrganizationResource;
 import com.oceanbase.odc.core.shared.constant.ResourceType;
 import com.oceanbase.odc.service.common.model.InnerUser;
 import com.oceanbase.odc.service.connection.database.model.Database;
@@ -35,7 +35,7 @@ import lombok.Data;
  * @date 2023/5/9 09:59
  */
 @Data
-public class SensitiveColumn implements SecurityResource, ResourceBindToSingleOrganization {
+public class SensitiveColumn implements SecurityResource, SingleOrganizationResource {
 
     @JsonProperty(access = Access.READ_ONLY)
     private Long id;

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/datasecurity/model/SensitiveColumn.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/datasecurity/model/SensitiveColumn.java
@@ -23,7 +23,7 @@ import javax.validation.constraints.NotNull;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonProperty.Access;
 import com.oceanbase.odc.core.authority.model.SecurityResource;
-import com.oceanbase.odc.core.shared.OrganizationIsolated;
+import com.oceanbase.odc.core.shared.ResourceBindToSingleOrganization;
 import com.oceanbase.odc.core.shared.constant.ResourceType;
 import com.oceanbase.odc.service.common.model.InnerUser;
 import com.oceanbase.odc.service.connection.database.model.Database;
@@ -35,7 +35,7 @@ import lombok.Data;
  * @date 2023/5/9 09:59
  */
 @Data
-public class SensitiveColumn implements SecurityResource, OrganizationIsolated {
+public class SensitiveColumn implements SecurityResource, ResourceBindToSingleOrganization {
 
     @JsonProperty(access = Access.READ_ONLY)
     private Long id;

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/datasecurity/model/SensitiveRule.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/datasecurity/model/SensitiveRule.java
@@ -26,7 +26,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonProperty.Access;
 import com.oceanbase.odc.common.validate.Name;
 import com.oceanbase.odc.core.authority.model.SecurityResource;
-import com.oceanbase.odc.core.shared.OrganizationIsolated;
+import com.oceanbase.odc.core.shared.ResourceBindToSingleOrganization;
 import com.oceanbase.odc.core.shared.constant.ResourceType;
 import com.oceanbase.odc.service.common.model.InnerUser;
 import com.oceanbase.odc.service.datasecurity.util.ParameterValidateUtil;
@@ -38,7 +38,7 @@ import lombok.Data;
  * @date 2023/5/9 11:40
  */
 @Data
-public class SensitiveRule implements SecurityResource, OrganizationIsolated {
+public class SensitiveRule implements SecurityResource, ResourceBindToSingleOrganization {
 
     @JsonProperty(access = Access.READ_ONLY)
     private Long id;

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/datasecurity/model/SensitiveRule.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/datasecurity/model/SensitiveRule.java
@@ -26,7 +26,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonProperty.Access;
 import com.oceanbase.odc.common.validate.Name;
 import com.oceanbase.odc.core.authority.model.SecurityResource;
-import com.oceanbase.odc.core.shared.ResourceBindToSingleOrganization;
+import com.oceanbase.odc.core.shared.SingleOrganizationResource;
 import com.oceanbase.odc.core.shared.constant.ResourceType;
 import com.oceanbase.odc.service.common.model.InnerUser;
 import com.oceanbase.odc.service.datasecurity.util.ParameterValidateUtil;
@@ -38,7 +38,7 @@ import lombok.Data;
  * @date 2023/5/9 11:40
  */
 @Data
-public class SensitiveRule implements SecurityResource, ResourceBindToSingleOrganization {
+public class SensitiveRule implements SecurityResource, SingleOrganizationResource {
 
     @JsonProperty(access = Access.READ_ONLY)
     private Long id;

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/flow/instance/BaseFlowNodeInstance.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/flow/instance/BaseFlowNodeInstance.java
@@ -27,7 +27,7 @@ import com.oceanbase.odc.common.graph.GraphVertex;
 import com.oceanbase.odc.core.authority.model.SecurityResource;
 import com.oceanbase.odc.core.flow.model.FlowableElement;
 import com.oceanbase.odc.core.flow.model.FlowableElementType;
-import com.oceanbase.odc.core.shared.OrganizationIsolated;
+import com.oceanbase.odc.core.shared.ResourceBindToSingleOrganization;
 import com.oceanbase.odc.metadb.flow.NodeInstanceEntity;
 import com.oceanbase.odc.metadb.flow.NodeInstanceEntityRepository;
 import com.oceanbase.odc.metadb.flow.SequenceInstanceRepository;
@@ -51,7 +51,8 @@ import lombok.extern.slf4j.Slf4j;
  */
 @Slf4j
 @Getter
-public abstract class BaseFlowNodeInstance extends GraphVertex implements SecurityResource, OrganizationIsolated {
+public abstract class BaseFlowNodeInstance extends GraphVertex implements SecurityResource,
+        ResourceBindToSingleOrganization {
     @Setter
     private volatile FlowNodeStatus status;
     @Setter

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/flow/instance/BaseFlowNodeInstance.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/flow/instance/BaseFlowNodeInstance.java
@@ -27,7 +27,7 @@ import com.oceanbase.odc.common.graph.GraphVertex;
 import com.oceanbase.odc.core.authority.model.SecurityResource;
 import com.oceanbase.odc.core.flow.model.FlowableElement;
 import com.oceanbase.odc.core.flow.model.FlowableElementType;
-import com.oceanbase.odc.core.shared.ResourceBindToSingleOrganization;
+import com.oceanbase.odc.core.shared.SingleOrganizationResource;
 import com.oceanbase.odc.metadb.flow.NodeInstanceEntity;
 import com.oceanbase.odc.metadb.flow.NodeInstanceEntityRepository;
 import com.oceanbase.odc.metadb.flow.SequenceInstanceRepository;
@@ -52,7 +52,7 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @Getter
 public abstract class BaseFlowNodeInstance extends GraphVertex implements SecurityResource,
-        ResourceBindToSingleOrganization {
+        SingleOrganizationResource {
     @Setter
     private volatile FlowNodeStatus status;
     @Setter

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/flow/instance/FlowInstance.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/flow/instance/FlowInstance.java
@@ -45,7 +45,7 @@ import com.oceanbase.odc.core.flow.ExecutionConfigurer;
 import com.oceanbase.odc.core.flow.builder.FlowableProcessBuilder;
 import com.oceanbase.odc.core.flow.model.FlowableElement;
 import com.oceanbase.odc.core.flow.util.FlowUtil;
-import com.oceanbase.odc.core.shared.OrganizationIsolated;
+import com.oceanbase.odc.core.shared.ResourceBindToSingleOrganization;
 import com.oceanbase.odc.core.shared.Verify;
 import com.oceanbase.odc.core.shared.constant.FlowStatus;
 import com.oceanbase.odc.core.shared.constant.ResourceType;
@@ -80,7 +80,7 @@ import lombok.extern.slf4j.Slf4j;
  */
 @Getter
 @Slf4j
-public class FlowInstance extends Graph implements SecurityResource, OrganizationIsolated {
+public class FlowInstance extends Graph implements SecurityResource, ResourceBindToSingleOrganization {
 
     private Long id;
     private Date createTime;

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/flow/instance/FlowInstance.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/flow/instance/FlowInstance.java
@@ -45,7 +45,7 @@ import com.oceanbase.odc.core.flow.ExecutionConfigurer;
 import com.oceanbase.odc.core.flow.builder.FlowableProcessBuilder;
 import com.oceanbase.odc.core.flow.model.FlowableElement;
 import com.oceanbase.odc.core.flow.util.FlowUtil;
-import com.oceanbase.odc.core.shared.ResourceBindToSingleOrganization;
+import com.oceanbase.odc.core.shared.SingleOrganizationResource;
 import com.oceanbase.odc.core.shared.Verify;
 import com.oceanbase.odc.core.shared.constant.FlowStatus;
 import com.oceanbase.odc.core.shared.constant.ResourceType;
@@ -80,7 +80,7 @@ import lombok.extern.slf4j.Slf4j;
  */
 @Getter
 @Slf4j
-public class FlowInstance extends Graph implements SecurityResource, ResourceBindToSingleOrganization {
+public class FlowInstance extends Graph implements SecurityResource, SingleOrganizationResource {
 
     private Long id;
     private Date createTime;

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/iam/HorizontalDataPermissionValidator.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/iam/HorizontalDataPermissionValidator.java
@@ -23,10 +23,10 @@ import org.apache.commons.lang.Validate;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import com.oceanbase.odc.core.shared.MultiOrganizationResource;
 import com.oceanbase.odc.core.shared.OrganizationResource;
 import com.oceanbase.odc.core.shared.PreConditions;
-import com.oceanbase.odc.core.shared.ResourceBindToMultiOrganizations;
-import com.oceanbase.odc.core.shared.ResourceBindToSingleOrganization;
+import com.oceanbase.odc.core.shared.SingleOrganizationResource;
 import com.oceanbase.odc.core.shared.Verify;
 import com.oceanbase.odc.core.shared.constant.ResourceType;
 import com.oceanbase.odc.service.iam.auth.AuthenticationFacade;
@@ -46,13 +46,13 @@ public class HorizontalDataPermissionValidator {
                 "Resources can not be null for HorizontalDataPermissionValidator#checkCurrentOrganization");
         Long currentOrganizationId = authenticationFacade.currentOrganizationId();
         for (T item : objects) {
-            if (item instanceof ResourceBindToSingleOrganization) {
-                Long organizationId = ((ResourceBindToSingleOrganization) item).organizationId();
+            if (item instanceof SingleOrganizationResource) {
+                Long organizationId = ((SingleOrganizationResource) item).organizationId();
                 Verify.notNull(organizationId, "organizationId");
                 PreConditions.validExists(ResourceType.valueOf(item.resourceType()), "id", item.id(),
                         () -> currentOrganizationId.equals(organizationId));
-            } else if (item instanceof ResourceBindToMultiOrganizations) {
-                Set<Long> organizationIds = ((ResourceBindToMultiOrganizations) item).organizationIds();
+            } else if (item instanceof MultiOrganizationResource) {
+                Set<Long> organizationIds = ((MultiOrganizationResource) item).organizationIds();
                 PreConditions.validExists(ResourceType.valueOf(item.resourceType()), "id", item.id(),
                         () -> organizationIds.contains(currentOrganizationId));
             } else {

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/iam/HorizontalDataPermissionValidator.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/iam/HorizontalDataPermissionValidator.java
@@ -17,13 +17,16 @@ package com.oceanbase.odc.service.iam;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 
 import org.apache.commons.lang.Validate;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
-import com.oceanbase.odc.core.shared.OrganizationIsolated;
+import com.oceanbase.odc.core.shared.OrganizationResource;
 import com.oceanbase.odc.core.shared.PreConditions;
+import com.oceanbase.odc.core.shared.ResourceBindToMultiOrganizations;
+import com.oceanbase.odc.core.shared.ResourceBindToSingleOrganization;
 import com.oceanbase.odc.core.shared.Verify;
 import com.oceanbase.odc.core.shared.constant.ResourceType;
 import com.oceanbase.odc.service.iam.auth.AuthenticationFacade;
@@ -34,19 +37,27 @@ public class HorizontalDataPermissionValidator {
     @Autowired
     private AuthenticationFacade authenticationFacade;
 
-    public final <T extends OrganizationIsolated> void checkCurrentOrganization(T object) {
+    public final <T extends OrganizationResource> void checkCurrentOrganization(T object) {
         checkCurrentOrganization(Collections.singletonList(object));
     }
 
-    public final <T extends OrganizationIsolated> void checkCurrentOrganization(List<T> objects) {
+    public final <T extends OrganizationResource> void checkCurrentOrganization(List<T> objects) {
         Validate.notNull(objects,
                 "Resources can not be null for HorizontalDataPermissionValidator#checkCurrentOrganization");
         Long currentOrganizationId = authenticationFacade.currentOrganizationId();
         for (T item : objects) {
-            Long organizationId = item.organizationId();
-            Verify.notNull(organizationId, "organizationId");
-            PreConditions.validExists(ResourceType.valueOf(item.resourceType()), "id", item.id(),
-                    () -> currentOrganizationId.equals(organizationId));
+            if (item instanceof ResourceBindToSingleOrganization) {
+                Long organizationId = ((ResourceBindToSingleOrganization) item).organizationId();
+                Verify.notNull(organizationId, "organizationId");
+                PreConditions.validExists(ResourceType.valueOf(item.resourceType()), "id", item.id(),
+                        () -> currentOrganizationId.equals(organizationId));
+            } else if (item instanceof ResourceBindToMultiOrganizations) {
+                Set<Long> organizationIds = ((ResourceBindToMultiOrganizations) item).organizationIds();
+                PreConditions.validExists(ResourceType.valueOf(item.resourceType()), "id", item.id(),
+                        () -> organizationIds.contains(currentOrganizationId));
+            } else {
+                throw new IllegalArgumentException("Unsupported type " + item.getClass().getName());
+            }
         }
     }
 

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/iam/UserService.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/iam/UserService.java
@@ -89,6 +89,7 @@ import com.oceanbase.odc.metadb.iam.RolePermissionEntity;
 import com.oceanbase.odc.metadb.iam.RolePermissionRepository;
 import com.oceanbase.odc.metadb.iam.RoleRepository;
 import com.oceanbase.odc.metadb.iam.UserEntity;
+import com.oceanbase.odc.metadb.iam.UserOrganizationEntity;
 import com.oceanbase.odc.metadb.iam.UserOrganizationRepository;
 import com.oceanbase.odc.metadb.iam.UserPermissionEntity;
 import com.oceanbase.odc.metadb.iam.UserPermissionRepository;
@@ -602,9 +603,11 @@ public class UserService {
 
     @SkipAuthorize
     public PaginatedData<User> listUserBasicsWithoutPermissionCheck() {
-        List<User> users =
-                userRepository.findByOrganizationId(authenticationFacade.currentOrganizationId()).stream()
-                        .map(User::new).collect(Collectors.toList());
+        List<UserOrganizationEntity> entities = userOrganizationRepository.findByOrganizationId(
+                authenticationFacade.currentOrganizationId());
+        List<User> users = userRepository.findByIdIn(
+                entities.stream().map(UserOrganizationEntity::getUserId).collect(Collectors.toList())).stream()
+                .map(User::new).collect(Collectors.toList());
         acquireRolesAndRoleIds(users);
         return new PaginatedData<>(users, CustomPage.empty());
     }
@@ -667,13 +670,17 @@ public class UserService {
             }
         }).collect(Collectors.toList());
 
-        Specification<UserEntity> spec =
-                Specification.where(UserSpecs.organizationIdEqual(authenticationFacade.currentOrganizationId()))
-                        .and(UserSpecs.enabledEqual(params.getEnabled()))
-                        .and(UserSpecs.namesLike(params.getNames())
-                                .or(UserSpecs.accountNamesLike(params.getAccountNames())));
+        Specification<UserEntity> spec = Specification.where(UserSpecs.enabledEqual(params.getEnabled()))
+                .and(UserSpecs.namesLike(params.getNames()).or(UserSpecs.accountNamesLike(params.getAccountNames())));
+
+        List<Long> userIdsInOrg = userOrganizationRepository.findByOrganizationId(
+                authenticationFacade.currentOrganizationId()).stream().map(UserOrganizationEntity::getUserId).collect(
+                        Collectors.toList());
         if (!findAllUsers) {
+            queryUserIds.addAll(userIdsInOrg);
             spec = spec.and(UserSpecs.userIdIn(queryUserIds));
+        } else {
+            spec = spec.and(UserSpecs.userIdIn(userIdsInOrg));
         }
         spec = spec.and(UserSpecs.sort(Sort.by(orderList)));
         Pageable page = pageable.equals(Pageable.unpaged()) ? pageable

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/iam/UserService.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/iam/UserService.java
@@ -671,13 +671,13 @@ public class UserService {
         }).collect(Collectors.toList());
 
         Specification<UserEntity> spec = Specification.where(UserSpecs.enabledEqual(params.getEnabled()))
-                .and(UserSpecs.namesLike(params.getNames()).or(UserSpecs.accountNamesLike(params.getAccountNames())));
+                .and(UserSpecs.namesLike(params.getNames())
+                        .or(UserSpecs.accountNamesLike(params.getAccountNames())));
 
         List<Long> userIdsInOrg = userOrganizationRepository.findByOrganizationId(
                 authenticationFacade.currentOrganizationId()).stream().map(UserOrganizationEntity::getUserId).collect(
                         Collectors.toList());
         if (!findAllUsers) {
-            queryUserIds.addAll(userIdsInOrg);
             spec = spec.and(UserSpecs.userIdIn(queryUserIds));
         } else {
             spec = spec.and(UserSpecs.userIdIn(userIdsInOrg));

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/iam/UserService.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/iam/UserService.java
@@ -366,7 +366,7 @@ public class UserService {
             throw new UnsupportedException(ErrorCodes.IllegalOperation, new Object[] {"admin account"},
                     "Operation on admin account is not allowed");
         }
-        permissionValidator.checkCurrentOrganization(new User(userEntity));
+        permissionValidator.checkCurrentOrganization(nullSafeGetUser(id));
 
         UserDeleteEvent event = new UserDeleteEvent();
         event.setUserId(id);
@@ -741,7 +741,7 @@ public class UserService {
         }
         userEntity.setEnabled(updateUserReq.isEnabled());
         userEntity.setDescription(updateUserReq.getDescription());
-        permissionValidator.checkCurrentOrganization(new User(userEntity));
+        permissionValidator.checkCurrentOrganization(nullSafeGetUser(id));
         userRepository.update(userEntity);
         publishTriggerEventAfterTx(new User(userEntity), TriggerEvent.USER_UPDATED);
         log.info("User has been updated: {}", userEntity);
@@ -789,7 +789,7 @@ public class UserService {
             throw new UnsupportedException(ErrorCodes.IllegalOperation, new Object[] {"admin account"},
                     "Operation on admin account is not allowed");
         }
-        permissionValidator.checkCurrentOrganization(new User(userEntity));
+        permissionValidator.checkCurrentOrganization(nullSafeGetUser(id));
         userEntity.setEnabled(enabled);
         userRepository.update(userEntity);
         User user = new User(userEntity);
@@ -812,8 +812,9 @@ public class UserService {
                     "New password has to be different from old password");
             SecurityContextUtils.setCurrentUser(new User(userEntity));
         } else {
-            userEntity = nullSafeGet(authenticationFacade.currentUserId());
-            permissionValidator.checkCurrentOrganization(authenticationFacade.currentUser());
+            long currentUserId = authenticationFacade.currentUserId();
+            userEntity = nullSafeGet(currentUserId);
+            permissionValidator.checkCurrentOrganization(nullSafeGetUser(currentUserId));
         }
         String previousPassword = userEntity.getPassword();
         FailedLoginAttemptLimiter attemptLimiter = userIdChangePasswordAttamptCache.get(userEntity.getId());
@@ -860,7 +861,7 @@ public class UserService {
     @PreAuthenticate(actions = "update", resourceType = "ODC_USER", indexOfIdParam = 0)
     public User resetPassword(long id, String password) {
         UserEntity userEntity = nullSafeGet(id);
-        permissionValidator.checkCurrentOrganization(new User(userEntity));
+        permissionValidator.checkCurrentOrganization(nullSafeGetUser(id));
         String previousPassword = userEntity.getPassword();
 
         PreConditions.validPassword(password);
@@ -887,6 +888,14 @@ public class UserService {
     }
 
     @SkipAuthorize("odc internal usage")
+    public User nullSafeGetUser(long id) {
+        UserEntity entity = nullSafeGet(id);
+        User user = new User(entity);
+        user.setOrganizationIds(userOrganizationRepository.findAllOrganizationIdByUserId(entity.getId()));
+        return user;
+    }
+
+    @SkipAuthorize("odc internal usage")
     public UserEntity nullSafeGet(String accountName) {
         return userRepository.findByAccountName(accountName)
                 .orElseThrow(() -> new NotFoundException(ResourceType.ODC_USER, "accountName", accountName));
@@ -901,7 +910,13 @@ public class UserService {
                     .collect(Collectors.joining(","));
             throw new NotFoundException(ResourceType.ODC_USER, "id", absentIds);
         }
-        return entities.stream().map(User::new).collect(Collectors.toList());
+        List<User> users = new ArrayList<>();
+        entities.stream().forEach(entity -> {
+            User user = new User(entity);
+            user.setOrganizationIds(userOrganizationRepository.findAllOrganizationIdByUserId(entity.getId()));
+            users.add(user);
+        });
+        return users;
     }
 
     @SkipAuthorize("odc internal usage")

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/iam/UserService.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/iam/UserService.java
@@ -366,7 +366,7 @@ public class UserService {
             throw new UnsupportedException(ErrorCodes.IllegalOperation, new Object[] {"admin account"},
                     "Operation on admin account is not allowed");
         }
-        permissionValidator.checkCurrentOrganization(nullSafeGetUser(id));
+        permissionValidator.checkCurrentOrganization(nullSafeGetUser(userEntity));
 
         UserDeleteEvent event = new UserDeleteEvent();
         event.setUserId(id);
@@ -741,7 +741,7 @@ public class UserService {
         }
         userEntity.setEnabled(updateUserReq.isEnabled());
         userEntity.setDescription(updateUserReq.getDescription());
-        permissionValidator.checkCurrentOrganization(nullSafeGetUser(id));
+        permissionValidator.checkCurrentOrganization(nullSafeGetUser(userEntity));
         userRepository.update(userEntity);
         publishTriggerEventAfterTx(new User(userEntity), TriggerEvent.USER_UPDATED);
         log.info("User has been updated: {}", userEntity);
@@ -789,7 +789,7 @@ public class UserService {
             throw new UnsupportedException(ErrorCodes.IllegalOperation, new Object[] {"admin account"},
                     "Operation on admin account is not allowed");
         }
-        permissionValidator.checkCurrentOrganization(nullSafeGetUser(id));
+        permissionValidator.checkCurrentOrganization(nullSafeGetUser(userEntity));
         userEntity.setEnabled(enabled);
         userRepository.update(userEntity);
         User user = new User(userEntity);
@@ -814,7 +814,7 @@ public class UserService {
         } else {
             long currentUserId = authenticationFacade.currentUserId();
             userEntity = nullSafeGet(currentUserId);
-            permissionValidator.checkCurrentOrganization(nullSafeGetUser(currentUserId));
+            permissionValidator.checkCurrentOrganization(nullSafeGetUser(userEntity));
         }
         String previousPassword = userEntity.getPassword();
         FailedLoginAttemptLimiter attemptLimiter = userIdChangePasswordAttamptCache.get(userEntity.getId());
@@ -861,7 +861,7 @@ public class UserService {
     @PreAuthenticate(actions = "update", resourceType = "ODC_USER", indexOfIdParam = 0)
     public User resetPassword(long id, String password) {
         UserEntity userEntity = nullSafeGet(id);
-        permissionValidator.checkCurrentOrganization(nullSafeGetUser(id));
+        permissionValidator.checkCurrentOrganization(nullSafeGetUser(userEntity));
         String previousPassword = userEntity.getPassword();
 
         PreConditions.validPassword(password);
@@ -888,10 +888,9 @@ public class UserService {
     }
 
     @SkipAuthorize("odc internal usage")
-    public User nullSafeGetUser(long id) {
-        UserEntity entity = nullSafeGet(id);
-        User user = new User(entity);
-        user.setOrganizationIds(userOrganizationRepository.findAllOrganizationIdByUserId(entity.getId()));
+    public User nullSafeGetUser(UserEntity userEntity) {
+        User user = new User(userEntity);
+        user.setOrganizationIds(userOrganizationRepository.findAllOrganizationIdByUserId(userEntity.getId()));
         return user;
     }
 

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/iam/auth/OrganizationAuthenticationInterceptor.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/iam/auth/OrganizationAuthenticationInterceptor.java
@@ -74,8 +74,7 @@ public class OrganizationAuthenticationInterceptor implements HandlerInterceptor
             "/api/v2/snippet/builtinSnippets",
             "/api/v2/cloud/collaboration/currentProject",
             "/api/v1/cloud/webhook/instanceChange/preCheck",
-            "/api/v1/cloud/webhook/instanceChange/processEvent",
-            "/api/v2/cloud/metadata"
+            "/api/v1/cloud/webhook/instanceChange/processEvent"
     };
 
     @Autowired

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/iam/auth/OrganizationAuthenticationInterceptor.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/iam/auth/OrganizationAuthenticationInterceptor.java
@@ -74,7 +74,8 @@ public class OrganizationAuthenticationInterceptor implements HandlerInterceptor
             "/api/v2/snippet/builtinSnippets",
             "/api/v2/cloud/collaboration/currentProject",
             "/api/v1/cloud/webhook/instanceChange/preCheck",
-            "/api/v1/cloud/webhook/instanceChange/processEvent"
+            "/api/v1/cloud/webhook/instanceChange/processEvent",
+            "/api/v2/cloud/metadata"
     };
 
     @Autowired

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/iam/auth/OrganizationIsolatedValueProvider.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/iam/auth/OrganizationIsolatedValueProvider.java
@@ -27,8 +27,8 @@ import com.oceanbase.odc.core.authority.auth.PermissionStrategy;
 import com.oceanbase.odc.core.authority.auth.ReturnValueProvider;
 import com.oceanbase.odc.core.authority.auth.SecurityContext;
 import com.oceanbase.odc.core.authority.exception.AccessDeniedException;
-import com.oceanbase.odc.core.shared.ResourceBindToMultiOrganizations;
-import com.oceanbase.odc.core.shared.ResourceBindToSingleOrganization;
+import com.oceanbase.odc.core.shared.MultiOrganizationResource;
+import com.oceanbase.odc.core.shared.SingleOrganizationResource;
 
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
@@ -69,14 +69,14 @@ public class OrganizationIsolatedValueProvider extends DefaultReturnValueProvide
 
     private void checkOrganizationIsolated(Object returnValue) {
         long expected = authenticationFacade.currentOrganizationId();
-        if (returnValue instanceof ResourceBindToSingleOrganization) {
-            long actual = ((ResourceBindToSingleOrganization) returnValue).organizationId().longValue();
+        if (returnValue instanceof SingleOrganizationResource) {
+            long actual = ((SingleOrganizationResource) returnValue).organizationId().longValue();
             if (expected != actual) {
                 log.warn("organizationId not matched, expected={}, actual={}", expected, actual);
                 throw new AccessDeniedException();
             }
-        } else if (returnValue instanceof ResourceBindToMultiOrganizations) {
-            Set<Long> organizationIds = ((ResourceBindToMultiOrganizations) returnValue).organizationIds();
+        } else if (returnValue instanceof MultiOrganizationResource) {
+            Set<Long> organizationIds = ((MultiOrganizationResource) returnValue).organizationIds();
             if (!organizationIds.contains(expected)) {
                 log.warn("organizationId not matched, expected={}, actual={}", expected, organizationIds);
                 throw new AccessDeniedException();

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/iam/model/Organization.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/iam/model/Organization.java
@@ -25,8 +25,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonProperty.Access;
 import com.oceanbase.odc.common.i18n.Internationalizable;
 import com.oceanbase.odc.core.authority.model.SecurityResource;
-import com.oceanbase.odc.core.shared.OrganizationIsolated;
 import com.oceanbase.odc.core.shared.PreConditions;
+import com.oceanbase.odc.core.shared.ResourceBindToSingleOrganization;
 import com.oceanbase.odc.core.shared.constant.OrganizationType;
 import com.oceanbase.odc.core.shared.constant.ResourceType;
 import com.oceanbase.odc.metadb.iam.OrganizationEntity;
@@ -40,7 +40,7 @@ import lombok.ToString;
  */
 @Data
 @ToString(exclude = "secret")
-public class Organization implements Serializable, SecurityResource, OrganizationIsolated {
+public class Organization implements Serializable, SecurityResource, ResourceBindToSingleOrganization {
     @JsonProperty(access = Access.READ_ONLY)
     private Long id;
     @JsonProperty(access = Access.READ_ONLY)

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/iam/model/Organization.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/iam/model/Organization.java
@@ -26,7 +26,7 @@ import com.fasterxml.jackson.annotation.JsonProperty.Access;
 import com.oceanbase.odc.common.i18n.Internationalizable;
 import com.oceanbase.odc.core.authority.model.SecurityResource;
 import com.oceanbase.odc.core.shared.PreConditions;
-import com.oceanbase.odc.core.shared.ResourceBindToSingleOrganization;
+import com.oceanbase.odc.core.shared.SingleOrganizationResource;
 import com.oceanbase.odc.core.shared.constant.OrganizationType;
 import com.oceanbase.odc.core.shared.constant.ResourceType;
 import com.oceanbase.odc.metadb.iam.OrganizationEntity;
@@ -40,7 +40,7 @@ import lombok.ToString;
  */
 @Data
 @ToString(exclude = "secret")
-public class Organization implements Serializable, SecurityResource, ResourceBindToSingleOrganization {
+public class Organization implements Serializable, SecurityResource, SingleOrganizationResource {
     @JsonProperty(access = Access.READ_ONLY)
     private Long id;
     @JsonProperty(access = Access.READ_ONLY)

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/iam/model/Role.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/iam/model/Role.java
@@ -22,7 +22,7 @@ import java.util.List;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonProperty.Access;
 import com.oceanbase.odc.core.authority.model.SecurityResource;
-import com.oceanbase.odc.core.shared.OrganizationIsolated;
+import com.oceanbase.odc.core.shared.ResourceBindToSingleOrganization;
 import com.oceanbase.odc.core.shared.constant.ResourceType;
 import com.oceanbase.odc.core.shared.constant.RoleType;
 import com.oceanbase.odc.metadb.iam.RoleEntity;
@@ -35,7 +35,7 @@ import lombok.Data;
  */
 
 @Data
-public class Role implements SecurityResource, OrganizationIsolated, Serializable {
+public class Role implements SecurityResource, ResourceBindToSingleOrganization, Serializable {
     private static final long serialVersionUID = 1094521546416165353L;
     @JsonProperty(access = Access.READ_ONLY)
     private Long id;

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/iam/model/Role.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/iam/model/Role.java
@@ -22,7 +22,7 @@ import java.util.List;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonProperty.Access;
 import com.oceanbase.odc.core.authority.model.SecurityResource;
-import com.oceanbase.odc.core.shared.ResourceBindToSingleOrganization;
+import com.oceanbase.odc.core.shared.SingleOrganizationResource;
 import com.oceanbase.odc.core.shared.constant.ResourceType;
 import com.oceanbase.odc.core.shared.constant.RoleType;
 import com.oceanbase.odc.metadb.iam.RoleEntity;
@@ -35,7 +35,7 @@ import lombok.Data;
  */
 
 @Data
-public class Role implements SecurityResource, ResourceBindToSingleOrganization, Serializable {
+public class Role implements SecurityResource, SingleOrganizationResource, Serializable {
     private static final long serialVersionUID = 1094521546416165353L;
     @JsonProperty(access = Access.READ_ONLY)
     private Long id;

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/iam/model/User.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/iam/model/User.java
@@ -34,8 +34,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonProperty.Access;
 import com.oceanbase.odc.common.json.SensitiveInput;
 import com.oceanbase.odc.core.authority.model.SecurityResource;
-import com.oceanbase.odc.core.shared.OrganizationIsolated;
 import com.oceanbase.odc.core.shared.PreConditions;
+import com.oceanbase.odc.core.shared.ResourceBindToMultiOrganizations;
 import com.oceanbase.odc.core.shared.constant.OrganizationType;
 import com.oceanbase.odc.core.shared.constant.ResourceType;
 import com.oceanbase.odc.core.shared.constant.UserType;
@@ -51,7 +51,7 @@ import lombok.ToString;
 
 @Data
 @ToString(exclude = {"password"})
-public class User implements Principal, UserDetails, SecurityResource, OrganizationIsolated, OidcUser {
+public class User implements Principal, UserDetails, SecurityResource, ResourceBindToMultiOrganizations, OidcUser {
 
     private static final long serialVersionUID = -7525670432276629968L;
 
@@ -100,6 +100,12 @@ public class User implements Principal, UserDetails, SecurityResource, Organizat
      */
     @JsonProperty(access = Access.READ_ONLY)
     private Long organizationId;
+
+    /**
+     * All organizations to which the user belongs to
+     */
+    @JsonProperty(access = Access.READ_ONLY)
+    private Set<Long> organizationIds;
 
     @JsonProperty(access = Access.READ_ONLY)
     private OrganizationType organizationType;
@@ -189,11 +195,6 @@ public class User implements Principal, UserDetails, SecurityResource, Organizat
     }
 
     @Override
-    public Long organizationId() {
-        return this.organizationId;
-    }
-
-    @Override
     public Long id() {
         return this.id;
     }
@@ -211,5 +212,10 @@ public class User implements Principal, UserDetails, SecurityResource, Organizat
     @Override
     public OidcIdToken getIdToken() {
         return null;
+    }
+
+    @Override
+    public Set<Long> organizationIds() {
+        return this.organizationIds;
     }
 }

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/iam/model/User.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/iam/model/User.java
@@ -34,8 +34,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonProperty.Access;
 import com.oceanbase.odc.common.json.SensitiveInput;
 import com.oceanbase.odc.core.authority.model.SecurityResource;
+import com.oceanbase.odc.core.shared.MultiOrganizationResource;
 import com.oceanbase.odc.core.shared.PreConditions;
-import com.oceanbase.odc.core.shared.ResourceBindToMultiOrganizations;
 import com.oceanbase.odc.core.shared.constant.OrganizationType;
 import com.oceanbase.odc.core.shared.constant.ResourceType;
 import com.oceanbase.odc.core.shared.constant.UserType;
@@ -51,7 +51,7 @@ import lombok.ToString;
 
 @Data
 @ToString(exclude = {"password"})
-public class User implements Principal, UserDetails, SecurityResource, ResourceBindToMultiOrganizations, OidcUser {
+public class User implements Principal, UserDetails, SecurityResource, MultiOrganizationResource, OidcUser {
 
     private static final long serialVersionUID = -7525670432276629968L;
 

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/integration/model/IntegrationConfig.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/integration/model/IntegrationConfig.java
@@ -25,7 +25,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonProperty.Access;
 import com.oceanbase.odc.common.validate.Name;
 import com.oceanbase.odc.core.authority.model.SecurityResource;
-import com.oceanbase.odc.core.shared.OrganizationIsolated;
+import com.oceanbase.odc.core.shared.ResourceBindToSingleOrganization;
 import com.oceanbase.odc.core.shared.constant.ResourceType;
 import com.oceanbase.odc.metadb.integration.IntegrationEntity;
 
@@ -38,7 +38,7 @@ import lombok.NoArgsConstructor;
  */
 @Data
 @NoArgsConstructor
-public class IntegrationConfig implements SecurityResource, OrganizationIsolated {
+public class IntegrationConfig implements SecurityResource, ResourceBindToSingleOrganization {
 
     @JsonProperty(access = Access.READ_ONLY)
     private Long id;

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/integration/model/IntegrationConfig.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/integration/model/IntegrationConfig.java
@@ -25,7 +25,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonProperty.Access;
 import com.oceanbase.odc.common.validate.Name;
 import com.oceanbase.odc.core.authority.model.SecurityResource;
-import com.oceanbase.odc.core.shared.ResourceBindToSingleOrganization;
+import com.oceanbase.odc.core.shared.SingleOrganizationResource;
 import com.oceanbase.odc.core.shared.constant.ResourceType;
 import com.oceanbase.odc.metadb.integration.IntegrationEntity;
 
@@ -38,7 +38,7 @@ import lombok.NoArgsConstructor;
  */
 @Data
 @NoArgsConstructor
-public class IntegrationConfig implements SecurityResource, ResourceBindToSingleOrganization {
+public class IntegrationConfig implements SecurityResource, SingleOrganizationResource {
 
     @JsonProperty(access = Access.READ_ONLY)
     private Long id;

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/regulation/approval/model/ApprovalFlowConfig.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/regulation/approval/model/ApprovalFlowConfig.java
@@ -27,7 +27,7 @@ import com.fasterxml.jackson.annotation.JsonProperty.Access;
 import com.oceanbase.odc.common.i18n.Internationalizable;
 import com.oceanbase.odc.common.validate.Name;
 import com.oceanbase.odc.core.authority.model.SecurityResource;
-import com.oceanbase.odc.core.shared.OrganizationIsolated;
+import com.oceanbase.odc.core.shared.ResourceBindToSingleOrganization;
 import com.oceanbase.odc.core.shared.constant.ResourceType;
 
 import lombok.Data;
@@ -38,7 +38,7 @@ import lombok.Data;
  * @Description: []
  */
 @Data
-public class ApprovalFlowConfig implements SecurityResource, OrganizationIsolated {
+public class ApprovalFlowConfig implements SecurityResource, ResourceBindToSingleOrganization {
     @JsonProperty(access = Access.READ_ONLY)
     private Long id;
 

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/regulation/approval/model/ApprovalFlowConfig.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/regulation/approval/model/ApprovalFlowConfig.java
@@ -27,7 +27,7 @@ import com.fasterxml.jackson.annotation.JsonProperty.Access;
 import com.oceanbase.odc.common.i18n.Internationalizable;
 import com.oceanbase.odc.common.validate.Name;
 import com.oceanbase.odc.core.authority.model.SecurityResource;
-import com.oceanbase.odc.core.shared.ResourceBindToSingleOrganization;
+import com.oceanbase.odc.core.shared.SingleOrganizationResource;
 import com.oceanbase.odc.core.shared.constant.ResourceType;
 
 import lombok.Data;
@@ -38,7 +38,7 @@ import lombok.Data;
  * @Description: []
  */
 @Data
-public class ApprovalFlowConfig implements SecurityResource, ResourceBindToSingleOrganization {
+public class ApprovalFlowConfig implements SecurityResource, SingleOrganizationResource {
     @JsonProperty(access = Access.READ_ONLY)
     private Long id;
 

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/regulation/ruleset/model/Rule.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/regulation/ruleset/model/Rule.java
@@ -25,7 +25,7 @@ import com.fasterxml.jackson.annotation.JsonProperty.Access;
 import com.oceanbase.odc.common.i18n.Internationalizable;
 import com.oceanbase.odc.common.json.NormalDialectTypeOutput;
 import com.oceanbase.odc.core.authority.model.SecurityResource;
-import com.oceanbase.odc.core.shared.OrganizationIsolated;
+import com.oceanbase.odc.core.shared.ResourceBindToSingleOrganization;
 import com.oceanbase.odc.core.shared.constant.DialectType;
 import com.oceanbase.odc.core.shared.constant.ResourceType;
 import com.oceanbase.odc.service.sqlcheck.model.CheckViolation;
@@ -39,7 +39,7 @@ import lombok.Data;
  */
 
 @Data
-public class Rule implements SecurityResource, OrganizationIsolated, Serializable {
+public class Rule implements SecurityResource, ResourceBindToSingleOrganization, Serializable {
 
     @JsonProperty(access = Access.READ_ONLY)
     private Long id;

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/regulation/ruleset/model/Rule.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/regulation/ruleset/model/Rule.java
@@ -25,7 +25,7 @@ import com.fasterxml.jackson.annotation.JsonProperty.Access;
 import com.oceanbase.odc.common.i18n.Internationalizable;
 import com.oceanbase.odc.common.json.NormalDialectTypeOutput;
 import com.oceanbase.odc.core.authority.model.SecurityResource;
-import com.oceanbase.odc.core.shared.ResourceBindToSingleOrganization;
+import com.oceanbase.odc.core.shared.SingleOrganizationResource;
 import com.oceanbase.odc.core.shared.constant.DialectType;
 import com.oceanbase.odc.core.shared.constant.ResourceType;
 import com.oceanbase.odc.service.sqlcheck.model.CheckViolation;
@@ -39,7 +39,7 @@ import lombok.Data;
  */
 
 @Data
-public class Rule implements SecurityResource, ResourceBindToSingleOrganization, Serializable {
+public class Rule implements SecurityResource, SingleOrganizationResource, Serializable {
 
     @JsonProperty(access = Access.READ_ONLY)
     private Long id;

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/regulation/ruleset/model/Ruleset.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/regulation/ruleset/model/Ruleset.java
@@ -26,7 +26,7 @@ import com.fasterxml.jackson.annotation.JsonProperty.Access;
 import com.oceanbase.odc.common.i18n.Internationalizable;
 import com.oceanbase.odc.common.validate.Name;
 import com.oceanbase.odc.core.authority.model.SecurityResource;
-import com.oceanbase.odc.core.shared.ResourceBindToSingleOrganization;
+import com.oceanbase.odc.core.shared.SingleOrganizationResource;
 import com.oceanbase.odc.core.shared.constant.ResourceType;
 import com.oceanbase.odc.service.common.model.InnerUser;
 
@@ -39,7 +39,7 @@ import lombok.Data;
  */
 
 @Data
-public class Ruleset implements SecurityResource, ResourceBindToSingleOrganization, Serializable {
+public class Ruleset implements SecurityResource, SingleOrganizationResource, Serializable {
     private Long id;
 
     @Internationalizable

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/regulation/ruleset/model/Ruleset.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/regulation/ruleset/model/Ruleset.java
@@ -26,7 +26,7 @@ import com.fasterxml.jackson.annotation.JsonProperty.Access;
 import com.oceanbase.odc.common.i18n.Internationalizable;
 import com.oceanbase.odc.common.validate.Name;
 import com.oceanbase.odc.core.authority.model.SecurityResource;
-import com.oceanbase.odc.core.shared.OrganizationIsolated;
+import com.oceanbase.odc.core.shared.ResourceBindToSingleOrganization;
 import com.oceanbase.odc.core.shared.constant.ResourceType;
 import com.oceanbase.odc.service.common.model.InnerUser;
 
@@ -39,7 +39,7 @@ import lombok.Data;
  */
 
 @Data
-public class Ruleset implements SecurityResource, OrganizationIsolated, Serializable {
+public class Ruleset implements SecurityResource, ResourceBindToSingleOrganization, Serializable {
     private Long id;
 
     @Internationalizable

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/resourcegroup/ResourceGroup.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/resourcegroup/ResourceGroup.java
@@ -32,7 +32,7 @@ import org.apache.commons.lang.Validate;
 import org.springframework.data.jpa.domain.Specification;
 
 import com.oceanbase.odc.core.authority.model.SecurityResource;
-import com.oceanbase.odc.core.shared.ResourceBindToSingleOrganization;
+import com.oceanbase.odc.core.shared.SingleOrganizationResource;
 import com.oceanbase.odc.core.shared.Verify;
 import com.oceanbase.odc.core.shared.constant.ErrorCodes;
 import com.oceanbase.odc.core.shared.constant.ResourceType;
@@ -69,7 +69,7 @@ import lombok.ToString;
 @ToString(exclude = {"resourceGroupRepository", "resourceGroupConnectionRepository", "authenticationFacade"})
 @EqualsAndHashCode(exclude = {"resourceGroupRepository", "resourceGroupConnectionRepository",
         "authenticationFacade", "createTime", "updateTime"})
-public class ResourceGroup implements SecurityResource, ResourceBindToSingleOrganization {
+public class ResourceGroup implements SecurityResource, SingleOrganizationResource {
 
     private Long id;
     @Setter

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/resourcegroup/ResourceGroup.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/resourcegroup/ResourceGroup.java
@@ -32,7 +32,7 @@ import org.apache.commons.lang.Validate;
 import org.springframework.data.jpa.domain.Specification;
 
 import com.oceanbase.odc.core.authority.model.SecurityResource;
-import com.oceanbase.odc.core.shared.OrganizationIsolated;
+import com.oceanbase.odc.core.shared.ResourceBindToSingleOrganization;
 import com.oceanbase.odc.core.shared.Verify;
 import com.oceanbase.odc.core.shared.constant.ErrorCodes;
 import com.oceanbase.odc.core.shared.constant.ResourceType;
@@ -69,7 +69,7 @@ import lombok.ToString;
 @ToString(exclude = {"resourceGroupRepository", "resourceGroupConnectionRepository", "authenticationFacade"})
 @EqualsAndHashCode(exclude = {"resourceGroupRepository", "resourceGroupConnectionRepository",
         "authenticationFacade", "createTime", "updateTime"})
-public class ResourceGroup implements SecurityResource, OrganizationIsolated {
+public class ResourceGroup implements SecurityResource, ResourceBindToSingleOrganization {
 
     private Long id;
     @Setter

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/schedule/model/ScheduleDetailRespHist.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/schedule/model/ScheduleDetailRespHist.java
@@ -20,7 +20,7 @@ import java.util.List;
 import java.util.Set;
 
 import com.oceanbase.odc.common.i18n.Internationalizable;
-import com.oceanbase.odc.core.shared.OrganizationIsolated;
+import com.oceanbase.odc.core.shared.ResourceBindToSingleOrganization;
 import com.oceanbase.odc.core.shared.constant.ResourceType;
 import com.oceanbase.odc.metadb.flow.FlowInstanceEntity;
 import com.oceanbase.odc.service.collaboration.project.model.Project;
@@ -37,7 +37,7 @@ import lombok.Data;
  */
 
 @Data
-public class ScheduleDetailRespHist implements OrganizationIsolated {
+public class ScheduleDetailRespHist implements ResourceBindToSingleOrganization {
 
 
     private Long id;

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/schedule/model/ScheduleDetailRespHist.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/schedule/model/ScheduleDetailRespHist.java
@@ -20,7 +20,7 @@ import java.util.List;
 import java.util.Set;
 
 import com.oceanbase.odc.common.i18n.Internationalizable;
-import com.oceanbase.odc.core.shared.ResourceBindToSingleOrganization;
+import com.oceanbase.odc.core.shared.SingleOrganizationResource;
 import com.oceanbase.odc.core.shared.constant.ResourceType;
 import com.oceanbase.odc.metadb.flow.FlowInstanceEntity;
 import com.oceanbase.odc.service.collaboration.project.model.Project;
@@ -37,7 +37,7 @@ import lombok.Data;
  */
 
 @Data
-public class ScheduleDetailRespHist implements ResourceBindToSingleOrganization {
+public class ScheduleDetailRespHist implements SingleOrganizationResource {
 
 
     private Long id;

--- a/server/plugins/task-plugin-ob-mysql/src/main/java/com/oceanbase/odc/plugin/task/obmysql/datatransfer/factory/BaseParameterFactory.java
+++ b/server/plugins/task-plugin-ob-mysql/src/main/java/com/oceanbase/odc/plugin/task/obmysql/datatransfer/factory/BaseParameterFactory.java
@@ -148,6 +148,13 @@ public abstract class BaseParameterFactory<T extends BaseParameter> {
 
         sessionConfig.setJdbcOption("sendConnectionAttributes", "true");
         sessionConfig.setJdbcOption("defaultConnectionAttributesBanList", "__client_ip");
+
+        if (StringUtils.isNotBlank(transferConfig.getConnectionInfo().getProxyHost())
+                && Objects.nonNull(transferConfig.getConnectionInfo().getProxyPort())) {
+            sessionConfig.setJdbcOption("socksProxyHost", transferConfig.getConnectionInfo().getProxyHost());
+            sessionConfig.setJdbcOption("socksProxyPort", transferConfig.getConnectionInfo().getProxyPort() + "");
+        }
+
         Optional.ofNullable(transferConfig.getExecutionTimeoutSeconds())
                 .ifPresent(timeout -> {
                     sessionConfig.setJdbcOption("socketTimeout", timeout * 1000 + "");

--- a/server/plugins/task-plugin-ob-mysql/src/main/java/com/oceanbase/odc/plugin/task/obmysql/datatransfer/factory/BaseParameterFactory.java
+++ b/server/plugins/task-plugin-ob-mysql/src/main/java/com/oceanbase/odc/plugin/task/obmysql/datatransfer/factory/BaseParameterFactory.java
@@ -151,8 +151,7 @@ public abstract class BaseParameterFactory<T extends BaseParameter> {
 
         if (StringUtils.isNotBlank(transferConfig.getConnectionInfo().getProxyHost())
                 && Objects.nonNull(transferConfig.getConnectionInfo().getProxyPort())) {
-            sessionConfig.setJdbcOption("socksProxyHost",
-                    String.valueOf(transferConfig.getConnectionInfo().getProxyHost()));
+            sessionConfig.setJdbcOption("socksProxyHost", transferConfig.getConnectionInfo().getProxyHost());
             sessionConfig.setJdbcOption("socksProxyPort",
                     String.valueOf(transferConfig.getConnectionInfo().getProxyPort()));
         }

--- a/server/plugins/task-plugin-ob-mysql/src/main/java/com/oceanbase/odc/plugin/task/obmysql/datatransfer/factory/BaseParameterFactory.java
+++ b/server/plugins/task-plugin-ob-mysql/src/main/java/com/oceanbase/odc/plugin/task/obmysql/datatransfer/factory/BaseParameterFactory.java
@@ -151,8 +151,10 @@ public abstract class BaseParameterFactory<T extends BaseParameter> {
 
         if (StringUtils.isNotBlank(transferConfig.getConnectionInfo().getProxyHost())
                 && Objects.nonNull(transferConfig.getConnectionInfo().getProxyPort())) {
-            sessionConfig.setJdbcOption("socksProxyHost", transferConfig.getConnectionInfo().getProxyHost());
-            sessionConfig.setJdbcOption("socksProxyPort", transferConfig.getConnectionInfo().getProxyPort() + "");
+            sessionConfig.setJdbcOption("socksProxyHost",
+                    String.valueOf(transferConfig.getConnectionInfo().getProxyHost()));
+            sessionConfig.setJdbcOption("socksProxyPort",
+                    String.valueOf(transferConfig.getConnectionInfo().getProxyPort()));
         }
 
         Optional.ofNullable(transferConfig.getExecutionTimeoutSeconds())

--- a/server/starters/web-starter/src/main/java/com/oceanbase/odc/service/iam/auth/saml/DefaultSamlUserService.java
+++ b/server/starters/web-starter/src/main/java/com/oceanbase/odc/service/iam/auth/saml/DefaultSamlUserService.java
@@ -20,12 +20,14 @@ import org.springframework.security.saml2.provider.service.authentication.Saml2A
 import org.springframework.stereotype.Service;
 
 import com.oceanbase.odc.core.authority.util.SkipAuthorize;
+import com.oceanbase.odc.service.common.util.ConditionalOnProperty;
 import com.oceanbase.odc.service.iam.auth.MappingRuleConvert;
 import com.oceanbase.odc.service.iam.auth.SsoUserDetailService;
 import com.oceanbase.odc.service.iam.auth.oauth2.MappingResult;
 import com.oceanbase.odc.service.iam.model.User;
 
 @Service
+@ConditionalOnProperty(value = "odc.iam.auth.type", havingValues = {"local"})
 public class DefaultSamlUserService {
 
     @Autowired


### PR DESCRIPTION
#### What type of PR is this?
type-adaption-for_obcloud

#### What this PR does / why we need it:
Adaption for deploy a new ODC 4.3.3 cluster in oblcoud.
This pr makes the following changes:
- Add new method `listInstances(Long organizationId)` in `CloudMetadataClient` to list all oceanbase instances under an obcloud organization.
- `UserService#listUserWithQueryParams` is modified to list users in an organization by query table of `iam_user_organization` instead of only by `iam_user` table, because a user can belong to multiple organizations.
- `BaseParameterFactory#setInitSqls` adaption for using ic to connect to instance by ob-loaddumper.
- Adaption for the horizontal authentication strategy that allows a user belong to multiple organizations in `HorizontalDataPermissionValidator` and `OrganizationIsolatedValueProvider`:
    + I renamed `OrganizationIsolated` to `OrganizationResource`, and create `SingleOrganizationResource` and `MultiOrganizationResource` which extends from it to distinguish whether a resource can belong to more than one organization. 
    + Only `User` model implements  `MultiOrganizationResource`, other models that originally implements `OrganizationIsolated` are changed to implements `SingleOrganizationResource`.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

<!--
This section is used to describe how this PR is implemented. 
If this is a PR that fixes a bug, this section describes how the bug was fixed.
If it's a new feature, this section briefly describes how to implement the new feature.
etc.
-->

#### Additional documentation e.g., usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```