### PR TITLE
feat(database): Sync current user database objects when grouping databases

### DIFF
--- a/server/odc-server/src/main/java/com/oceanbase/odc/server/web/controller/v2/DBObjectIndexController.java
+++ b/server/odc-server/src/main/java/com/oceanbase/odc/server/web/controller/v2/DBObjectIndexController.java
@@ -70,7 +70,7 @@ public class DBObjectIndexController {
 
     @ApiOperation(value = "syncCurrentUserVisibleDatabases",
             notes = "Sync all databases visible to the current user")
-    @RequestMapping(value = "/sync/currentUser", method = RequestMethod.POST)
+    @RequestMapping(value = "/syncAll", method = RequestMethod.POST)
     public SuccessResponse<Boolean> syncCurrentUserVisibleDatabases() {
         return Responses.success(dbSchemaIndexService.syncCurrentUserVisibleDatabases());
     }

--- a/server/odc-server/src/main/java/com/oceanbase/odc/server/web/controller/v2/DBObjectIndexController.java
+++ b/server/odc-server/src/main/java/com/oceanbase/odc/server/web/controller/v2/DBObjectIndexController.java
@@ -68,5 +68,12 @@ public class DBObjectIndexController {
         return Responses.success(dbSchemaIndexService.syncDatabaseObjects(req));
     }
 
+    @ApiOperation(value = "syncCurrentUserDatabaseObjectsWithProject",
+            notes = "Sync all database objects under the project that the current user is joining")
+    @RequestMapping(value = "/syncAllWithProject", method = RequestMethod.POST)
+    public SuccessResponse<Boolean> syncCurrentUserDatabaseObjectsWithProject() {
+        return Responses.success(dbSchemaIndexService.syncCurrentUserDatabaseObjectsWithProject());
+    }
+
 
 }

--- a/server/odc-server/src/main/java/com/oceanbase/odc/server/web/controller/v2/DBObjectIndexController.java
+++ b/server/odc-server/src/main/java/com/oceanbase/odc/server/web/controller/v2/DBObjectIndexController.java
@@ -68,11 +68,11 @@ public class DBObjectIndexController {
         return Responses.success(dbSchemaIndexService.syncDatabaseObjects(req));
     }
 
-    @ApiOperation(value = "syncCurrentUserDatabaseObjectsWithProject",
-            notes = "Sync all database objects under the project that the current user is joining")
-    @RequestMapping(value = "/syncAllWithProject", method = RequestMethod.POST)
-    public SuccessResponse<Boolean> syncCurrentUserDatabaseObjectsWithProject() {
-        return Responses.success(dbSchemaIndexService.syncCurrentUserDatabaseObjectsWithProject());
+    @ApiOperation(value = "syncCurrentUserVisibleDatabases",
+            notes = "Sync all databases visible to the current user")
+    @RequestMapping(value = "/sync/currentUser", method = RequestMethod.POST)
+    public SuccessResponse<Boolean> syncCurrentUserVisibleDatabases() {
+        return Responses.success(dbSchemaIndexService.syncCurrentUserVisibleDatabases());
     }
 
 

--- a/server/odc-service/src/main/java/com/oceanbase/odc/metadb/connection/DatabaseRepository.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/metadb/connection/DatabaseRepository.java
@@ -46,6 +46,9 @@ public interface DatabaseRepository extends JpaRepository<DatabaseEntity, Long>,
 
     List<DatabaseEntity> findByProjectIdAndExisted(Long projectId, Boolean existed);
 
+    List<DatabaseEntity> findByProjectIdInAndExistedAndObjectSyncStatusNot(Collection<Long> projectIds, Boolean existed,
+            DBObjectSyncStatus dbObjectSyncStatus);
+
     List<DatabaseEntity> findByIdIn(Collection<Long> ids);
 
     List<DatabaseEntity> findByNameIn(Collection<String> name);

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/connection/database/DatabaseService.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/connection/database/DatabaseService.java
@@ -460,6 +460,17 @@ public class DatabaseService {
     }
 
     @SkipAuthorize("internal usage")
+    public Set<Database> listExistAndNotPendingDatabasesByProjectIdIn(@NonNull Collection<Long> projectIds) {
+        if (CollectionUtils.isEmpty(projectIds)) {
+            return Collections.emptySet();
+        }
+        return databaseRepository
+                .findByProjectIdInAndExistedAndObjectSyncStatusNot(projectIds, true, DBObjectSyncStatus.PENDING)
+                .stream()
+                .map(databaseMapper::entityToModel).collect(Collectors.toSet());
+    }
+
+    @SkipAuthorize("internal usage")
     public Set<Database> listDatabaseByNames(@NotEmpty Collection<String> names) {
         return databaseRepository.findByNameIn(names).stream().map(databaseMapper::entityToModel)
                 .collect(Collectors.toSet());

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/db/schema/DBSchemaIndexService.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/db/schema/DBSchemaIndexService.java
@@ -199,7 +199,7 @@ public class DBSchemaIndexService {
         return resp;
     }
 
-    public Boolean syncCurrentUserDatabaseObjectsWithProject() {
+    public Boolean syncCurrentUserVisibleDatabases() {
         this.databaseService.refreshExpiredPendingDBObjectStatus();
         long userId = authenticationFacade.currentUserId();
         Set<Long> joinedProjectIds = projectService.getMemberProjectIds(userId);

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/db/schema/DBSchemaIndexService.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/db/schema/DBSchemaIndexService.java
@@ -199,6 +199,18 @@ public class DBSchemaIndexService {
         return resp;
     }
 
+    public Boolean syncCurrentUserDatabaseObjectsWithProject() {
+        this.databaseService.refreshExpiredPendingDBObjectStatus();
+        long userId = authenticationFacade.currentUserId();
+        Set<Long> joinedProjectIds = projectService.getMemberProjectIds(userId);
+        if (CollectionUtils.isEmpty(joinedProjectIds)) {
+            return true;
+        }
+        dbSchemaSyncTaskManager
+                .submitTaskByDatabases(databaseService.listExistAndNotPendingDatabasesByProjectIdIn(joinedProjectIds));
+        return true;
+    }
+
     public Boolean syncDatabaseObjects(@NonNull @Valid SyncDBObjectReq req) {
         this.databaseService.refreshExpiredPendingDBObjectStatus();
         Set<Database> databases = new HashSet<>();


### PR DESCRIPTION
#### What type of PR is this?
type-feature

#### What this PR does / why we need it:
At present, the section that groups databases in the resource tree will obtain all databases that the user has the right to operate. In this case, all data objects under the project that the user has joined need to be synchronized