### PR TITLE
fix(task): correct executorIdenfifier port to odc server port for process mode

### DIFF
--- a/server/odc-server/src/main/java/com/oceanbase/odc/supervisor/runtime/SupervisorApplication.java
+++ b/server/odc-server/src/main/java/com/oceanbase/odc/supervisor/runtime/SupervisorApplication.java
@@ -46,7 +46,7 @@ public class SupervisorApplication {
         // TODO(longxuan): will be given in future release
         TaskSupervisor taskSupervisor =
                 new TaskSupervisor(new SupervisorEndpoint(SystemUtils.getLocalIpAddress(), port),
-                        JobConstants.ODC_AGENT_CLASS_NAME);
+                        -1, JobConstants.ODC_AGENT_CLASS_NAME);
         taskSupervisorServer = new TaskSupervisorServer(port, new LocalTaskCommandExecutor(taskSupervisor));
         try {
             taskSupervisorServer.start();

--- a/server/odc-server/src/test/java/com/oceanbase/odc/supervisor/SupervisorApplicationTest.java
+++ b/server/odc-server/src/test/java/com/oceanbase/odc/supervisor/SupervisorApplicationTest.java
@@ -81,9 +81,9 @@ public class SupervisorApplicationTest {
         supervisorApplication.start(new String[] {});
         String ip = SystemUtils.getLocalIpAddress();
         remoteSupervisorEndpoint = new SupervisorEndpoint(ip, allocatePort);
-        localSupervisorEndpoint = new SupervisorEndpoint(ip, 8989);
+        localSupervisorEndpoint = new SupervisorEndpoint(ip, 8999);
         localTaskSupervisorProxy =
-                new LocalTaskSupervisorProxy(localSupervisorEndpoint, JobConstants.ODC_AGENT_CLASS_NAME);
+                new LocalTaskSupervisorProxy(localSupervisorEndpoint, 8989, JobConstants.ODC_AGENT_CLASS_NAME);
         JobEventHandler jobEventHandler = Mockito.mock(JobEventHandler.class);
         taskSupervisorJobCaller =
                 new TaskSupervisorJobCaller(jobEventHandler, localTaskSupervisorProxy, new TaskExecutorClient());

--- a/server/odc-server/src/test/java/com/oceanbase/odc/supervisor/runtime/TaskSupervisorServerTest.java
+++ b/server/odc-server/src/test/java/com/oceanbase/odc/supervisor/runtime/TaskSupervisorServerTest.java
@@ -113,7 +113,7 @@ public class TaskSupervisorServerTest {
 
     @Test
     public void testNoneStartCommandProcess() throws IOException {
-        ExecutorEndpoint endpoint = new ExecutorEndpoint("command", "127.0.0.1", 8989, 12345, "identifier");
+        ExecutorEndpoint endpoint = new ExecutorEndpoint("command", "127.0.0.1", 8999, 8989, 12345, "identifier");
         for (CommandType commandType : CommandType.values()) {
             if (commandType == CommandType.START) {
                 continue;

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/task/caller/BaseJobCaller.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/task/caller/BaseJobCaller.java
@@ -26,6 +26,8 @@ import com.oceanbase.odc.service.task.exception.JobException;
 import com.oceanbase.odc.service.task.listener.JobCallerEvent;
 import com.oceanbase.odc.service.task.schedule.JobIdentity;
 import com.oceanbase.odc.service.task.service.TaskFrameworkService;
+import com.oceanbase.odc.service.task.supervisor.endpoint.ExecutorEndpoint;
+import com.oceanbase.odc.service.task.util.JobUtils;
 import com.oceanbase.odc.service.task.util.TaskExecutorClient;
 import com.oceanbase.odc.service.task.util.TaskSupervisorUtil;
 
@@ -52,8 +54,10 @@ public abstract class BaseJobCaller implements JobCaller {
         }
         try {
             executorInfo = doStart(context);
-            executorIdentifier = executorInfo.getExecutorIdentifier();;
+            ExecutorEndpoint executorEndpoint = executorInfo.getExecutorEndpoint();
+            executorIdentifier = JobUtils.getCorrectedExecutorIdentifier(executorEndpoint, jobConfiguration);
             rows = taskFrameworkService.startSuccess(ji.getId(), executorInfo.getResourceID(),
+                    executorEndpoint.getExecutorPort(),
                     executorIdentifier.toString(), context);
             if (rows > 0) {
                 afterStartSucceed(executorIdentifier, ji);

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/task/caller/ExecutorIdentifier.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/task/caller/ExecutorIdentifier.java
@@ -26,6 +26,7 @@ public interface ExecutorIdentifier {
 
     String getHost();
 
+    // that's the server port, not the executor's listen port for process mode
     int getPort();
 
     String getNamespace();

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/task/caller/ExecutorInfo.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/task/caller/ExecutorInfo.java
@@ -16,6 +16,7 @@
 package com.oceanbase.odc.service.task.caller;
 
 import com.oceanbase.odc.service.resource.ResourceID;
+import com.oceanbase.odc.service.task.supervisor.endpoint.ExecutorEndpoint;
 
 import lombok.Data;
 
@@ -26,5 +27,5 @@ import lombok.Data;
 @Data
 public class ExecutorInfo {
     private final ResourceID resourceID;
-    private final ExecutorIdentifier executorIdentifier;
+    private final ExecutorEndpoint executorEndpoint;
 }

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/task/caller/JobCallerBuilder.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/task/caller/JobCallerBuilder.java
@@ -19,6 +19,7 @@ import java.util.Date;
 import java.util.Map;
 
 import com.oceanbase.odc.common.util.StringUtils;
+import com.oceanbase.odc.common.util.SystemUtils;
 import com.oceanbase.odc.service.resource.ResourceManager;
 import com.oceanbase.odc.service.task.config.JobConfiguration;
 import com.oceanbase.odc.service.task.config.JobConfigurationHolder;
@@ -29,6 +30,8 @@ import com.oceanbase.odc.service.task.enums.TaskMonitorMode;
 import com.oceanbase.odc.service.task.enums.TaskRunMode;
 import com.oceanbase.odc.service.task.jasypt.JasyptEncryptorConfigProperties;
 import com.oceanbase.odc.service.task.resource.PodConfig;
+import com.oceanbase.odc.service.task.supervisor.TaskSupervisor;
+import com.oceanbase.odc.service.task.supervisor.endpoint.SupervisorEndpoint;
 import com.oceanbase.odc.service.task.util.JobPropertiesUtils;
 import com.oceanbase.odc.service.task.util.JobUtils;
 
@@ -63,7 +66,9 @@ public class JobCallerBuilder {
         String mainClassName = StringUtils.isBlank(taskFrameworkProperties.getProcessMainClassName())
                 ? JobConstants.ODC_AGENT_CLASS_NAME
                 : taskFrameworkProperties.getProcessMainClassName();
-        return new ProcessJobCaller(config, mainClassName);
+        TaskSupervisor taskSupervisor = new TaskSupervisor(new SupervisorEndpoint(SystemUtils.getLocalIpAddress(),
+                DefaultExecutorIdentifier.DEFAULT_PORT), JobUtils.getODCServerPort(configuration), mainClassName);
+        return new ProcessJobCaller(config, taskSupervisor);
     }
 
     /**

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/task/caller/K8sJobCaller.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/task/caller/K8sJobCaller.java
@@ -30,6 +30,7 @@ import com.oceanbase.odc.service.task.resource.K8sPodResource;
 import com.oceanbase.odc.service.task.resource.K8sResourceContext;
 import com.oceanbase.odc.service.task.resource.PodConfig;
 import com.oceanbase.odc.service.task.schedule.JobIdentity;
+import com.oceanbase.odc.service.task.supervisor.endpoint.ExecutorEndpoint;
 import com.oceanbase.odc.service.task.util.JobUtils;
 
 import lombok.extern.slf4j.Slf4j;
@@ -64,12 +65,16 @@ public class K8sJobCaller extends BaseJobCaller {
                     resourceManager.create(resourceLocation, buildK8sResourceContext(context, resourceLocation));
             K8sPodResource k8sPodResource = resource.getResource();
             String arn = k8sPodResource.resourceID().getIdentifier();
-
-            return new ExecutorInfo(k8sPodResource.resourceID(),
+            ExecutorIdentifier executorIdentifier =
                     DefaultExecutorIdentifier.builder().namespace(resource.getResource().getNamespace())
                             .host(resource.getResource().getPodIpAddress())
                             .port(Integer.valueOf(resource.getResource().getServicePort()))
-                            .executorName(arn).build());
+                            .executorName(arn).build();
+            ExecutorEndpoint executorEndpoint = new ExecutorEndpoint("k8s", resource.getResource().getPodIpAddress(),
+                    -1, -1,
+                    Integer.valueOf(resource.getResource().getServicePort()), executorIdentifier.toString());
+            return new ExecutorInfo(k8sPodResource.resourceID(),
+                    executorEndpoint);
         } catch (Throwable e) {
             throw new JobException("doStart failed for " + context, e);
         }

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/task/dummy/LocalMockK8sJobClient.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/task/dummy/LocalMockK8sJobClient.java
@@ -62,8 +62,8 @@ public class LocalMockK8sJobClient implements K8sJobClientSelector {
         private final TaskSupervisor taskSupervisor;
 
         public LocalProcessClient() {
-            taskSupervisor = new TaskSupervisor(new SupervisorEndpoint(SystemUtils.getLocalIpAddress(), 8989),
-                    "com.oceanbase.odc.supervisor.SupervisorAgent");
+            taskSupervisor = new TaskSupervisor(new SupervisorEndpoint(SystemUtils.getLocalIpAddress(), 8999),
+                    8989, "com.oceanbase.odc.supervisor.SupervisorAgent");
             taskSupervisor.setJobInfoSerializer(null);
         }
 
@@ -76,7 +76,8 @@ public class LocalMockK8sJobClient implements K8sJobClientSelector {
                         JobCallerBuilder.buildK8sEnv(jobContext, LogUtils.getBaseLogPath()));
                 ExecutorInfo executorInfo = jobCaller.doStart(
                         jobContext);
-                ExecutorIdentifier executorIdentifier = executorInfo.getExecutorIdentifier();
+                ExecutorEndpoint endpoint = executorInfo.getExecutorEndpoint();
+                ExecutorIdentifier executorIdentifier = ExecutorIdentifierParser.parser(endpoint.getIdentifier());
 
                 return new K8sPodResource(k8sResourceContext.getRegion(), k8sResourceContext.getGroup(),
                         k8sResourceContext.type(),

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/task/resource/LocalProcessResource.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/task/resource/LocalProcessResource.java
@@ -27,7 +27,6 @@ import com.oceanbase.odc.service.task.supervisor.TaskSupervisor;
 import com.oceanbase.odc.service.task.supervisor.endpoint.SupervisorEndpoint;
 import com.oceanbase.odc.service.task.supervisor.runtime.LocalTaskCommandExecutor;
 import com.oceanbase.odc.service.task.supervisor.runtime.TaskSupervisorServer;
-import com.oceanbase.odc.service.task.util.TaskSupervisorUtil;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -41,21 +40,25 @@ import lombok.extern.slf4j.Slf4j;
 public class LocalProcessResource {
     protected final SupervisorEndpointRepository supervisorEndpointRepository;
     protected TaskSupervisorServer taskSupervisorServer;
+    private final SupervisorEndpoint supervisorEndpoint;
+    private final Integer supervisorOwnerPort;
 
-    public LocalProcessResource(SupervisorEndpointRepository supervisorEndpointRepository) {
+    public LocalProcessResource(SupervisorEndpointRepository supervisorEndpointRepository,
+            SupervisorEndpoint supervisorEndpoint, Integer supervisorOwnerPort) {
         this.supervisorEndpointRepository = supervisorEndpointRepository;
+        this.supervisorOwnerPort = supervisorOwnerPort;
+        this.supervisorEndpoint = supervisorEndpoint;
     }
 
     public void prepareLocalProcessResource() {
-        SupervisorEndpoint localEndpoint = TaskSupervisorUtil.getDefaultSupervisorEndpoint();
-        startTaskSupervisorServer(localEndpoint);
-        tryRegisterTaskSupervisorAgent(localEndpoint);
+        startTaskSupervisorServer(supervisorEndpoint);
+        tryRegisterTaskSupervisorAgent(supervisorEndpoint);
     }
 
     private void startTaskSupervisorServer(SupervisorEndpoint supervisorEndpoint) {
         TaskSupervisor taskSupervisor =
                 new TaskSupervisor(supervisorEndpoint,
-                        JobConstants.ODC_AGENT_CLASS_NAME);
+                        supervisorOwnerPort, JobConstants.ODC_AGENT_CLASS_NAME);
         taskSupervisorServer =
                 new TaskSupervisorServer(supervisorEndpoint.getPort(), new LocalTaskCommandExecutor(taskSupervisor));
         try {

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/task/schedule/daemon/v2/DoFinishJobV2.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/task/schedule/daemon/v2/DoFinishJobV2.java
@@ -51,6 +51,7 @@ import com.oceanbase.odc.service.task.supervisor.TaskCallerResult;
 import com.oceanbase.odc.service.task.supervisor.TaskSupervisor;
 import com.oceanbase.odc.service.task.supervisor.endpoint.ExecutorEndpoint;
 import com.oceanbase.odc.service.task.supervisor.endpoint.SupervisorEndpoint;
+import com.oceanbase.odc.service.task.util.JobUtils;
 
 import cn.hutool.core.util.StrUtil;
 import lombok.extern.slf4j.Slf4j;
@@ -173,6 +174,7 @@ public class DoFinishJobV2 implements Job {
         ExecutorIdentifier identifier = ExecutorIdentifierParser.parser(executorIdentifierStr);
         ExecutorEndpoint executorEndpoint =
                 new ExecutorEndpoint("command", supervisorEndpoint.getHost(), supervisorEndpoint.getPort(),
+                        JobUtils.getODCServerPort(configuration),
                         identifier.getPort(), executorIdentifierStr);
         JobContext jobContext = new DefaultJobContextBuilder().build(jobEntity, configuration);
         TaskCallerResult taskCallerResult = configuration.getTaskSupervisorJobCaller().destroyTask(supervisorEndpoint,
@@ -195,7 +197,7 @@ public class DoFinishJobV2 implements Job {
         if (StringUtils.equals(StringUtils.trim(identifier.getHost()),
                 StringUtils.trim(SystemUtils.getLocalIpAddress()))) {
             // in same machine, kill it
-            TaskSupervisor taskSupervisor = new TaskSupervisor(null, null);
+            TaskSupervisor taskSupervisor = new TaskSupervisor(null, null, null);
             taskSupervisor.destroyTask(identifier);
             return true;
         } else {

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/task/service/StdTaskFrameworkService.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/task/service/StdTaskFrameworkService.java
@@ -318,7 +318,8 @@ public class StdTaskFrameworkService implements TaskFrameworkService {
     }
 
     @Override
-    public int startSuccess(Long id, ResourceID resourceID, String executorIdentifier, JobContext jobContext) {
+    public int startSuccess(Long id, ResourceID resourceID, int executorListenPort, String executorIdentifier,
+            JobContext jobContext) {
         JobEntity jobEntity = find(id);
         Map<String, String> jobProperties = jobEntity.getJobProperties();
         // resource id null will not correct jobProperties
@@ -351,15 +352,15 @@ public class StdTaskFrameworkService implements TaskFrameworkService {
             if (!StringUtils.startsWith(host, "http")) {
                 host = "http://" + host;
             }
-            String port = String.valueOf(identifier.getPort());
+            String port = String.valueOf(executorListenPort);
             return jobRepository.updateExecutorEndpointAndExecutorIdentifierById(jobEntity.getId(), host + ":" + port,
                     executorIdentifier);
         }
     }
 
     @Override
-    public int startSuccess(Long id, String executorIdentifier, JobContext jobContext) {
-        return startSuccess(id, null, executorIdentifier, jobContext);
+    public int startSuccess(Long id, int executorListenPort, String executorIdentifier, JobContext jobContext) {
+        return startSuccess(id, null, executorListenPort, executorIdentifier, jobContext);
     }
 
     @Override

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/task/service/TaskFrameworkService.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/task/service/TaskFrameworkService.java
@@ -76,10 +76,11 @@ public interface TaskFrameworkService {
     long countRunningJobs(TaskRunMode runMode);
 
     // api for start job v1
-    int startSuccess(Long id, ResourceID resourceID, String executorIdentifier, JobContext jobContext);
+    int startSuccess(Long id, ResourceID resourceID, int executorListenPort, String executorIdentifier,
+            JobContext jobContext);
 
     // api for start job v2
-    int startSuccess(Long id, String executorIdentifier, JobContext jobContext);
+    int startSuccess(Long id, int executorListenPort, String executorIdentifier, JobContext jobContext);
 
     int beforeStart(Long id);
 

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/task/supervisor/DefaultJobEventListener.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/task/supervisor/DefaultJobEventListener.java
@@ -27,6 +27,7 @@ import com.oceanbase.odc.service.task.listener.JobCallerEvent;
 import com.oceanbase.odc.service.task.schedule.JobIdentity;
 import com.oceanbase.odc.service.task.service.TaskFrameworkService;
 import com.oceanbase.odc.service.task.supervisor.endpoint.ExecutorEndpoint;
+import com.oceanbase.odc.service.task.util.JobUtils;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -52,7 +53,8 @@ public class DefaultJobEventListener implements JobEventHandler {
         JobConfiguration jobConfiguration = JobConfigurationHolder.getJobConfiguration();
         TaskFrameworkService taskFrameworkService = jobConfiguration.getTaskFrameworkService();
         int rows = taskFrameworkService.startSuccess(jobContext.getJobIdentity().getId(),
-                executorIdentifier.getIdentifier(), jobContext);
+                executorIdentifier.getExecutorPort(),
+                JobUtils.getCorrectedExecutorIdentifier(executorIdentifier, jobConfiguration).toString(), jobContext);
         if (rows <= 0) {
             throw new JobException("Update job status to RUNNING failed, jobId={0}.",
                     jobContext.getJobIdentity().getId());

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/task/supervisor/TaskSupervisor.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/task/supervisor/TaskSupervisor.java
@@ -57,13 +57,16 @@ public class TaskSupervisor {
     @Getter
     private final SupervisorEndpoint supervisorEndpoint;
 
+    private final Integer supervisorOwnerPort;
+
     private final String mainClassName;
 
     @Setter
     private BiConsumer<JobContext, ProcessConfig> jobInfoSerializer = TaskSupervisor::writeJobContextToFile;
 
-    public TaskSupervisor(SupervisorEndpoint supervisorEndpoint, String mainClassName) {
+    public TaskSupervisor(SupervisorEndpoint supervisorEndpoint, Integer supervisorOwnerPort, String mainClassName) {
         this.supervisorEndpoint = supervisorEndpoint;
+        this.supervisorOwnerPort = supervisorOwnerPort;
         this.mainClassName = mainClassName;
     }
 
@@ -116,6 +119,7 @@ public class TaskSupervisor {
                 .namespace(pid + "")
                 .executorName(executorName).build();
         return new ExecutorEndpoint(COMMAND_PROTOCOL_NAME, supervisorEndpoint.getHost(), supervisorEndpoint.getPort(),
+                supervisorOwnerPort,
                 port, executorIdentifier.toString());
     }
 

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/task/supervisor/endpoint/ExecutorEndpoint.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/task/supervisor/endpoint/ExecutorEndpoint.java
@@ -28,6 +28,8 @@ public class ExecutorEndpoint {
     private String protocol;
     private String host;
     private Integer supervisorPort;
+    // owner of supervisor to run other protocol, may be null, if not provided
+    private Integer supervisorOwnerPort;
     private Integer executorPort;
     private String identifier;
 

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/task/supervisor/proxy/LocalTaskSupervisorProxy.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/task/supervisor/proxy/LocalTaskSupervisorProxy.java
@@ -41,11 +41,13 @@ public class LocalTaskSupervisorProxy implements TaskSupervisorProxy {
     private final SupervisorEndpoint localEndPoint;
 
     public LocalTaskSupervisorProxy(SupervisorEndpoint supervisorEndpoint,
+            Integer supervisorOwnerPort,
             String mainClassName) {
         this.localEndPoint = supervisorEndpoint;
-        log.info("LocalTaskSupervisorProxy start with endpoint={}", supervisorEndpoint);
+        log.info("LocalTaskSupervisorProxy start with endpoint={}, ownerPort = {}", supervisorEndpoint,
+                supervisorOwnerPort);
         remoteTaskSupervisorProxy = new RemoteTaskSupervisorProxy(new TaskNetClient());
-        taskSupervisor = new TaskSupervisor(supervisorEndpoint, mainClassName);
+        taskSupervisor = new TaskSupervisor(supervisorEndpoint, supervisorOwnerPort, mainClassName);
     }
 
     @Override

--- a/server/odc-service/src/test/java/com/oceanbase/odc/service/task/schedule/daemon/v2/DaemonV2TestBase.java
+++ b/server/odc-service/src/test/java/com/oceanbase/odc/service/task/schedule/daemon/v2/DaemonV2TestBase.java
@@ -27,6 +27,7 @@ import org.springframework.data.domain.Page;
 import com.oceanbase.odc.common.event.EventPublisher;
 import com.oceanbase.odc.common.util.SystemUtils;
 import com.oceanbase.odc.metadb.task.JobEntity;
+import com.oceanbase.odc.service.common.model.HostProperties;
 import com.oceanbase.odc.service.resource.ResourceManager;
 import com.oceanbase.odc.service.task.caller.ResourceIDUtil;
 import com.oceanbase.odc.service.task.config.JobConfiguration;
@@ -49,6 +50,7 @@ import com.oceanbase.odc.service.task.supervisor.endpoint.SupervisorEndpoint;
  */
 public abstract class DaemonV2TestBase {
     protected JobConfiguration configuration;
+    protected HostProperties hostProperties;
     protected TaskFrameworkService taskFrameworkService;
     protected TaskFrameworkProperties taskFrameworkProperties;
     protected JobEntity jobEntity;
@@ -80,6 +82,8 @@ public abstract class DaemonV2TestBase {
         Mockito.when(taskFrameworkService.updateTaskResult(ArgumentMatchers.any(), ArgumentMatchers.any(),
                 ArgumentMatchers.any())).thenReturn(1);
         hostUrlProvider = Mockito.mock(HostUrlProvider.class);
+        hostProperties = Mockito.mock(HostProperties.class);
+        Mockito.when(hostProperties.getPort()).thenReturn("8989");
         configuration = Mockito.mock(JobConfiguration.class);
         startJobRateLimiter = Mockito.mock(StartJobRateLimiter.class);
         jobCredentialProvider = Mockito.mock(JobCredentialProvider.class);
@@ -98,6 +102,7 @@ public abstract class DaemonV2TestBase {
         Mockito.when(configuration.getTransactionManager()).thenReturn(new SimpleTransactionManager());
         Mockito.when(configuration.getJobCredentialProvider()).thenReturn(jobCredentialProvider);
         Mockito.when(configuration.getEventPublisher()).thenReturn(eventPublisher);
+        Mockito.when(configuration.getHostProperties()).thenReturn(hostProperties);
         jobEntity = new JobEntity();
         jobEntity.setId(1024L);
         Map<String, String> jobProperties = new HashMap<>();

--- a/server/odc-service/src/test/java/com/oceanbase/odc/service/task/schedule/daemon/v2/StartPreparingJobV2Test.java
+++ b/server/odc-service/src/test/java/com/oceanbase/odc/service/task/schedule/daemon/v2/StartPreparingJobV2Test.java
@@ -50,7 +50,7 @@ public class StartPreparingJobV2Test extends DaemonV2TestBase {
         Mockito.when(supervisorAgentAllocator.checkAllocateSupervisorEndpointState(ArgumentMatchers.any())).thenReturn(
                 Optional.of(supervisorEndpoint));
         ExecutorEndpoint executorEndpoint = new ExecutorEndpoint("agent", supervisorEndpoint.getHost(),
-                supervisorEndpoint.getPort(), 8888, "identifier");
+                supervisorEndpoint.getPort(), 8989, 8888, "identifier");
         Mockito.when(taskSupervisorJobCaller.startTask(ArgumentMatchers.any(), ArgumentMatchers.any(),
                 ArgumentMatchers.any())).thenReturn(executorEndpoint);
         startPreparingJobV2 = new StartPreparingJobV2();

--- a/server/odc-service/src/test/java/com/oceanbase/odc/service/task/supervisor/TaskSupervisorTest.java
+++ b/server/odc-service/src/test/java/com/oceanbase/odc/service/task/supervisor/TaskSupervisorTest.java
@@ -49,7 +49,7 @@ public class TaskSupervisorTest {
         processConfig.setJvmXmsMB(1024);
         processConfig.setJvmXmxMB(1024);
         processConfig.setEnvironments(new HashMap<>());
-        taskSupervisor = new TaskSupervisor(supervisorEndpoint, TaskSupervisor.class.getName());
+        taskSupervisor = new TaskSupervisor(supervisorEndpoint, 8989, TaskSupervisor.class.getName());
         taskSupervisor.setJobInfoSerializer(null);
     }
 


### PR DESCRIPTION
…cause log get required this port

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines.
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request.
3. Ensure you have added or ran the appropriate tests for your PR.
5. If the PR is unfinished, you may add or remove a WIP or [WIP] prefix to your pull request title.
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
type-bug
type-feature
type-docs
etc.

Optionally add one or more of the following kinds if applicable:
module-resultset
module-sql execution
etc.
-->
type-bug
#### What this PR does / why we need it:
the Port in ExecutorIdentifier have different meaning in different run mode.
In process mode, it represent the ODC server port and will be used for log content get request process.
In K8s mode, it represent the Agent port for future request send.
Correct logic to fix previous logic.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

<!--
This section is used to describe how this PR is implemented. 
If this is a PR that fixes a bug, this section describes how the bug was fixed.
If it's a new feature, this section briefly describes how to implement the new feature.
etc.
-->

#### Additional documentation e.g., usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```