### PR TITLE
fix(Script): only one script download when select many same name scripts

### DIFF
--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/script/ScriptService.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/script/ScriptService.java
@@ -25,8 +25,10 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
@@ -332,10 +334,15 @@ public class ScriptService {
             if (!downloadDir.exists()) {
                 FileUtils.forceMkdir(downloadDir);
             }
+            Map<String, Integer> duplicateNameFileCountMap = new HashMap<>();
             for (ScriptMetaEntity objectMetadata : scriptMetas) {
                 StorageObject storageObject =
                         objectStorageFacade.loadObject(objectMetadata.getBucketName(), objectMetadata.getObjectId());
-                File file = new File(downloadDir, objectMetadata.getObjectName());
+                int count = duplicateNameFileCountMap.getOrDefault(objectMetadata.getObjectName(), 0) + 1;
+                duplicateNameFileCountMap.put(objectMetadata.getObjectName(), count);
+                String fileName =
+                        count > 1 ? objectMetadata.getObjectName() + "(" + count + ")" : objectMetadata.getObjectName();
+                File file = new File(downloadDir, fileName);
                 FileUtils.copyInputStreamToFile(storageObject.getContent(), file);
             }
 

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/script/ScriptService.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/script/ScriptService.java
@@ -338,8 +338,8 @@ public class ScriptService {
             for (ScriptMetaEntity objectMetadata : scriptMetas) {
                 StorageObject storageObject =
                         objectStorageFacade.loadObject(objectMetadata.getBucketName(), objectMetadata.getObjectId());
-                int count = duplicateNameFileCountMap.getOrDefault(objectMetadata.getObjectName(), 0) + 1;
-                duplicateNameFileCountMap.put(objectMetadata.getObjectName(), count);
+                int count = duplicateNameFileCountMap.compute(objectMetadata.getObjectName(),
+                        (k, v) -> v == null ? 1 : v + 1);
                 String fileName =
                         count > 1 ? objectMetadata.getObjectName() + "(" + count + ")" : objectMetadata.getObjectName();
                 File file = new File(downloadDir, fileName);


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines.
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request.
3. Ensure you have added or ran the appropriate tests for your PR.
5. If the PR is unfinished, you may add or remove a WIP or [WIP] prefix to your pull request title.
-->

#### What type of PR is this?
type-bug
<!--
Add one of the following kinds:
type-bug
type-feature
type-docs
etc.

Optionally add one or more of the following kinds if applicable:
module-resultset
module-sql execution
etc.
-->

#### What this PR does / why we need it:
fix bug: only one script download when select many same name scripts
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

<!--
This section is used to describe how this PR is implemented. 
If this is a PR that fixes a bug, this section describes how the bug was fixed.
If it's a new feature, this section briefly describes how to implement the new feature.
etc.
-->

#### Additional documentation e.g., usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```