### PR TITLE
fix(riskLevel): add default detect rule condition that is task type equals APPLY_TABLE_PERMISSION

### DIFF
--- a/server/integration-test/src/test/java/com/oceanbase/odc/migrate/jdbc/common/V43411RectifyDetectRuleOfTaskTypeMigrateTest.java
+++ b/server/integration-test/src/test/java/com/oceanbase/odc/migrate/jdbc/common/V43411RectifyDetectRuleOfTaskTypeMigrateTest.java
@@ -1,0 +1,244 @@
+/*
+ * Copyright (c) 2023 OceanBase.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.oceanbase.odc.migrate.jdbc.common;
+
+import java.lang.reflect.Method;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import javax.sql.DataSource;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.util.CollectionUtils;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.oceanbase.odc.ServiceTestEnv;
+import com.oceanbase.odc.core.shared.constant.OrganizationType;
+import com.oceanbase.odc.metadb.iam.OrganizationRepository;
+import com.oceanbase.odc.metadb.regulation.risklevel.RiskDetectRuleEntity;
+import com.oceanbase.odc.metadb.regulation.risklevel.RiskDetectRuleRepository;
+import com.oceanbase.odc.metadb.regulation.risklevel.RiskLevelEntity;
+import com.oceanbase.odc.metadb.regulation.risklevel.RiskLevelRepository;
+import com.oceanbase.odc.metadb.regulation.risklevel.RiskLevelStyle;
+
+import cn.hutool.core.util.ReflectUtil;
+
+/**
+ * Test cases for {@link V43411RectifyDetectRuleOfTaskTypeMigrate}
+ * 
+ * @Author: ysj
+ * @Date: 2025/4/18 14:31
+ * @Since: ODC_release_4.3.4
+ * @Description:
+ */
+public class V43411RectifyDetectRuleOfTaskTypeMigrateTest extends ServiceTestEnv {
+
+    @Autowired
+    private DataSource dataSource;
+    @Autowired
+    private RiskDetectRuleRepository repository;
+    @Autowired
+    private RiskLevelRepository riskLevelRepository;
+    @Autowired
+    private OrganizationRepository organizationRepository;
+
+    private NamedParameterJdbcTemplate jdbcTemplate;
+    private Map<Long, Long> organizationId2HighestRiskLevelId = new HashMap<>();
+    private final V43411RectifyDetectRuleOfTaskTypeMigrate migrate = new V43411RectifyDetectRuleOfTaskTypeMigrate();
+    private Method checkExistDetectRuleCondition;
+
+    @Before
+    public void setUp() {
+        riskLevelRepository.deleteAll();
+        repository.deleteAll();
+        addMockedHighestRiskLevel();
+
+        jdbcTemplate = new NamedParameterJdbcTemplate(dataSource);
+        checkExistDetectRuleCondition = ReflectUtil.getMethod(V43411RectifyDetectRuleOfTaskTypeMigrate.class,
+                "checkExistDefaultDetectRuleCondition", JsonNode.class);
+        checkExistDetectRuleCondition.setAccessible(true);
+    }
+
+    @After
+    public void clear() {
+        repository.deleteAll();
+        riskLevelRepository.deleteAll();
+    }
+
+    @Test
+    public void migrate_checkConditionMethod_ExistSuccess() throws Exception {
+        String existExpression = "{\n"
+                + "  \"booleanOperator\": \"OR\",\n"
+                + "  \"children\": [\n"
+                + "    {\n"
+                + "      \"expression\": \"TASK_TYPE\",\n"
+                + "      \"operator\": \"EQUALS\",\n"
+                + "      \"type\": \"CONDITION\",\n"
+                + "      \"value\": \"APPLY_TABLE_PERMISSION\"\n"
+                + "    }\n"
+                + "  ],\n"
+                + "  \"type\": \"CONDITION_GROUP\"\n"
+                + "}";
+        Boolean exist = ReflectUtil.invoke(migrate, checkExistDetectRuleCondition,
+                new ObjectMapper().readTree(existExpression));
+        Assert.assertTrue(exist);
+    }
+
+    @Test
+    public void migrate_checkConditionMethod_NotExistSuccess() throws Exception {
+        String existExpression = "{\n"
+                + "  \"booleanOperator\": \"OR\",\n"
+                + "  \"children\": [\n"
+                + "    {\n"
+                + "      \"expression\": \"TASK_TYPE\",\n"
+                + "      \"operator\": \"CONTAINS\",\n"
+                + "      \"type\": \"CONDITION\",\n"
+                + "      \"value\": \"MOCKDATE\"\n"
+                + "    }\n"
+                + "  ],\n"
+                + "  \"type\": \"CONDITION_GROUP\"\n"
+                + "}";
+        Boolean exist = ReflectUtil.invoke(migrate, checkExistDetectRuleCondition,
+                new ObjectMapper().readTree(existExpression));
+        Assert.assertFalse(exist);
+    }
+
+    @Test
+    public void migrate_riskDetectRuleNotExists_migrateSucceed() throws Exception {
+        Assert.assertTrue(listAllExistRiskDetectRule().isEmpty());
+        migrate.migrate(dataSource);
+        List<Map<String, Object>> detectRules = listAllExistRiskDetectRule();
+        for (Map<String, Object> detectRule : detectRules) {
+            String valueJson = (String) detectRule.get("value_json");
+            Boolean exist = ReflectUtil.invoke(migrate, checkExistDetectRuleCondition,
+                    new ObjectMapper().readTree(valueJson));
+            Assert.assertTrue(exist);
+        }
+    }
+
+    @Test
+    public void migrate_riskDetectRuleExists_migrateSucceed() throws Exception {
+        addMockedRiskDetectRules();
+        List<Map<String, Object>> detectRules = listAllExistRiskDetectRule();
+
+        Assert.assertEquals(detectRules.size(), organizationId2HighestRiskLevelId.size());
+        for (Map<String, Object> detectRule : detectRules) {
+            String valueJson = (String) detectRule.get("value_json");
+            Boolean exist = ReflectUtil.invoke(migrate, checkExistDetectRuleCondition,
+                    new ObjectMapper().readTree(valueJson));
+            Assert.assertFalse(exist);
+        }
+
+        migrate.migrate(dataSource);
+        detectRules = listAllExistRiskDetectRule();
+        for (Map<String, Object> detectRule : detectRules) {
+            String valueJson = (String) detectRule.get("value_json");
+            Boolean exist = ReflectUtil.invoke(migrate, checkExistDetectRuleCondition,
+                    new ObjectMapper().readTree(valueJson));
+            Assert.assertTrue(exist);
+        }
+    }
+
+    @Test
+    public void migrateRepeatably_riskDetectRule_migrateSucceed() throws Exception {
+        Assert.assertTrue(listAllExistRiskDetectRule().isEmpty());
+        migrate.migrate(dataSource);
+        // repeatably migrate
+        migrate.migrate(dataSource);
+        ObjectMapper objectMapper = new ObjectMapper();
+        List<Map<String, Object>> detectRules = listAllExistRiskDetectRule();
+        for (Map<String, Object> detectRule : detectRules) {
+            String valueJson = (String) detectRule.get("value_json");
+            JsonNode detectNode = objectMapper.readTree(valueJson);
+            JsonNode detectSubNodes = detectNode.path("children");
+            for (JsonNode detectSubNode : detectSubNodes) {
+                Boolean exist = ReflectUtil.invoke(migrate, checkExistDetectRuleCondition, detectSubNode);
+                Assert.assertFalse(exist);
+            }
+        }
+    }
+
+    private void addMockedHighestRiskLevel() {
+        List<RiskLevelEntity> riskLevels =
+                riskLevelRepository.saveAllAndFlush(organizationRepository.findIdByType(OrganizationType.TEAM)
+                        .stream().map(orgId -> {
+                            RiskLevelEntity riskLevelEntity = new RiskLevelEntity();
+                            riskLevelEntity.setOrganizationId(orgId);
+                            riskLevelEntity.setCreateTime(new Date());
+                            riskLevelEntity.setUpdateTime(new Date());
+                            riskLevelEntity.setLevel(3);
+                            riskLevelEntity.setStyle(RiskLevelStyle.RED);
+                            riskLevelEntity.setName(
+                                    "${com.oceanbase.odc.builtin-resource.regulation.risklevel.high-risk.name}");
+                            riskLevelEntity.setApprovalFlowConfigId(1L);
+                            riskLevelEntity.setDescription("test risk level");
+                            return riskLevelEntity;
+                        }).collect(Collectors.toList()));
+        organizationId2HighestRiskLevelId.putAll(riskLevels.stream()
+                .collect(Collectors.toMap(RiskLevelEntity::getOrganizationId, RiskLevelEntity::getId, (o, r) -> o)));
+    }
+
+    private void addMockedRiskDetectRules() {
+        String existExpression = "{\n"
+                + "  \"booleanOperator\": \"OR\",\n"
+                + "  \"children\": [\n"
+                + "    {\n"
+                + "      \"expression\": \"TASK_TYPE\",\n"
+                + "      \"operator\": \"CONTAINS\",\n"
+                + "      \"type\": \"CONDITION\",\n"
+                + "      \"value\": \"MOCKDATE\"\n"
+                + "    }\n"
+                + "  ],\n"
+                + "  \"type\": \"CONDITION_GROUP\"\n"
+                + "}";
+        repository.saveAllAndFlush(organizationId2HighestRiskLevelId.keySet()
+                .stream().map(orgId -> {
+                    RiskDetectRuleEntity riskDetectRuleEntity = new RiskDetectRuleEntity();
+                    riskDetectRuleEntity.setOrganizationId(orgId);
+                    riskDetectRuleEntity.setRiskLevelId(organizationId2HighestRiskLevelId.get(orgId));
+                    riskDetectRuleEntity.setCreateTime(new Date());
+                    riskDetectRuleEntity.setUpdateTime(new Date());
+                    riskDetectRuleEntity.setName("test risk detect rule");
+                    riskDetectRuleEntity.setBuiltIn(true);
+                    riskDetectRuleEntity.setCreatorId(1L);
+                    riskDetectRuleEntity.setValueJson(existExpression);
+                    return riskDetectRuleEntity;
+                }).collect(Collectors.toList()));
+    }
+
+    private List<Map<String, Object>> listAllExistRiskDetectRule() {
+        if (CollectionUtils.isEmpty(organizationId2HighestRiskLevelId)) {
+            return Collections.emptyList();
+        }
+        String sql = "SELECT value_json " +
+                "FROM regulation_riskdetect_rule " +
+                "WHERE organization_id IN (:organizationIds) AND risk_level_id IN (:riskLevelIds)";
+        HashMap<String, Object> params = new HashMap<>();
+        params.put("organizationIds", organizationId2HighestRiskLevelId.keySet());
+        params.put("riskLevelIds", organizationId2HighestRiskLevelId.values());
+        return jdbcTemplate.queryForList(sql, params);
+    }
+}

--- a/server/odc-migrate/src/main/java/com/oceanbase/odc/migrate/jdbc/common/V42415AddDefaultRiskDetectRules.java
+++ b/server/odc-migrate/src/main/java/com/oceanbase/odc/migrate/jdbc/common/V42415AddDefaultRiskDetectRules.java
@@ -48,7 +48,7 @@ import lombok.extern.slf4j.Slf4j;
 @Migratable(version = "4.2.4.15", description = "add default risk level detect rules")
 public class V42415AddDefaultRiskDetectRules implements JdbcMigratable {
     private static final String DEFAULT_HIGH_RISK_DETECT_RULE_VALUE =
-            "{\"booleanOperator\":\"OR\",\"children\":[{\"expression\":\"ENVIRONMENT_NAME\",\"operator\":\"EQUALS\",\"type\":\"CONDITION\",\"value\":\"${com.oceanbase.odc.builtin-resource.collaboration.environment.prod.name}\"},{\"expression\":\"TASK_TYPE\",\"operator\":\"IN\",\"type\":\"CONDITION\",\"value\":[\"APPLY_PROJECT_PERMISSION\",\"APPLY_DATABASE_PERMISSION\"]}],\"type\":\"CONDITION_GROUP\"}";
+            "{\"booleanOperator\":\"OR\",\"children\":[{\"expression\":\"ENVIRONMENT_NAME\",\"operator\":\"EQUALS\",\"type\":\"CONDITION\",\"value\":\"${com.oceanbase.odc.builtin-resource.collaboration.environment.prod.name}\"},{\"expression\":\"TASK_TYPE\",\"operator\":\"IN\",\"type\":\"CONDITION\",\"value\":[\"APPLY_PROJECT_PERMISSION\",\"APPLY_DATABASE_PERMISSION\",\"APPLY_TABLE_PERMISSION\"]}],\"type\":\"CONDITION_GROUP\"}";
     private static final String DEFAULT_HIGH_RISK_DETECT_NAME = "default high risk level detect rule";
 
     private TransactionTemplate transactionTemplate;

--- a/server/odc-migrate/src/main/java/com/oceanbase/odc/migrate/jdbc/common/V43410RectifyDetectRuleOfTaskTypeMigrate.java
+++ b/server/odc-migrate/src/main/java/com/oceanbase/odc/migrate/jdbc/common/V43410RectifyDetectRuleOfTaskTypeMigrate.java
@@ -1,0 +1,221 @@
+/*
+ * Copyright (c) 2023 OceanBase.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.oceanbase.odc.migrate.jdbc.common;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import javax.sql.DataSource;
+
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.jdbc.datasource.DataSourceTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
+import org.springframework.util.CollectionUtils;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.oceanbase.odc.common.json.JsonUtils;
+import com.oceanbase.odc.common.util.ObjectUtil;
+import com.oceanbase.odc.core.migrate.JdbcMigratable;
+import com.oceanbase.odc.core.migrate.Migratable;
+import com.oceanbase.odc.core.shared.constant.TaskType;
+import com.oceanbase.odc.service.regulation.risklevel.model.ConditionExpression;
+import com.oceanbase.odc.service.regulation.risklevel.model.NodeType;
+
+import lombok.Data;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * @Author: Mayang
+ * @Description: version: 4.3.4, this migration is only for highRiskLevel detect rules for team
+ *               organizations, add the types of tasks supported by default in ODC V434
+ */
+@Slf4j
+@Migratable(version = "4.3.4.10",
+        description = "For rectifying default risk level detect rules in V4.3.4")
+public class V43410RectifyDetectRuleOfTaskTypeMigrate implements JdbcMigratable {
+    private NamedParameterJdbcTemplate jdbcTemplate;
+    private TransactionTemplate txTemplate;
+    private static final String DEFAULT_TASK_TYPE_DETECT_RULE =
+            "{\"expression\":\"TASK_TYPE\",\"operator\":\"EQUALS\",\"type\":\"CONDITION\",\"value\":\"APPLY_TABLE_PERMISSION\"}";
+    private static final String DEFAULT_HIGH_RISK_DETECT_NAME = "default high risk level detect rule";
+
+    @Override
+    public void migrate(DataSource dataSource) {
+        this.jdbcTemplate = new NamedParameterJdbcTemplate(dataSource);
+        this.txTemplate = new TransactionTemplate(new DataSourceTransactionManager(dataSource));
+        final Map<Long, Long> organizationId2HighestRiskLevelId = getOrganizationIdMappingHighestRiskLevelId(
+                listAllTeamOrganizationId());
+        int affectedRows = upsertRiskLevelDetectRule(organizationId2HighestRiskLevelId);
+        log.info("Migrate final detect rules: {}, affected rows: {}",
+                JsonUtils.toJson(organizationId2HighestRiskLevelId), affectedRows);
+    }
+
+
+    private List<Long> listAllTeamOrganizationId() {
+        String sql = "SELECT id FROM iam_organization WHERE type = 'TEAM'";
+        return jdbcTemplate.queryForList(sql, new HashMap<>(), Long.class);
+    }
+
+    private Map<Long, Long> getOrganizationIdMappingHighestRiskLevelId(Collection<Long> organizationIds) {
+        if (CollectionUtils.isEmpty(organizationIds)) {
+            return Collections.emptyMap();
+        }
+        String sql =
+                "SELECT id, organization_id FROM regulation_risklevel WHERE organization_id IN (:organizationIds) AND level = (SELECT MAX(level) FROM regulation_risklevel)";
+        HashMap<String, Object> params = new HashMap<>();
+        params.put("organizationIds", organizationIds);
+        return jdbcTemplate.query(sql, params, rs -> {
+            Map<Long, Long> resultMap = new HashMap<>();
+            while (rs.next()) {
+                long riskLevelId = rs.getLong("id");
+                long orgId = rs.getLong("organization_id");
+                resultMap.computeIfAbsent(orgId, k -> riskLevelId);
+            }
+            return resultMap;
+        });
+    }
+
+    private List<DetectRule> listRiskLevelDetectRules(Map<Long, Long> organizationId2HighestRiskLevelId) {
+        if (CollectionUtils.isEmpty(organizationId2HighestRiskLevelId)) {
+            return Collections.emptyList();
+        }
+        String sql = "SELECT id, risk_level_id,organization_id,value_json " +
+                "FROM regulation_riskdetect_rule " +
+                "WHERE organization_id IN (:organizationIds) AND risk_level_id IN (:riskLevelIds)";
+        HashMap<String, Object> params = new HashMap<>();
+        params.put("organizationIds", organizationId2HighestRiskLevelId.keySet());
+        params.put("riskLevelIds", organizationId2HighestRiskLevelId.values());
+        return jdbcTemplate.query(sql, params, (rs, rowNum) -> {
+            DetectRule detectRule = new DetectRule();
+            detectRule.setId(rs.getLong("id"));
+            detectRule.setRiskLevelId(rs.getLong("risk_level_id"));
+            detectRule.setOrganizationId(rs.getLong("organization_id"));
+            detectRule.setValueJson(rs.getString("value_json"));
+            return detectRule;
+        });
+    }
+
+    private boolean checkExistDefaultDetectRuleCondition(JsonNode detectRuleNode) {
+        try {
+            if (!NodeType.CONDITION_GROUP.name().equals(detectRuleNode.path("type").asText()) ||
+                    !"OR".equals(detectRuleNode.path("booleanOperator").asText())) {
+                return false;
+            }
+            JsonNode children = detectRuleNode.path("children");
+            if (!children.isArray()) {
+                return false;
+            }
+            for (JsonNode child : children) {
+                if (!NodeType.CONDITION.name().equals(child.path("type").asText()) ||
+                        !ConditionExpression.TASK_TYPE.name().equals(child.path("expression").asText()) ||
+                        !"EQUALS".equals(child.path("operator").asText())) {
+                    continue;
+                }
+                if (TaskType.APPLY_TABLE_PERMISSION.name().equals(child.path("value").asText())) {
+                    return true;
+                }
+            }
+        } catch (Exception e) {
+            log.warn("Check exist default detect rule condition failed", e);
+        }
+        return false;
+    }
+
+    private Map<Long, DetectRule> checkAndFillDetectRulesByOrganizationId(
+            Map<Long, Long> organizationId2HighestRiskLevelId) throws Exception {
+        final Map<Long, DetectRule> organizationId2DetectRules =
+                listRiskLevelDetectRules(organizationId2HighestRiskLevelId)
+                        .stream()
+                        .collect(Collectors.toMap(DetectRule::getOrganizationId, Function.identity(), (o, r) -> o));
+        ObjectMapper objectMapper = new ObjectMapper();
+        JsonNode defaultTaskTypeDetectRule = objectMapper.readTree(DEFAULT_TASK_TYPE_DETECT_RULE);
+        for (Long orgId : organizationId2HighestRiskLevelId.keySet()) {
+            DetectRule detectRule = ObjectUtil.defaultIfNull(organizationId2DetectRules.get(orgId), new DetectRule());
+            detectRule.setRiskLevelId(organizationId2HighestRiskLevelId.get(orgId));
+            detectRule.setOrganizationId(orgId);
+
+            ObjectNode wrapperCondition = objectMapper.createObjectNode();
+            wrapperCondition.put("booleanOperator", "OR");
+            wrapperCondition.put("type", NodeType.CONDITION_GROUP.name());
+            ArrayNode childrenArray = objectMapper.createArrayNode();
+            childrenArray.add(defaultTaskTypeDetectRule);
+            if (StringUtils.isNotBlank(detectRule.getValueJson())) {
+                JsonNode currentValueJson = objectMapper.readTree(detectRule.getValueJson());
+                if (checkExistDefaultDetectRuleCondition(currentValueJson)) {
+                    organizationId2DetectRules.remove(orgId);
+                    continue;
+                }
+                childrenArray.add(currentValueJson);
+            }
+            wrapperCondition.set("children", childrenArray);
+
+            detectRule.setValueJsonOld(detectRule.getValueJson());
+            detectRule.setValueJson(objectMapper.writeValueAsString(wrapperCondition));
+            organizationId2DetectRules.computeIfAbsent(orgId, k -> detectRule);
+        }
+        return organizationId2DetectRules;
+    }
+
+    private int upsertRiskLevelDetectRule(Map<Long, Long> organizationId2HighestRiskLevelId) {
+        if (CollectionUtils.isEmpty(organizationId2HighestRiskLevelId)) {
+            return 0;
+        }
+        try {
+            final Map<Long, DetectRule> organizationId2DetectRules =
+                    checkAndFillDetectRulesByOrganizationId(organizationId2HighestRiskLevelId);
+            String sql =
+                    "INSERT INTO regulation_riskdetect_rule (create_time, update_time, name, risk_level_id, is_builtin, creator_id, organization_id, value_json_old, value_json) "
+                            + "VALUES (NOW(), NOW(), :name, :riskLevelId, :isBuiltin, 1, :organizationId, :valueJsonOld, :valueJson) "
+                            + "ON DUPLICATE KEY UPDATE update_time = NOW(), value_json_old = :valueJsonOld, value_json = :valueJson";
+            int[] affectedRows = this.txTemplate.execute(status -> {
+                MapSqlParameterSource[] parameterSources = organizationId2DetectRules.values().stream()
+                        .map(detectRule -> new MapSqlParameterSource()
+                                .addValue("name", DEFAULT_HIGH_RISK_DETECT_NAME)
+                                .addValue("riskLevelId", detectRule.getRiskLevelId())
+                                .addValue("isBuiltin", -1L)
+                                .addValue("organizationId", detectRule.getOrganizationId())
+                                .addValue("valueJsonOld", detectRule.getValueJsonOld())
+                                .addValue("valueJson", detectRule.getValueJson()))
+                        .toArray(MapSqlParameterSource[]::new);
+                return jdbcTemplate.batchUpdate(sql, parameterSources);
+            });
+            return affectedRows == null ? 0 : Arrays.stream(affectedRows).sum();
+        } catch (Exception e) {
+            log.warn("Migrate V43410 to rectify detect rule of task type error", e);
+        }
+        return 0;
+    }
+
+    @Data
+    private static class DetectRule {
+        Long id;
+        Long riskLevelId;
+        Long organizationId;
+        String valueJsonOld;
+        String valueJson;
+    }
+}

--- a/server/odc-migrate/src/main/java/com/oceanbase/odc/migrate/jdbc/common/V43410RectifyDetectRuleOfTaskTypeMigrate.java
+++ b/server/odc-migrate/src/main/java/com/oceanbase/odc/migrate/jdbc/common/V43410RectifyDetectRuleOfTaskTypeMigrate.java
@@ -189,12 +189,12 @@ public class V43410RectifyDetectRuleOfTaskTypeMigrate implements JdbcMigratable 
                     checkAndFillDetectRulesByOrganizationId(organizationId2HighestRiskLevelId);
             String sql =
                     "INSERT INTO regulation_riskdetect_rule (create_time, update_time, name, risk_level_id, is_builtin, creator_id, organization_id, value_json_old, value_json) "
-                            + "VALUES (NOW(), NOW(), :name, :riskLevelId, :isBuiltin, 1, :organizationId, :valueJsonOld, :valueJson) "
+                            + "VALUES (NOW(), NOW(), :detectRuleName, :riskLevelId, :isBuiltin, 1, :organizationId, :valueJsonOld, :valueJson) "
                             + "ON DUPLICATE KEY UPDATE update_time = NOW(), value_json_old = :valueJsonOld, value_json = :valueJson";
             int[] affectedRows = this.txTemplate.execute(status -> {
                 MapSqlParameterSource[] parameterSources = organizationId2DetectRules.values().stream()
                         .map(detectRule -> new MapSqlParameterSource()
-                                .addValue("name", DEFAULT_HIGH_RISK_DETECT_NAME)
+                                .addValue("detectRuleName", DEFAULT_HIGH_RISK_DETECT_NAME)
                                 .addValue("riskLevelId", detectRule.getRiskLevelId())
                                 .addValue("isBuiltin", -1L)
                                 .addValue("organizationId", detectRule.getOrganizationId())

--- a/server/odc-migrate/src/main/java/com/oceanbase/odc/migrate/jdbc/common/V43411RectifyDetectRuleOfTaskTypeMigrate.java
+++ b/server/odc-migrate/src/main/java/com/oceanbase/odc/migrate/jdbc/common/V43411RectifyDetectRuleOfTaskTypeMigrate.java
@@ -54,9 +54,9 @@ import lombok.extern.slf4j.Slf4j;
  *               organizations, add the types of tasks supported by default in ODC V434
  */
 @Slf4j
-@Migratable(version = "4.3.4.10",
+@Migratable(version = "4.3.4.11",
         description = "For rectifying default risk level detect rules in V4.3.4")
-public class V43410RectifyDetectRuleOfTaskTypeMigrate implements JdbcMigratable {
+public class V43411RectifyDetectRuleOfTaskTypeMigrate implements JdbcMigratable {
     private NamedParameterJdbcTemplate jdbcTemplate;
     private TransactionTemplate txTemplate;
     private static final String DEFAULT_TASK_TYPE_DETECT_RULE =

--- a/server/odc-migrate/src/main/java/com/oceanbase/odc/migrate/jdbc/common/V43411RectifyDetectRuleOfTaskTypeMigrate.java
+++ b/server/odc-migrate/src/main/java/com/oceanbase/odc/migrate/jdbc/common/V43411RectifyDetectRuleOfTaskTypeMigrate.java
@@ -205,7 +205,7 @@ public class V43411RectifyDetectRuleOfTaskTypeMigrate implements JdbcMigratable 
             });
             return affectedRows == null ? 0 : Arrays.stream(affectedRows).sum();
         } catch (Exception e) {
-            log.warn("Migrate V43410 to rectify detect rule of task type error", e);
+            log.warn("Migrate V434 to rectify detect rule of task type error", e);
         }
         return 0;
     }

--- a/server/odc-migrate/src/main/java/com/oceanbase/odc/migrate/jdbc/common/V43411RectifyDetectRuleOfTaskTypeMigrate.java
+++ b/server/odc-migrate/src/main/java/com/oceanbase/odc/migrate/jdbc/common/V43411RectifyDetectRuleOfTaskTypeMigrate.java
@@ -61,6 +61,7 @@ public class V43411RectifyDetectRuleOfTaskTypeMigrate implements JdbcMigratable 
     private static final String DEFAULT_TASK_TYPE_DETECT_RULE =
             "{\"expression\":\"TASK_TYPE\",\"operator\":\"EQUALS\",\"type\":\"CONDITION\",\"value\":\"APPLY_TABLE_PERMISSION\"}";
     private static final String DEFAULT_HIGH_RISK_DETECT_NAME = "default high risk level detect rule";
+    private static final int HIGHEST_RISK_LEVEL = 3;
 
     @Override
     public void migrate(DataSource dataSource) {
@@ -90,8 +91,9 @@ public class V43411RectifyDetectRuleOfTaskTypeMigrate implements JdbcMigratable 
             return Collections.emptyMap();
         }
         String sql =
-                "SELECT id, organization_id FROM regulation_risklevel WHERE organization_id IN (:organizationIds) AND level = (SELECT MAX(level) FROM regulation_risklevel)";
+                "SELECT id, organization_id FROM regulation_risklevel WHERE level = :level AND organization_id IN (:organizationIds)";
         HashMap<String, Object> params = new HashMap<>();
+        params.put("level", HIGHEST_RISK_LEVEL);
         params.put("organizationIds", organizationIds);
         return jdbcTemplate.query(sql, params, rs -> {
             Map<Long, Long> resultMap = new HashMap<>();


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines.
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request.
3. Ensure you have added or ran the appropriate tests for your PR.
5. If the PR is unfinished, you may add or remove a WIP or [WIP] prefix to your pull request title.
-->

#### What type of PR is this?
type-bug
<!--
Add one of the following kinds:
type-bug
type-feature
type-docs
etc.

Optionally add one or more of the following kinds if applicable:
module-resultset
module-sql execution
etc.
-->

#### What this PR does / why we need it:
Provide the default highest risk level identification rule condition for users upgrading to ODC 434 or later for the first time: Task type equal to APPLY_TABLE_PERMISSION
