### PR TITLE
fix(result-export): export result set by obloaderdumper for ob datasource

### DIFF
--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/resultset/DumperResultSetExportTaskManager.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/resultset/DumperResultSetExportTaskManager.java
@@ -138,7 +138,9 @@ public class DumperResultSetExportTaskManager implements ResultSetExportTaskMana
             }
             Verify.notGreaterThan(parameter.getMaxRows(), organizationConfigUtils.getDefaultQueryLimit().longValue(),
                     "query limit value");
-            parameter.setSql(SqlRewriteUtil.addQueryLimit(parameter.getSql(), session, parameter.getMaxRows()));
+            if (!connectionConfig.getDialectType().isOceanbase()) {
+                parameter.setSql(SqlRewriteUtil.addQueryLimit(parameter.getSql(), session, parameter.getMaxRows()));
+            }
 
             ResultSetExportTask task = new ResultSetExportTask(workingDir, logDir, parameter, session,
                     cloudObjectStorageService, dataTransferProperties, dataTransferAdapter.getMaxDumpSizeBytes());

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/resultset/ResultSetExportTask.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/resultset/ResultSetExportTask.java
@@ -219,6 +219,7 @@ public class ResultSetExportTask implements Callable<ResultSetExportResult> {
         config.setUsePrepStmts(dataTransferProperties.isUseServerPrepStmts());
 
         config.setExecutionTimeoutSeconds(parameter.getExecutionTimeoutSeconds());
+        config.setMaxRows(parameter.getMaxRows());
 
         return config;
     }

--- a/server/plugins/task-plugin-api/src/main/java/com/oceanbase/odc/plugin/task/api/datatransfer/model/DataTransferConfig.java
+++ b/server/plugins/task-plugin-api/src/main/java/com/oceanbase/odc/plugin/task/api/datatransfer/model/DataTransferConfig.java
@@ -68,6 +68,7 @@ public class DataTransferConfig implements TaskParameters, Serializable {
     private boolean mergeSchemaFiles;
     private String querySql;
     private String fileType;
+    private Long maxRows;
     /**
      * only for ob-loader-dumper
      */

--- a/server/plugins/task-plugin-ob-mysql/src/main/java/com/oceanbase/odc/plugin/task/obmysql/datatransfer/factory/DumpParameterFactory.java
+++ b/server/plugins/task-plugin-ob-mysql/src/main/java/com/oceanbase/odc/plugin/task/obmysql/datatransfer/factory/DumpParameterFactory.java
@@ -77,6 +77,7 @@ public class DumpParameterFactory extends BaseParameterFactory<DumpParameter> {
         setFileConfig(parameter, workingDir);
         if (StringUtils.isNotEmpty(transferConfig.getQuerySql())) {
             parameter.setQuerySql(transferConfig.getQuerySql());
+            parameter.setMaxRows(transferConfig.getMaxRows());
         }
         parameter.setSkipCheckDir(true);
         if (transferConfig.getMaxDumpSizeBytes() != null) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines.
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request.
3. Ensure you have added or ran the appropriate tests for your PR.
5. If the PR is unfinished, you may add or remove a WIP or [WIP] prefix to your pull request title.
-->

#### What type of PR is this?
type-bug
<!--
Add one of the following kinds:
type-bug
type-feature
type-docs
etc.

Optionally add one or more of the following kinds if applicable:
module-resultset
module-sql execution
etc.
-->

#### What this PR does / why we need it:
We used to rewrite sql to add query limit. For example, `select 1 from dual` would be rewritten into `select * from (select 1 from dual) limit 1000`. Now obloaderdumper support this max rows, so we don't need to rewrite sqls.