### PR TITLE
fix(permission): authentication will wrongly fail when resource ids are the same but resource types are different

### DIFF
--- a/server/integration-test/src/test/java/com/oceanbase/odc/service/iam/ResourceRoleBasedPermissionExtractorTest.java
+++ b/server/integration-test/src/test/java/com/oceanbase/odc/service/iam/ResourceRoleBasedPermissionExtractorTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2023 OceanBase.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.oceanbase.odc.service.iam;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import com.oceanbase.odc.AuthorityTestEnv;
+import com.oceanbase.odc.core.authority.permission.Permission;
+import com.oceanbase.odc.metadb.iam.resourcerole.UserResourceRoleEntity;
+
+/**
+ * @Author: Lebie
+ * @Date: 2025/3/27 15:28
+ * @Description: []
+ */
+public class ResourceRoleBasedPermissionExtractorTest extends AuthorityTestEnv {
+    @Autowired
+    private ResourceRoleBasedPermissionExtractor extractor;
+
+    @Test
+    public void testGetResourcePermissions_MultiResourceIds_Success() {
+        UserResourceRoleEntity entity1 = new UserResourceRoleEntity();
+        entity1.setId(1L);
+        entity1.setResourceId(1L);
+        entity1.setResourceRoleId(1L);
+
+        UserResourceRoleEntity entity2 = new UserResourceRoleEntity();
+        entity2.setId(2L);
+        entity2.setResourceId(2L);
+        entity2.setResourceRoleId(2L);
+
+        List<Permission> actual = extractor.getResourcePermissions(Arrays.asList(entity1, entity2));
+        Assert.assertEquals(2, actual.size());
+    }
+
+    @Test
+    public void testGetResourcePermissions_OneResourceIdMultiRoles_Success() {
+        UserResourceRoleEntity entity1 = new UserResourceRoleEntity();
+        entity1.setId(1L);
+        entity1.setResourceId(1L);
+        entity1.setResourceRoleId(1L);
+
+        UserResourceRoleEntity entity2 = new UserResourceRoleEntity();
+        entity2.setId(2L);
+        entity2.setResourceId(1L);
+        entity2.setResourceRoleId(2L);
+
+        List<Permission> actual = extractor.getResourcePermissions(Arrays.asList(entity1, entity2));
+        Assert.assertEquals(1, actual.size());
+    }
+
+    @Test
+    public void testGetResourcePermissions_SameResourceIdMultiTypes_Success() {
+        UserResourceRoleEntity entity1 = new UserResourceRoleEntity();
+        entity1.setId(1L);
+        entity1.setResourceId(1L);
+        entity1.setResourceRoleId(1L);
+
+        UserResourceRoleEntity entity2 = new UserResourceRoleEntity();
+        entity2.setId(2L);
+        entity2.setResourceId(1L);
+        entity2.setResourceRoleId(6L);
+
+        List<Permission> result = extractor.getResourcePermissions(Arrays.asList(entity1, entity2));
+        Assert.assertEquals(2, result.size());
+    }
+
+}

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/iam/ResourceRoleBasedPermissionExtractor.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/iam/ResourceRoleBasedPermissionExtractor.java
@@ -31,10 +31,16 @@ import com.oceanbase.odc.core.authority.model.DefaultSecurityResource;
 import com.oceanbase.odc.core.authority.permission.Permission;
 import com.oceanbase.odc.core.authority.permission.PermissionProvider;
 import com.oceanbase.odc.core.authority.permission.ResourceRoleBasedPermission;
+import com.oceanbase.odc.core.shared.constant.ResourceType;
+import com.oceanbase.odc.core.shared.exception.UnexpectedException;
 import com.oceanbase.odc.metadb.iam.resourcerole.ResourceRoleEntity;
 import com.oceanbase.odc.metadb.iam.resourcerole.ResourceRoleRepository;
 import com.oceanbase.odc.metadb.iam.resourcerole.UserResourceRoleEntity;
 import com.oceanbase.odc.service.iam.auth.DefaultPermissionProvider;
+
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * @Author: Lebie
@@ -42,9 +48,9 @@ import com.oceanbase.odc.service.iam.auth.DefaultPermissionProvider;
  * @Description: []
  */
 @Component
+@Slf4j
 public class ResourceRoleBasedPermissionExtractor {
     private final PermissionProvider permissionProvider = new DefaultPermissionProvider();
-
 
     @Autowired
     private ResourceRoleRepository repository;
@@ -54,25 +60,41 @@ public class ResourceRoleBasedPermissionExtractor {
             return Collections.EMPTY_LIST;
         }
         List<Permission> permissions = new ArrayList<>();
-        Map<Long, List<UserResourceRoleEntity>> resourceId2Entities =
-                entities.stream().collect(Collectors.groupingBy(UserResourceRoleEntity::getResourceId));
-        for (Entry<Long, List<UserResourceRoleEntity>> entry : resourceId2Entities.entrySet()) {
-            Set<Long> resourceRoleIds =
-                    entry.getValue().stream().map(UserResourceRoleEntity::getResourceRoleId)
-                            .collect(Collectors.toSet());
-            List<ResourceRoleEntity> resourceRoleEntities = repository.findAllById(resourceRoleIds);
+        Map<Long, ResourceRoleEntity> id2Role = repository
+                .findAllById(entities.stream().map(UserResourceRoleEntity::getResourceRoleId).collect(
+                        Collectors.toSet()))
+                .stream()
+                .collect(Collectors.toMap(ResourceRoleEntity::getId, entity -> entity));
+
+        Map<InnerResource, Set<String>> resource2RoleNames = entities.stream()
+                .collect(Collectors.groupingBy(entity -> {
+                    ResourceRoleEntity role = id2Role.get(entity.getResourceRoleId());
+                    if (role == null) {
+                        throw new UnexpectedException("resource role not found, id: " + entity.getResourceRoleId());
+                    }
+                    return new InnerResource(entity.getResourceId(), role.getResourceType());
+                }, Collectors.mapping(entity -> id2Role.get(entity.getResourceRoleId()).getRoleName().name(),
+                        Collectors.toSet())));
+
+        for (Entry<InnerResource, Set<String>> entry : resource2RoleNames.entrySet()) {
+            InnerResource resource = entry.getKey();
             Permission permission =
                     permissionProvider.getPermissionByResourceRoles(
-                            new DefaultSecurityResource(String.valueOf(entry.getKey()),
-                                    resourceRoleEntities.get(0).getResourceType().name()),
-                            resourceRoleEntities.stream().map(role -> role.getRoleName().name()).collect(
-                                    Collectors.toList()));
+                            new DefaultSecurityResource(String.valueOf(resource.resourceId),
+                                    resource.resourceType.name()),
+                            entry.getValue());
             if (!(permission instanceof ResourceRoleBasedPermission)) {
                 throw new IllegalStateException("Permission's type is illegal " + permission);
             }
             permissions.add(permission);
-
         }
         return permissions;
+    }
+
+    @EqualsAndHashCode
+    @AllArgsConstructor
+    private class InnerResource {
+        Long resourceId;
+        ResourceType resourceType;
     }
 }

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/iam/ResourceRoleService.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/iam/ResourceRoleService.java
@@ -289,7 +289,8 @@ public class ResourceRoleService {
 
     @SkipAuthorize("internal usage")
     public List<UserResourceRole> listByUserId(Long userId) {
-        List<UserResourceRole> userResourceRoles = fromEntities(userResourceRoleRepository.findByUserId(userId));
+        List<UserResourceRole> userResourceRoles = fromEntities(userResourceRoleRepository
+                .findByOrganizationIdAndUserId(authenticationFacade.currentOrganizationId(), userId));
         List<UserGlobalResourceRole> globalResourceRoles =
                 globalResourceRoleService.findGlobalResourceRoleUsersByOrganizationIdAndUserId(
                         authenticationFacade.currentOrganizationId(),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines.
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request.
3. Ensure you have added or ran the appropriate tests for your PR.
5. If the PR is unfinished, you may add or remove a WIP or [WIP] prefix to your pull request title.
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
type-bug
type-feature
type-docs
etc.

Optionally add one or more of the following kinds if applicable:
module-resultset
module-sql execution
etc.
-->
type-bug
#### What this PR does / why we need it:
This PR fixed two issues of permission framework:
1. when quering resource roles, it does not query by organization id, which may cause to horizontal authetication bug;
2. when resource ids are the same, but they are different resource types, it has logic error when authentication.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

<!--
This section is used to describe how this PR is implemented. 
If this is a PR that fixes a bug, this section describes how the bug was fixed.
If it's a new feature, this section briefly describes how to implement the new feature.
etc.
-->

#### Additional documentation e.g., usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```