### PR TITLE
fix(schedule): landing page displayed number of partition plans enabled is incorrect

### DIFF
--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/flow/FlowInstanceService.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/flow/FlowInstanceService.java
@@ -1352,6 +1352,28 @@ public class FlowInstanceService {
                 new BeanPropertyRowMapper<>(ServiceTaskInstanceEntity.class));
     }
 
+    public int getEnabledPartitionPlanCount(@NotNull InnerQueryFlowInstanceParams params) {
+        Set<Long> joinedProjectIds = projectService.getMemberProjectIds(authenticationFacade.currentUserId());
+        if (CollectionUtils.isEmpty(joinedProjectIds)) {
+            return 0;
+        }
+        Set<Long> partitionPlanFlowInstanceIds =
+                innerListDistinctServiceTaskInstances(new InnerQueryFlowInstanceParams()
+                        .setTaskTypes(Collections.singleton(TaskType.PARTITION_PLAN))
+                        .setStartTime(params.getStartTime())
+                        .setEndTime(params.getEndTime()))
+                                .stream().map(ServiceTaskInstanceEntity::getFlowInstanceId).collect(Collectors.toSet());
+        if (CollectionUtils.isNotEmpty(partitionPlanFlowInstanceIds)) {
+            Specification<FlowInstanceEntity> spec = FlowInstanceSpecs
+                    .organizationIdEquals(authenticationFacade.currentOrganizationId())
+                    .and(FlowInstanceSpecs.idIn(partitionPlanFlowInstanceIds))
+                    .and(FlowInstanceSpecs.projectIdIn(joinedProjectIds))
+                    .and(FlowInstanceSpecs.statusIn(Collections.singleton(FlowStatus.EXECUTION_SUCCEEDED)));
+            return flowInstanceRepository.findAll(spec).size();
+        }
+        return 0;
+    }
+
     /**
      * This is a temporary method that only uses ODC 4.3.4
      * 

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/schedule/ScheduleService.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/schedule/ScheduleService.java
@@ -22,6 +22,7 @@ import java.io.File;
 import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
@@ -144,6 +145,7 @@ import com.oceanbase.odc.service.schedule.model.ScheduleTaskDetailRespHist;
 import com.oceanbase.odc.service.schedule.model.ScheduleTaskListOverview;
 import com.oceanbase.odc.service.schedule.model.ScheduleTaskOverview;
 import com.oceanbase.odc.service.schedule.model.ScheduleTaskStat;
+import com.oceanbase.odc.service.schedule.model.ScheduleTaskType;
 import com.oceanbase.odc.service.schedule.model.ScheduleType;
 import com.oceanbase.odc.service.schedule.model.TriggerConfig;
 import com.oceanbase.odc.service.schedule.model.TriggerStrategy;
@@ -156,6 +158,7 @@ import com.oceanbase.odc.service.task.exception.JobException;
 import com.oceanbase.odc.service.task.model.OdcTaskLogLevel;
 import com.oceanbase.odc.service.task.schedule.JobScheduler;
 
+import cn.hutool.core.map.MapUtil;
 import cn.hutool.core.util.ObjectUtil;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
@@ -1043,21 +1046,32 @@ public class ScheduleService {
         if (authenticationFacade.currentOrganization().getType() == OrganizationType.INDIVIDUAL) {
             throw new UnsupportedException("Individual space is not supported");
         }
-        Set<Long> joinedProjectIds = projectService.getMemberProjectIds(authenticationFacade.currentUserId());
-        if (CollectionUtils.isEmpty(joinedProjectIds)) {
-            return Collections.emptyList();
-        }
 
         /**
-         * Currently, only the following statistics alter schedule types are supported
+         * Currently, only the following statistics alter schedule types are supported to query table of
+         * schedule_schedule
          */
         List<ScheduleType> supportedScheduleTypes =
-                Arrays.asList(ScheduleType.SQL_PLAN, ScheduleType.PARTITION_PLAN,
-                        ScheduleType.DATA_DELETE, ScheduleType.DATA_ARCHIVE);
+                Arrays.asList(ScheduleType.SQL_PLAN, ScheduleType.DATA_DELETE, ScheduleType.DATA_ARCHIVE);
         params.setScheduleTypes(ObjectUtil.defaultIfNull(params.getScheduleTypes(), Collections.emptySet()));
         params.getScheduleTypes()
                 .retainAll(supportedScheduleTypes.stream().filter(Objects::nonNull).collect(Collectors.toSet()));
         if (CollectionUtils.isEmpty(params.getScheduleTypes())) {
+            return Collections.emptyList();
+        }
+
+        Map<ScheduleTaskType, ScheduleTaskStat> scheduleTaskType2TaskStats =
+                listTaskStat(params).stream()
+                        .collect(Collectors.toMap(ScheduleTaskStat::getType, Function.identity(), (e, r) -> e));
+
+        Map<ScheduleType, List<ScheduleEntity>> scheduleType2ScheduleEntities =
+                listEnabledCronSchedules(params).stream().collect(Collectors.groupingBy(ScheduleEntity::getType));
+        return listScheduleStats(params, scheduleTaskType2TaskStats, scheduleType2ScheduleEntities);
+    }
+
+    private List<ScheduleEntity> listEnabledCronSchedules(@NonNull QueryScheduleStatParams params) {
+        Set<Long> joinedProjectIds = projectService.getMemberProjectIds(authenticationFacade.currentUserId());
+        if (CollectionUtils.isEmpty(joinedProjectIds)) {
             return Collections.emptyList();
         }
 
@@ -1073,31 +1087,40 @@ public class ScheduleService {
             scheduleSpec = scheduleSpec.and(
                     OdcJpaRepository.between(ScheduleEntity_.createTime, params.getStartTime(), params.getEndTime()));
         }
-        List<ScheduleEntity> schedules = filterSchedules(scheduleRepository.findAll(scheduleSpec));
+        return filterSchedules(scheduleRepository.findAll(scheduleSpec));
+    }
 
-        Map<ScheduleType, ScheduleTaskStat> scheduleType2TaskStats =
-                listTaskStat(params).stream()
-                        .collect(Collectors.toMap(ScheduleTaskStat::getType, Function.identity()));
-
-        final List<ScheduleStat> scheduleStats = new ArrayList<>();
-        Map<ScheduleType, List<ScheduleEntity>> scheduleType2ScheduleEntities =
-                schedules.stream().collect(Collectors.groupingBy(ScheduleEntity::getType));
-
+    private List<ScheduleStat> listScheduleStats(@NonNull QueryScheduleStatParams params,
+            @NonNull Map<ScheduleTaskType, ScheduleTaskStat> scheduleTaskType2TaskStats,
+            @NonNull Map<ScheduleType, List<ScheduleEntity>> scheduleType2ScheduleEntities) {
+        final Map<ScheduleType, ScheduleStat> scheduleType2Stat = new HashMap<>();
         scheduleType2ScheduleEntities.forEach((type, scheduleList) -> {
-            ScheduleStat scheduleStat = ScheduleStat.init(type);
-            ScheduleTaskStat scheduleSubTaskStat =
-                    scheduleType2TaskStats.getOrDefault(type, ScheduleTaskStat.init(type));
-            scheduleStat.getTaskStat().merge(scheduleSubTaskStat);
-            scheduleStat.setSuccessEnabledCount(scheduleList.size());
-            scheduleStats.add(scheduleStat);
-            scheduleType2TaskStats.remove(type);
+            Set<ScheduleTaskType> subTaskTypes = ScheduleTaskType.from(type);
+            if (CollectionUtils.isNotEmpty(subTaskTypes)) {
+                ScheduleStat scheduleStat = ScheduleStat.init(type);
+                Set<ScheduleTaskStat> scheduleSubTaskStats =
+                        subTaskTypes.stream()
+                                .map(t -> scheduleTaskType2TaskStats.getOrDefault(t, ScheduleTaskStat.init(t)))
+                                .collect(Collectors.toSet());
+                scheduleStat.setSuccessEnabledCount(scheduleList.size());
+                scheduleStat.merge(scheduleSubTaskStats);
+                scheduleType2Stat.put(scheduleStat.getType(), scheduleStat);
+                MapUtil.removeAny(scheduleTaskType2TaskStats, subTaskTypes.toArray(new ScheduleTaskType[0]));
+            }
         });
-        for (ScheduleTaskStat remainSubTaskStat : scheduleType2TaskStats.values()) {
-            ScheduleStat stat = ScheduleStat.init(remainSubTaskStat.getType());
-            stat.getTaskStat().merge(remainSubTaskStat);
-            scheduleStats.add(stat);
+        for (ScheduleTaskStat remainSubTaskStat : scheduleTaskType2TaskStats.values()) {
+            ScheduleType scheduleType = ScheduleTaskType.from(remainSubTaskStat.getType());
+            ScheduleStat stat = scheduleType2Stat.computeIfAbsent(scheduleType, k -> ScheduleStat.init(scheduleType));
+            if (stat.getType() == ScheduleType.PARTITION_PLAN) {
+                InnerQueryFlowInstanceParams innerQueryPartitionPlanParams = new InnerQueryFlowInstanceParams()
+                        .setStartTime(params.getStartTime())
+                        .setEndTime(params.getEndTime());
+                stat.setSuccessEnabledCount(
+                        flowInstanceService.getEnabledPartitionPlanCount(innerQueryPartitionPlanParams));
+            }
+            stat.merge(Collections.singleton(remainSubTaskStat));
         }
-        return scheduleStats;
+        return new ArrayList<>(scheduleType2Stat.values());
     }
 
     private List<ScheduleEntity> filterSchedules(List<ScheduleEntity> schedules) {
@@ -1131,14 +1154,17 @@ public class ScheduleService {
          * ODC 4.3.4 only {@link ScheduleType.DATA_DELETE} and {@link ScheduleType.DATA_ARCHIVE} is used to
          * taskFramework
          */
-        Set<ScheduleType> scheduleTypes =
-                new HashSet<>(ObjectUtil.defaultIfNull(params.getScheduleTypes(), Collections.emptySet()));
-        scheduleTypes.retainAll(Arrays.asList(ScheduleType.DATA_ARCHIVE, ScheduleType.DATA_DELETE));
-        if (CollectionUtils.isEmpty(scheduleTypes)) {
+        Set<ScheduleTaskType> queryScheduleTaskTypes = new HashSet<>(Optional.ofNullable(params.getScheduleTypes())
+                .map(s -> s.stream().map(ScheduleTaskType::from).flatMap(Collection::stream)
+                        .collect(Collectors.toSet()))
+                .orElse(Collections.emptySet()));
+        queryScheduleTaskTypes.retainAll(Arrays.asList(ScheduleTaskType.DATA_DELETE, ScheduleTaskType.DATA_ARCHIVE,
+                ScheduleTaskType.DATA_ARCHIVE_DELETE, ScheduleTaskType.DATA_ARCHIVE_ROLLBACK));
+        if (CollectionUtils.isEmpty(queryScheduleTaskTypes)) {
             return Collections.emptyList();
         }
 
-        Set<String> jobGroups = scheduleTypes.stream().map(Enum::name).collect(Collectors.toSet());
+        Set<String> jobGroups = queryScheduleTaskTypes.stream().map(Enum::name).collect(Collectors.toSet());
         List<ScheduleTaskEntity> scheduleTasks = scheduleTaskRepository.find(Pageable.unpaged(),
                 QueryScheduleTaskParams.builder()
                         .jobGroups(jobGroups)
@@ -1157,7 +1183,7 @@ public class ScheduleService {
 
         final List<ScheduleTaskStat> scheduleTaskStats = new ArrayList<>();
         jobGroup2ScheduleTasks.forEach((jobGroup, scheduleTasksWithSameJobGroup) -> {
-            ScheduleTaskStat stat = ScheduleTaskStat.init(ScheduleType.valueOf(jobGroup));
+            ScheduleTaskStat stat = ScheduleTaskStat.init(ScheduleTaskType.valueOf(jobGroup));
             for (ScheduleTaskEntity scheduleTaskEntity : scheduleTasksWithSameJobGroup) {
                 stat.count(scheduleTaskEntity.getStatus());
             }

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/schedule/model/ScheduleStat.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/schedule/model/ScheduleStat.java
@@ -15,6 +15,15 @@
  */
 package com.oceanbase.odc.service.schedule.model;
 
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import org.apache.commons.collections4.CollectionUtils;
+
+import cn.hutool.core.util.ObjectUtil;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NonNull;
@@ -33,13 +42,28 @@ import lombok.experimental.Accessors;
 public class ScheduleStat {
     private ScheduleType type;
     private Integer successEnabledCount;
-    private ScheduleTaskStat taskStat;
+    private Set<ScheduleTaskStat> taskStats;
 
     public static ScheduleStat init(@NonNull ScheduleType type) {
         return ScheduleStat.builder()
                 .type(type)
                 .successEnabledCount(0)
-                .taskStat(ScheduleTaskStat.init(type))
+                .taskStats(new HashSet<>())
                 .build();
+    }
+
+    public void merge(@NonNull Set<ScheduleTaskStat> subTaskStats) {
+        if (CollectionUtils.isEmpty(subTaskStats)) {
+            return;
+        }
+        Map<ScheduleTaskType, ScheduleTaskStat> taskType2Stat = subTaskStats.stream().collect(
+                Collectors.toMap(ScheduleTaskStat::getType, Function.identity()));
+        this.setTaskStats(ObjectUtil.defaultIfNull(this.getTaskStats(), new HashSet<>()));
+        for (ScheduleTaskStat taskStat : taskStats) {
+            taskStat.merge(taskType2Stat.remove(taskStat.getType()));
+        }
+        taskType2Stat.forEach((type, stat) -> {
+            this.taskStats.add(stat);
+        });
     }
 }

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/schedule/model/ScheduleTaskStat.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/schedule/model/ScheduleTaskStat.java
@@ -15,6 +15,10 @@
  */
 package com.oceanbase.odc.service.schedule.model;
 
+import java.util.List;
+
+import org.apache.commons.collections4.CollectionUtils;
+
 import com.oceanbase.odc.core.shared.constant.FlowStatus;
 import com.oceanbase.odc.core.shared.constant.TaskStatus;
 import com.oceanbase.odc.core.shared.constant.TaskType;
@@ -23,6 +27,7 @@ import com.oceanbase.odc.core.shared.exception.UnsupportedException;
 import cn.hutool.core.util.ObjectUtil;
 import lombok.Builder;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 import lombok.NonNull;
 import lombok.experimental.Accessors;
 
@@ -35,23 +40,25 @@ import lombok.experimental.Accessors;
 @Data
 @Builder
 @Accessors(chain = true)
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
 public class ScheduleTaskStat {
-    private ScheduleType type;
+    @EqualsAndHashCode.Include
+    private ScheduleTaskType type;
     private Integer successExecutionCount;
     private Integer failedExecutionCount;
     private Integer waitingExecutionCount;
     private Integer executingCount;
     private Integer otherCount;
 
-    public static ScheduleTaskStat init(@NonNull ScheduleType type) {
+    public static ScheduleTaskStat init(@NonNull ScheduleTaskType type) {
         return empty().setType(type);
     }
 
     public static ScheduleTaskStat init(@NonNull TaskType type) {
         if (type == TaskType.ASYNC) {
-            return empty().setType(ScheduleType.SQL_PLAN);
+            return empty().setType(ScheduleTaskType.SQL_PLAN);
         } else if (type == TaskType.PARTITION_PLAN) {
-            return empty().setType(ScheduleType.PARTITION_PLAN);
+            return empty().setType(ScheduleTaskType.PARTITION_PLAN);
         }
         throw new UnsupportedException("Unsupported sub task type: " + type);
     }
@@ -65,6 +72,13 @@ public class ScheduleTaskStat {
         this.waitingExecutionCount = safeAdd(this.waitingExecutionCount, stat.getWaitingExecutionCount());
         this.executingCount = safeAdd(this.executingCount, stat.getExecutingCount());
         this.otherCount = safeAdd(this.otherCount, stat.getOtherCount());
+    }
+
+    public void merge(List<ScheduleTaskStat> stats) {
+        if (CollectionUtils.isEmpty(stats)) {
+            return;
+        }
+        stats.forEach(this::merge);
     }
 
     public static ScheduleTaskStat empty() {

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/schedule/model/ScheduleTaskType.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/schedule/model/ScheduleTaskType.java
@@ -15,6 +15,13 @@
  */
 package com.oceanbase.odc.service.schedule.model;
 
+import java.util.Collections;
+import java.util.Set;
+
+import com.google.common.collect.Sets;
+
+import lombok.NonNull;
+
 /**
  * @Author：tinker
  * @Date: 2024/6/18 16:56
@@ -38,6 +45,26 @@ public enum ScheduleTaskType {
 
     LOGICAL_DATABASE_CHANGE,
 
-    LOAD_DATA
+    LOAD_DATA;
+
+    public static Set<ScheduleTaskType> from(ScheduleType scheduleType) {
+        if (scheduleType == null) {
+            return Collections.emptySet();
+        }
+        if (scheduleType == ScheduleType.DATA_ARCHIVE) {
+            return Sets.newHashSet(ScheduleTaskType.DATA_ARCHIVE, ScheduleTaskType.DATA_ARCHIVE_DELETE,
+                    ScheduleTaskType.DATA_ARCHIVE_ROLLBACK);
+        }
+        return Collections.singleton(ScheduleTaskType.valueOf(scheduleType.name()));
+    }
+
+    public static ScheduleType from(@NonNull ScheduleTaskType scheduleTaskType) {
+        if (scheduleTaskType == ScheduleTaskType.DATA_ARCHIVE
+                || scheduleTaskType == ScheduleTaskType.DATA_ARCHIVE_DELETE
+                || scheduleTaskType == ScheduleTaskType.DATA_ARCHIVE_ROLLBACK) {
+            return ScheduleType.DATA_ARCHIVE;
+        }
+        return ScheduleType.valueOf(scheduleTaskType.name());
+    }
 
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines.
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request.
3. Ensure you have added or ran the appropriate tests for your PR.
5. If the PR is unfinished, you may add or remove a WIP or [WIP] prefix to your pull request title.
-->

#### What type of PR is this?
type-bug
<!--
Add one of the following kinds:
type-bug
type-feature
type-docs
etc.

Optionally add one or more of the following kinds if applicable:
module-resultset
module-sql execution
etc.
-->

#### What this PR does / why we need it:
- Adjust the logic for obtaining the number of enabled partitions by querying the flow_isntance table
- Adjusted to get all sub-tasks of a periodic parent task instead of grouping them. For example, the sub-tasks of a periodic data archiving task include data cleaning + data archiving. The actual number of tasks should be 2 instead of 1
- Adjust the structure of the code to make it more concise
