### PR TITLE
fix(session): fix SQL execute generate result failed caused by material view

### DIFF
--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/session/model/SqlExecuteResult.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/session/model/SqlExecuteResult.java
@@ -501,7 +501,7 @@ public class SqlExecuteResult {
         List<JdbcColumnMetaData> columnList = resultSetMetaData.getFieldMetaDataList();
         Set<JdbcColumnMetaData> columnSet = columnList.stream()
                 .collect(Collectors.toMap(jcmd -> jcmd.getCatalogName() + "." + jcmd.getTableName(), jcmd -> jcmd,
-                    (jcmd1, jcmd2) -> jcmd2))
+                        (jcmd1, jcmd2) -> jcmd2))
                 .values().stream().collect(Collectors.toSet());
 
         Set<String> tableNames = columnSet.stream()

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/session/model/SqlExecuteResult.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/session/model/SqlExecuteResult.java
@@ -500,7 +500,8 @@ public class SqlExecuteResult {
         }
         List<JdbcColumnMetaData> columnList = resultSetMetaData.getFieldMetaDataList();
         Set<JdbcColumnMetaData> columnSet = columnList.stream()
-                .collect(Collectors.toMap(jcmd -> jcmd.getCatalogName() + "." + jcmd.getTableName(), jcmd -> jcmd))
+                .collect(Collectors.toMap(jcmd -> jcmd.getCatalogName() + "." + jcmd.getTableName(), jcmd -> jcmd,
+                    (jcmd1, jcmd2) -> jcmd2))
                 .values().stream().collect(Collectors.toSet());
 
         Set<String> tableNames = columnSet.stream()

--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/session/model/SqlExecuteResult.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/session/model/SqlExecuteResult.java
@@ -499,10 +499,13 @@ public class SqlExecuteResult {
             return false;
         }
         List<JdbcColumnMetaData> columnList = resultSetMetaData.getFieldMetaDataList();
-        Set<JdbcColumnMetaData> columnSet = columnList.stream()
-                .collect(Collectors.toMap(jcmd -> jcmd.getCatalogName() + "." + jcmd.getTableName(), jcmd -> jcmd,
-                        (jcmd1, jcmd2) -> jcmd2))
-                .values().stream().collect(Collectors.toSet());
+        Set<JdbcColumnMetaData> columnSet = new HashSet<>(
+                columnList.stream()
+                        .collect(Collectors.toMap(
+                                jcmd -> jcmd.getCatalogName() + "." + jcmd.getTableName(),
+                                jcmd -> jcmd,
+                                (existing, current) -> existing))
+                        .values());
 
         Set<String> tableNames = columnSet.stream()
                 .map(JdbcColumnMetaData::getTableName)


### PR DESCRIPTION

#### What type of PR is this?
fix

#### What this PR does / why we need it:
Fixed the issue where `queryTableOrViewData.getMorResults` failed due to duplicate keys in the `toMap` method, which in turn affected the failure of some sql console rule.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

#### Additional documentation e.g., usage docs, etc.:

```docs

```