### PR TITLE
fix(flow): fix the partition plan subtask database change execution failed

### DIFF
--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/config/OrganizationConfigUtils.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/config/OrganizationConfigUtils.java
@@ -55,7 +55,7 @@ public class OrganizationConfigUtils {
             parameters.setQueryLimit(getDefaultQueryLimit());
         }
         Verify.notGreaterThan(parameters.getQueryLimit(), getDefaultMaxQueryLimit(),
-            "query limit value");
+                "query limit value");
     }
 
     public Integer getDefaultMaxQueryLimit() {

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/config/OrganizationConfigUtils.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/config/OrganizationConfigUtils.java
@@ -22,7 +22,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import com.oceanbase.odc.core.authority.util.SkipAuthorize;
+import com.oceanbase.odc.core.shared.Verify;
 import com.oceanbase.odc.service.config.model.Configuration;
+import com.oceanbase.odc.service.flow.task.model.DatabaseChangeParameters;
 import com.oceanbase.odc.service.iam.auth.AuthenticationFacade;
 
 import lombok.extern.slf4j.Slf4j;
@@ -46,6 +48,14 @@ public class OrganizationConfigUtils {
             throw new IllegalStateException("organization configuration not found: " + key);
         }
         return configuration.getValue();
+    }
+
+    public void checkQueryLimitValidity(DatabaseChangeParameters parameters) {
+        if (parameters.getQueryLimit() == null) {
+            parameters.setQueryLimit(getDefaultQueryLimit());
+        }
+        Verify.notGreaterThan(parameters.getQueryLimit(), getDefaultMaxQueryLimit(),
+            "query limit value");
     }
 
     public Integer getDefaultMaxQueryLimit() {

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/flow/task/DatabaseChangeThread.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/flow/task/DatabaseChangeThread.java
@@ -157,8 +157,7 @@ public class DatabaseChangeThread extends Thread {
                 try {
                     List<SqlTuple> sqlTuples = Collections.singletonList(SqlTuple.newTuple(sql));
                     OrganizationConfigUtils configUtils = SpringContextUtil.getBean(OrganizationConfigUtils.class);
-                    Verify.notGreaterThan(parameters.getQueryLimit(), configUtils.getDefaultMaxQueryLimit(),
-                            "query limit value");
+                    configUtils.checkQueryLimitValidity(parameters);
                     OdcStatementCallBack statementCallback =
                             new OdcStatementCallBack(sqlTuples, connectionSession, true, parameters.getQueryLimit());
                     statementCallback.setMaxCachedLines(0);

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/flow/task/model/DatabaseChangeParameters.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/flow/task/model/DatabaseChangeParameters.java
@@ -44,7 +44,7 @@ public class DatabaseChangeParameters implements Serializable, TaskParameters {
     private TaskErrorStrategy errorStrategy;
     private boolean markAsFailedWhenAnyErrorsHappened;
     private String delimiter = ";";
-    private Integer queryLimit = 1000;
+    private Integer queryLimit;
     private Integer riskLevelIndex;
     @NotNull
     private Boolean generateRollbackPlan;

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/schedule/job/SqlPlanJob.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/schedule/job/SqlPlanJob.java
@@ -24,7 +24,6 @@ import org.quartz.JobExecutionContext;
 
 import com.alibaba.fastjson.JSON;
 import com.oceanbase.odc.common.json.JsonUtils;
-import com.oceanbase.odc.core.shared.Verify;
 import com.oceanbase.odc.core.shared.constant.FlowStatus;
 import com.oceanbase.odc.core.shared.constant.TaskType;
 import com.oceanbase.odc.core.shared.exception.UnsupportedException;

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/schedule/job/SqlPlanJob.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/schedule/job/SqlPlanJob.java
@@ -148,8 +148,7 @@ public class SqlPlanJob implements OdcJob {
         parameters.setSqlObjectIds(sqlPlanParameters.getSqlObjectIds());
         parameters.setTimeoutMillis(sqlPlanParameters.getTimeoutMillis());
         OrganizationConfigUtils configUtils = SpringContextUtil.getBean(OrganizationConfigUtils.class);
-        Verify.notGreaterThan(sqlPlanParameters.getQueryLimit(), configUtils.getDefaultQueryLimit(),
-                "query limit value");
+        configUtils.checkQueryLimitValidity(sqlPlanParameters);
         parameters.setQueryLimit(sqlPlanParameters.getQueryLimit());
         parameters.setErrorStrategy(sqlPlanParameters.getErrorStrategy());
         parameters.setSessionTimeZone(connectProperties.getDefaultTimeZone());

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/task/base/databasechange/DatabaseChangeTask.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/task/base/databasechange/DatabaseChangeTask.java
@@ -205,8 +205,7 @@ public class DatabaseChangeTask extends TaskBase<FlowTaskResult> {
                 try {
                     List<SqlTuple> sqlTuples = Collections.singletonList(SqlTuple.newTuple(sql));
                     OrganizationConfigUtils configUtils = SpringContextUtil.getBean(OrganizationConfigUtils.class);
-                    Verify.notGreaterThan(this.databaseChangeParameters.getQueryLimit(),
-                            configUtils.getDefaultMaxQueryLimit(), "query limit value");
+                    configUtils.checkQueryLimitValidity(this.databaseChangeParameters);
                     OdcStatementCallBack statementCallback = new OdcStatementCallBack(sqlTuples, connectionSession,
                             true, this.databaseChangeParameters.getQueryLimit());
                     statementCallback.setMaxCachedLines(0);


### PR DESCRIPTION

#### What type of PR is this?
bugfix

#### What this PR does / why we need it:
The constant value used by `query limit` defined in the `databaseChangeParameters` is not synchronized with the value of the organization configuration, causing the partition plan subtask database change failed to execution.

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

#### Additional documentation e.g., usage docs, etc.:

```docs

```