### PR TITLE
fix(sql-execute): remove length check when querying sql audit

### DIFF
--- a/server/odc-core/src/main/java/com/oceanbase/odc/core/sql/util/OBUtils.java
+++ b/server/odc-core/src/main/java/com/oceanbase/odc/core/sql/util/OBUtils.java
@@ -492,7 +492,7 @@ public class OBUtils {
                 .append(dialectType.isMysql() ? "oceanbase" : "sys")
                 .append(".gv$ob_sql_audit where trace_id=")
                 .value(traceId)
-                .append(" and length(query_sql)>0 and is_inner_sql=0 ")
+                .append(" and is_inner_sql=0 ")
                 .append(dialectType.isMysql() ? "limit 1" : "and rownum<=1");
         try (ResultSet rs = statement.executeQuery(sqlBuilder.toString())) {
             if (!rs.next()) {

--- a/server/plugins/connect-plugin-ob-mysql/src/main/java/com/oceanbase/odc/plugin/connect/obmysql/OBMySQLDiagnoseExtension.java
+++ b/server/plugins/connect-plugin-ob-mysql/src/main/java/com/oceanbase/odc/plugin/connect/obmysql/OBMySQLDiagnoseExtension.java
@@ -212,7 +212,7 @@ public class OBMySQLDiagnoseExtension implements SqlDiagnoseExtensionPoint {
     @Override
     public SqlExecDetail getExecutionDetailById(Connection connection, @NonNull String id) throws SQLException {
         // v$sql_audit中对于分区表会有多条记录，需要过滤
-        String appendSql = "TRACE_ID = '" + id + "' AND LENGTH(QUERY_SQL) > 0 AND IS_INNER_SQL = 0;";
+        String appendSql = "TRACE_ID = '" + id + "' AND IS_INNER_SQL = 0;";
         return innerGetExecutionDetail(connection, appendSql, id);
     }
 

--- a/server/plugins/connect-plugin-ob-oracle/src/main/java/com/oceanbase/odc/plugin/connect/oboracle/OBOracleDiagnoseExtension.java
+++ b/server/plugins/connect-plugin-ob-oracle/src/main/java/com/oceanbase/odc/plugin/connect/oboracle/OBOracleDiagnoseExtension.java
@@ -147,7 +147,7 @@ public class OBOracleDiagnoseExtension extends OBMySQLDiagnoseExtension {
     @Override
     public SqlExecDetail getExecutionDetailById(Connection connection, @NonNull String id) throws SQLException {
         // v$sql_audit中对于分区表会有多条记录，需要过滤
-        String appendSql = "TRACE_ID = '" + id + "' AND LENGTH(QUERY_SQL) > 0 AND IS_INNER_SQL = 0;";
+        String appendSql = "TRACE_ID = '" + id + "' AND IS_INNER_SQL = 0;";
         return innerGetExecutionDetail(connection, appendSql, id);
     }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines.
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request.
3. Ensure you have added or ran the appropriate tests for your PR.
5. If the PR is unfinished, you may add or remove a WIP or [WIP] prefix to your pull request title.
-->

#### What type of PR is this?
type-bug
<!--
Add one of the following kinds:
type-bug
type-feature
type-docs
etc.

Optionally add one or more of the following kinds if applicable:
module-resultset
module-sql execution
etc.
-->

#### What this PR does / why we need it:
OB 4.2.5 has added an internal variable, which is named ''eable_sql_audit_query_sql'. If this variable is true, then the query SQL in the SQL audit view is empty.