### PR TITLE
fix(sqlcheck): fix sqlcheck failed in get origin `createTable`

### DIFF
--- a/server/odc-service/src/main/java/com/oceanbase/odc/service/sqlcheck/rule/MySQLOfflineDdlExists.java
+++ b/server/odc-service/src/main/java/com/oceanbase/odc/service/sqlcheck/rule/MySQLOfflineDdlExists.java
@@ -170,7 +170,7 @@ public class MySQLOfflineDdlExists implements SqlCheckRule {
             ColumnDefinition origin = extractColumnDefFrom(target, changed.getColumnReference());
             // only ob 4.x check online feature
             if (isOb4x) {
-                boolean isAllNonNull = Stream.of(target, origin).allMatch(Objects::nonNull);
+                boolean isAllNonNull = (null != target) && (null != origin);
                 if (isAllNonNull && isOnLineDDL(origin, changed, target.getTableOptions())) {
                     return null;
                 }


### PR DESCRIPTION

#### What type of PR is this?
bugfix

#### What this PR does / why we need it:
sqlcheck failed caused by origin `createTable` is null

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

#### Additional documentation e.g., usage docs, etc.:
