### PR TITLE
fix(task): k8s parse resource identifier failed

### DIFF
--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/task/resource/K8sPodResource.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/task/resource/K8sPodResource.java
@@ -100,7 +100,7 @@ public class K8sPodResource implements Resource {
     }
 
     public static Pair<String, String> parseIPAndPort(String k8sEndPoint) {
-        String[] infos = StringUtils.split(k8sEndPoint, "::");
+        String[] infos = StringUtils.splitByWholeSeparator(k8sEndPoint, "::");
         if (null == infos || infos.length != 6) {
             throw new IllegalStateException(
                     "expect k8s endpoint constructed by k8s::region::namespace::arn::ip::port, but current is "

--- a/server/odc-service/src/test/java/com/oceanbase/odc/service/task/resource/K8sPodResourceTest.java
+++ b/server/odc-service/src/test/java/com/oceanbase/odc/service/task/resource/K8sPodResourceTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2023 OceanBase.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.oceanbase.odc.service.task.resource;
+
+import org.apache.commons.lang3.tuple.Pair;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * @author longpeng.zlp
+ * @date 2025/4/29 09:59
+ */
+public class K8sPodResourceTest {
+    @Test
+    public void testParseIpAndPort() {
+        String ipAndPortStr =
+                "k8s::cn-shanghai::default::obc:aliyun:iaas:cn-shanghai:oceanbase:pod:p-T5205qKf9N0001::null::null";
+        Pair<String, String> ret = K8sPodResource.parseIPAndPort(ipAndPortStr);
+        Assert.assertNull(ret.getLeft());
+        Assert.assertNull(ret.getRight());
+    }
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines.
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request.
3. Ensure you have added or ran the appropriate tests for your PR.
5. If the PR is unfinished, you may add or remove a WIP or [WIP] prefix to your pull request title.
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
type-bug
type-feature
type-docs
etc.

Optionally add one or more of the following kinds if applicable:
module-resultset
module-sql execution
etc.
-->
type-bug
#### What this PR does / why we need it:
if use StringUtils, splitByWholeSeparator should be used if we want split by characters but not a single character
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

<!--
This section is used to describe how this PR is implemented. 
If this is a PR that fixes a bug, this section describes how the bug was fixed.
If it's a new feature, this section briefly describes how to implement the new feature.
etc.
-->

#### Additional documentation e.g., usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```